### PR TITLE
Pull Request: Decouple Logging FilePath from C:\Temp to Environment Variables

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -26,10 +26,30 @@ Ensure you have the following prerequisites before proceeding:
   - `Sampler`
   - `xDSCResourceDesigner`
 
-### Setting Up: *AZDODSC_CACHE_DIRECTORY* Environment Variable
+### *AZDODSC_CACHE_DIRECTORY* Environment Variable
 
-The system environment variable `AZDODSC_CACHE_DIRECTORY` is used by the module to store caching settings and the cache itself.
-Make sure this variable is properly set up in your system environment.
+The system environment variable `AZDODSC_CACHE_DIRECTORY` is used by the module
+to store caching settings and the cache itself. Make sure this variable is properly
+set up in your system environment.
+
+### *AZDO_WARNINGLOGGING_FILEPATH* and *AZDO_ERRORLOGGING_FILEPATH* Environment Variables
+
+The `AZDO_WARNINGLOGGING_FILEPATH` and `AZDO_ERRORLOGGING_FILEPATH`environment
+variables are typically used in Azure DevOps (AzDO) pipelines or custom scripts
+to specify file paths where warning and error logs should be stored.
+These variables help manage logging by directing different types of log messages
+to separate files, aiding in better organization and analysis.
+
+#### Usage
+
+- **AZDO_WARNINGLOGGING_FILEPATH**: This variable defines the path to a file
+where all warnings generated during the execution of a pipeline or script will
+be logged. It's useful for tracking non-critical issues that may need attention
+but do not halt the execution.
+
+- **AZDO_ERRORLOGGING_FILEPATH**: This variable specifies the path to a file
+designated for logging errors. Errors are typically more severe than warnings
+and might require immediate action or investigation.
 
 ## Setting Up Managed Identity
 

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Logging/Proxy Functions/Write-Error.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Logging/Proxy Functions/Write-Error.ps1
@@ -33,15 +33,19 @@ Function Write-Error
         [string]$Message,
 
         [Parameter()]
-        [string]$LogFilePath = "C:\Temp\error_log.txt"
+        [string]$LogFilePath = "$($env:AZDO_ERRORLOGGING_FILEPATH)"
     )
 
     #  Call the original Write-Error cmdlet to display the message
     Microsoft.PowerShell.Utility\Write-Error $Message
     $VerbosePreference = $originalPreference
 
-    # Append the message to the log file
-    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    Add-Content -Path $LogFilePath -Value "[$timestamp] $Message"
+    # Test if the env:enableVerboseLogging variable is set to true
+    if ($null -ne $LogFilePath)
+    {
+        # Append the message to the log file
+        $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+        Add-Content -Path $LogFilePath -Value "[$timestamp] $Message"
+    }
 
 }

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Logging/Proxy Functions/Write-Verbose.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Logging/Proxy Functions/Write-Verbose.ps1
@@ -35,7 +35,7 @@ Function Write-Verbose
     Microsoft.PowerShell.Utility\Write-Verbose $Message
 
     # Test if the env:enableVerboseLogging variable is set to true
-    if ($null -ne $env:AZDO_VERBOSELOGGING_FILEPATH)
+    if ($null -ne $LogFilePath)
     {
         # Append the message to the log file
         $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Logging/Proxy Functions/Write-Warning.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Logging/Proxy Functions/Write-Warning.ps1
@@ -32,7 +32,7 @@ Function Write-Warning
         [string]$Message,
 
         [Parameter()]
-        [string]$LogFilePath = "C:\Temp\warning_log.txt"
+        [string]$LogFilePath = "$($env:AZDO_WARNINGLOGGING_FILEPATH)"
     )
 
     # Call the original Write-Verbose cmdlet to display the message if verbose preference is enabled
@@ -41,7 +41,11 @@ Function Write-Warning
     Microsoft.PowerShell.Utility\Write-Warning $Message
     $VerbosePreference = $originalPreference
 
-    # Append the message to the log file
-    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-    Add-Content -Path $LogFilePath -Value "[$timestamp] $Message"
+    if ($null -ne $LogFilePath)
+    {
+        # Append the message to the log file
+        $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+        Add-Content -Path $LogFilePath -Value "[$timestamp] $Message"
+    }
+
 }


### PR DESCRIPTION
# Overview
This pull request addresses the need to make our logging file paths more flexible and configurable by decoupling them from the hardcoded directory C:\Temp. Instead, the file paths will now be determined by environment variables. This change improves the portability and configurability of our application.

# Changes Made
- Removed hardcoded logging paths pointing to C:\Temp.
- Introduced two new environment variables:
    AZDO_WARNINGLOGGING_FILEPATH
    AZDO_ERRORLOGGING_FILEPATH
- Updated the logging configuration to read file paths from these environment variables.
- Updated Configuration
- Removed logging support if environmental variables are not set.

