### PR TITLE
Adjustment to AzDoGitPermission Resource - Set Project-Level Permissions

### DIFF
--- a/source/Classes/006.AzDevOpsDscResourceBase.ps1
+++ b/source/Classes/006.AzDevOpsDscResourceBase.ps1
@@ -232,6 +232,10 @@ class AzDevOpsDscResourceBase : AzDevOpsApiDscResourceBase
                     }([DSCGetSummaryState]::Unchanged) {
                         $dscRequiredAction = [RequiredAction]::None
                         Write-Verbose "Resource Not Changed. Setting action to Remove."
+                    }([DSCGetSummaryState]::Error) {
+                        $dscRequiredAction = [RequiredAction]::Error
+                        Write-Verbose "Resource in Error state. Setting action to Error."
+                        throw $currentProperties.LookupResult.Reason
                     }
                     default {
                         $errorMessage = "Could not obtain a valid 'LookupResult.Status' value within '$($this.GetResourceName())' Test() function. Value was '$($currentProperties.LookupResult.Status)'"

--- a/source/Classes/041.AzDoGitPermission.ps1
+++ b/source/Classes/041.AzDoGitPermission.ps1
@@ -49,9 +49,9 @@ class AzDoGitPermission : AzDevOpsDscResourceBase
     [Alias('Name')]
     [System.String]$ProjectName
 
-    [DscProperty(Mandatory)]
+    [DscProperty()]
     [Alias('Repository')]
-    [System.String]$RepositoryName
+    [System.String]$RepositoryName = $null
 
     [DscProperty()]
     [Alias('Inherited')]

--- a/source/Enum/DSCGetSummaryState.ps1
+++ b/source/Enum/DSCGetSummaryState.ps1
@@ -29,4 +29,6 @@ enum DSCGetSummaryState
     Renamed = 3
     # Missing
     Missing = 4
+    # Error
+    Error = 5
 }

--- a/source/Examples/Resources/AzDoGitPermission.md
+++ b/source/Examples/Resources/AzDoGitPermission.md
@@ -6,11 +6,13 @@
 AzDoGitPermission [string] #ResourceName
 {
     ProjectName = [String]$ProjectName
-    RepositoryName = [String]$RepositoryName
+    [ RepositoryName = [String]$RepositoryName ]
     Permissions = [HashTable]$Permissions # See Permissions Syntax
     [ Ensure = [String] {'Present', 'Absent'}]
 }
 ```
+
+The `RepositoryName` property is optional. If it is not provided, the Git permissions will be applied at the project-level.
 
 ## Permissions Syntax
 
@@ -192,4 +194,30 @@ $params = @{
 
 Invoke-AzDoLCM @params
 
+```
+
+## Example 5: Sample Configuration using AzDO-DSC-LCM setting Project Permissions
+
+``` YAML
+parameters: {}
+
+variables: {
+  ProjectName: SampleProject,
+  RepositoryName: SampleRepository
+}
+
+resources:
+
+  - name: Project-Level Git Permissions Sample
+    type: AzureDevOpsDsc/AzDoGitPermission
+    dependsOn: 
+        - AzureDevOpsDsc/AzDoProjectGroup/SampleGroupReadAccess
+    properties:
+      projectName: $ProjectName
+      isInherited: false
+      Permissions:
+        - Identity: '[$ProjectName]\SampleGroupReadAccess'
+          Permission:
+            Read: "Allow"
+            ManageNote: "Allow"   
 ```

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ACE/Clear-AzDoACE.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ACE/Clear-AzDoACE.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+Clears Access Control Entries (ACEs) for a specified security namespace in Azure DevOps.
+
+.DESCRIPTION
+The Clear-AzDoACE function removes ACEs from a specified security namespace in Azure DevOps.
+It takes the organization name, security namespace ID, and a difference ACLs object as input parameters.
+The function constructs a URI for the Azure DevOps REST API and invokes the API to clear the ACEs.
+
+.PARAMETER OrganizationName
+The name of the Azure DevOps organization.
+
+.PARAMETER SecurityNamespaceID
+The ID of the security namespace from which ACEs will be cleared.
+
+.PARAMETER DifferenceACLs
+An object containing the difference ACLs, including the token and subdescriptors.
+
+.PARAMETER ApiVersion
+The API version to use for the Azure DevOps REST API. Defaults to the version returned by Get-AzDevOpsApiVersion.
+
+.EXAMPLE
+Clear-AzDoACE -OrganizationName "MyOrganization" -SecurityNamespaceID "12345" -DifferenceACLs $aclObject
+
+This example clears the ACEs for the specified security namespace in the "MyOrganization" Azure DevOps organization.
+
+.NOTES
+The function uses the Invoke-AzDevOpsApiRestMethod to call the Azure DevOps REST API.
+#>
+Function Clear-AzDoACE {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$OrganizationName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SecurityNamespaceID,
+
+        [Parameter(Mandatory = $true)]
+        [Object]$DifferenceACLs,
+
+        [Parameter()]
+        [String]
+        $ApiVersion = $(Get-AzDevOpsApiVersion -Default)
+    )
+
+    Write-Verbose "[Clear-AzDoACE] Started."
+    Write-Verbose "[Clear-AzDoACE] Organization Name: $OrganizationName"
+    Write-Verbose "[Clear-AzDoACE] Security Namespace ID: $SecurityNamespaceID"
+    Write-Verbose "[Clear-AzDoACE] Difference ACLs: $($DifferenceACLs | ConvertTo-Json)"
+
+    $Token = $DifferenceACLs.token._token
+    # Define a hashtable to store parameters for the Invoke-AzDevOpsApiRestMethod function.
+
+    $SubDescriptors = $DifferenceACLs.aces.Identity.value.ACLIdentity.descriptor
+
+    # If there are no subdescriptors, no work is required - skip!
+    if (-not $SubDescriptors)
+    {
+        Write-Verbose "[Clear-AzDoACE] No subdescriptors found. Skipping."
+        return
+    }
+
+    # Join the subdescriptors into a comma-separated string.
+    $SubDescriptors = $SubDescriptors -join ','
+
+    $params = @{
+        <#
+            Construct the Uri using string formatting with the -f operator.
+            It includes the API endpoint, group identity, member identity, and the API version.
+        #>
+
+        Uri = 'https://dev.azure.com/{0}/_apis/accesscontrolentries/{1}?token={2}&descriptors={3}&api-version={4}' -f $OrganizationName,
+                                                                                            $SecurityNamespaceID,
+                                                                                            $Token,
+                                                                                            $SubDescriptors,
+                                                                                            $ApiVersion
+        # Set the method to PUT.
+        Method = 'DELETE'
+    }
+
+    Write-Verbose "[Clear-AzDoACE] Uri: $($params.Uri)"
+
+    try
+    {
+        <#
+            Call the Invoke-AzDevOpsApiRestMethod function with the parameters defined above.
+            The "@" symbol is used to pass the hashtable as splatting parameters.
+        #>
+        Write-Verbose "[Clear-AzDoACE] Attempting to invoke REST method to clear ACEs from $Token Token."
+        $null = Invoke-AzDevOpsApiRestMethod @params
+
+    }
+    catch
+    {
+        # If an exception occurs, write an error message to the console with details about the issue.
+        Write-Error "[Clear-AzDoACE] Failed to set ACLs: $($_.Exception.Message)"
+    }
+
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/AzDoPermission/Set-AzDoPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/AzDoPermission/Set-AzDoPermission.ps1
@@ -31,22 +31,41 @@ an error message is written to the console.
 
 Function Set-AzDoPermission
 {
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClearACE')]
         [string]$OrganizationName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClearACE')]
         [string]$SecurityNamespaceID,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClearACE')]
         [Object]$SerializedACLs,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ClearACE')]
+        [Switch]$ClearACEs,
+
+        [Parameter(ParameterSetName = 'ClearACE')]
+        [Object]$DifferenceACLs,
+
+        [Parameter(ParameterSetName = 'Default')]
+        [Parameter(ParameterSetName = 'ClearACE')]
         [String]
         $ApiVersion = $(Get-AzDevOpsApiVersion -Default)
     )
 
     Write-Verbose "[Set-AzDoPermission] Started."
+
+    # Check if the ClearACEs switch is set to true. If so clear the ACEs prior to setting the new ACLs.
+    if ($ClearACEs.IsPresent)
+    {
+        Write-Verbose "[Set-AzDoPermission] Clearing ACEs."
+        Clear-AzDoACE -OrganizationName $OrganizationName -SecurityNamespaceID $SecurityNamespaceID -DifferenceACLs $DifferenceACLs
+    }
+
 
     # Define a hashtable to store parameters for the Invoke-AzDevOpsApiRestMethod function.
 

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-ACL.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-ACL.ps1
@@ -68,6 +68,11 @@ Function ConvertTo-ACL
 
     # Verbose output indicating the start of the function.
     Write-Verbose "[ConvertTo-ACL] Started."
+    Write-Verbose "[ConvertTo-ACL] Security Namespace: $SecurityNamespace"
+    Write-Verbose "[ConvertTo-ACL] Permissions: $($Permissions | Out-String)"
+    Write-Verbose "[ConvertTo-ACL] isInherited: $isInherited"
+    Write-Verbose "[ConvertTo-ACL] Organization Name: $OrganizationName"
+    Write-Verbose "[ConvertTo-ACL] Token Name: $TokenName"
 
     # Create a hash table for ACL token parameters.
     $ACLTokenParams = @{

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-ACL.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-ACL.ps1
@@ -106,7 +106,7 @@ Function ConvertTo-ACL
     }
 
     # Group the ACEs by the identity removing any duplicates.
-    $ACL.aces = Group-ACEs -ACEs $ACL.aces
+    $ACL.aces = @(Group-ACEs -ACEs $ACL.aces)
 
     Write-Verbose "[ConvertTo-ACL] Created ACL: $($ACL | Out-String)"
 

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Group-ACEs.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Group-ACEs.ps1
@@ -24,6 +24,8 @@
 #>
 Function Group-ACEs
 {
+    [CmdletBinding()]
+    [OutputType([System.Collections.ArrayList])]
     param(
         # Mandatory parameter: an array of ACE objects.
         [Parameter()]
@@ -59,7 +61,16 @@ Function Group-ACEs
     # Add the single identities to the ACE list
     $Single | ForEach-Object {
         Write-Verbose "[Group-ACE] Adding single identity: $($_.Group[0].Identity)"
-        $ACEList.Add($_.Group[0])
+        $ACEList.Add(
+            @{
+                Identity    = $_.Group[0].Identity
+                Permissions = @{
+                    Deny            = $_.Group[0].Permissions.Deny
+                    Allow           = $_.Group[0].Permissions.Allow
+                    DescriptorType  = $_.Group[0].Permissions.DescriptorType
+                }
+            }
+        )
     }
 
     Write-Verbose "[Group-ACE] Grouping multiple identities by permissions."
@@ -85,6 +96,8 @@ Function Group-ACEs
     }
 
     Write-Verbose "[Group-ACE] Completed."
-    $ACEList
+
+    # Return the list of ACEs
+    return $ACEList
 
 }

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Test-ACLListforChanges.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Test-ACLListforChanges.ps1
@@ -78,7 +78,7 @@ Function Test-ACLListforChanges
 
     if ($ReferenceACLs.ACEs.Count -ne $DifferenceACLs.ACEs.Count)
     {
-        Write-Verbose "[Test-ACLListforChanges] ACLs count is not equal."
+        Write-Verbose "[Test-ACLListforChanges] ACEs count is not equal."
         $result.status = "Changed"
         $result.reason += @{
             Value = $ReferenceACLs

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Get-AzDevOpsApiVersion.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Get-AzDevOpsApiVersion.ps1
@@ -19,7 +19,7 @@ function Get-AzDevOpsApiVersion
         $Default
     )
 
-    [string]$defaultApiVersion = '7.0-preview.1'
+    [string]$defaultApiVersion = '7.1'
 
     [string[]]$apiVersions = @(
 
@@ -27,11 +27,9 @@ function Get-AzDevOpsApiVersion
         #'5.0', # Not supported
         #'5.1', # Not supported
         '6.0',
+        '7.0',
         '7.1',
-        '7.0-preview.1',
-        '7.1-preview.1',
-        '7.1-preview.4',
-        '7.2-preview.4'
+        '7.2-preview.1'
 
     )
 

--- a/source/Modules/AzureDevOpsDsc.Common/LocalizedData/001.LocalizedDataAzResourceTokenPatten.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/LocalizedData/001.LocalizedDataAzResourceTokenPatten.ps1
@@ -28,7 +28,7 @@ data LocalizedDataAzResourceTokenPatten
     @{
         # Git ACL Token Patterns
         OrganizationGit     = '^azdoorg$'
-        GitProject          = '^\(repoV2\)\\/\(\?<ProjectId>[A-Za-z0-9-]+\)$'
+        GitProject          = '^(repoV2)(\/|\\)(?<ProjectName>[A-Za-z0-9-_]+)'
         GitRepository       = '(?<ProjectName>[A-Za-z0-9-_]+)(\/|\\)(?<GitRepoName>[A-Za-z0-9-_]+)'
         # Identity ACL Token Patterns
         GroupPermission     = '^(?<ProjectId>[A-Za-z0-9-_]+)\\(?<GroupId>[A-Za-z0-9-_]+)$'

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Get-AzDoGitPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Get-AzDoGitPermission.ps1
@@ -48,7 +48,7 @@ Function Get-AzDoGitPermission
         [Parameter(Mandatory = $true)]
         [string]$ProjectName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [string]$RepositoryName,
 
         [Parameter(Mandatory = $true)]
@@ -77,6 +77,13 @@ Function Get-AzDoGitPermission
     Write-Verbose "[Get-AzDoGitPermission] Security Namespace: $SecurityNamespace"
     Write-Verbose "[Get-AzDoGitPermission] Organization Name: $OrganizationName"
 
+    if ([String]::IsNullOrEmpty($ProjectName)) {
+        Write-Warning "[Get-AzDoGitPermission] Project Name not specified. Defaulting to top-level Project permissions"
+        $ProjectName = $null
+    } else {
+        Write-Verbose "[Get-AzDoGitPermission] Project Name: $ProjectName"
+    }
+
     #
     # Construct a hashtable detailing the group
 
@@ -95,20 +102,38 @@ Function Get-AzDoGitPermission
     # Define the ACL List
     $ACLList = [System.Collections.Generic.List[Hashtable]]::new()
 
-    #
-    # Perform a Lookup within the Cache for the Repository
-    $repository = Get-CacheItem -Key $('{0}\{1}' -f $ProjectName, $RepositoryName) -Type 'LiveRepositories'
+    # Perform a Lookup within the Cache for the Project
+    $projectCache = Get-CacheItem -Key $ProjectName -Type 'LiveProjects'
 
-    # Test if the Repository was found
-    if (-not $repository)
+    # Test if the Project was found
+    if (-not $projectCache)
     {
-        Write-Warning "[Get-AzDoGitPermission] Repository not found: $RepositoryName"
-        $getGroupResult.status = [DSCGetSummaryState]::NotFound
+        Write-Warning "[Get-AzDoGitPermission] Project not found: $ProjectName"
+        $getGroupResult.status = [DSCGetSummaryState]::Error
+        $getGroupResult.reason = "Project not found: $ProjectName"
+
         return $getGroupResult
     }
 
+    # Test if the ProjectName was specified
+    if ($null -ne $ProjectName) {
+
+        #
+        # Perform a Lookup within the Cache for the Repository
+        $repositoryCache = Get-CacheItem -Key $('{0}\{1}' -f $ProjectName, $RepositoryName) -Type 'LiveRepositories'
+
+        # Test if the Repository was found, however only if the ProjectName was specified
+        if (-not $repositoryCache)
+        {
+            Write-Warning "[Get-AzDoGitPermission] Repository not found: $RepositoryName"
+            $getGroupResult.status = [DSCGetSummaryState]::NotFound
+            return $getGroupResult
+        }
+
+    }
+
     #
-    # Perform Lookup of the Permissions for the Repository
+    # Perform Lookup of the Permissions
 
     $namespace = Get-CacheItem -Key $SecurityNamespace -Type 'SecurityNamespaces'
     Write-Verbose "[Get-AzDoGitPermission] Retrieved namespace: $($namespace.namespaceId)"
@@ -130,8 +155,9 @@ Function Get-AzDoGitPermission
     # Test if the ACLs were found
     if ($DevOpsACLs -eq $null)
     {
-        Write-Warning "[Get-AzDoGitPermission] No ACLs found for the repository."
-        $getGroupResult.status = [DSCGetSummaryState]::NotFound
+        Write-Error "[Get-AzDoGitPermission] No ACLs were found within the Security Namespace."
+        $getGroupResult.status = [DSCGetSummaryState]::Error
+        $getGroupResult.reason = "No ACLs were found within the Security Namespace."
         return $getGroupResult
     }
 
@@ -146,8 +172,16 @@ Function Get-AzDoGitPermission
         return $getGroupResult
     }
 
-    $DifferenceACLs = $DifferenceACLs | Where-Object {
-        ($_.Token.Type -eq 'GitRepository') -and ($_.Token.RepoId -eq $repository.id)
+    # Filter the ACLs for the Repository
+    # If the Repository is not specified, return the GitProject ACLs
+    if ($null -eq $ProjectName) {
+        # Filter the ACLs for the top-level GitProject
+        $DifferenceACLs = $DifferenceACLs | Where-Object { ($_.Token.Type -eq 'GitProject') -and ($_.Token.ProjectId -eq $projectCache.id) }
+    } else {
+        # Filter the ACLs for the GitRepository
+        $DifferenceACLs = $DifferenceACLs | Where-Object {
+            ($_.Token.Type -eq 'GitRepository') -and ($_.Token.RepoId -eq $repositoryCache.id)
+        }
     }
 
     Write-Verbose "[Get-AzDoGitPermission] ACL List retrieved and formatted."
@@ -160,7 +194,12 @@ Function Get-AzDoGitPermission
         SecurityNamespace   = $SecurityNamespace
         isInherited         = $isInherited
         OrganizationName    = $OrganizationName
-        TokenName           = '[{0}]\{1}' -f $ProjectName, $RepositoryName
+        TokenName           = $(
+                                if ($null -eq $ProjectName) {
+                                    'repoV2\{0}' -f $ProjectName
+                                } else {
+                                    '[{0}]\{1}' -f $ProjectName, $RepositoryName
+                                })
     }
 
     # Convert the Permissions to an ACL Token

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Get-AzDoGitPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Get-AzDoGitPermission.ps1
@@ -76,12 +76,14 @@ Function Get-AzDoGitPermission
 
     Write-Verbose "[Get-AzDoGitPermission] Security Namespace: $SecurityNamespace"
     Write-Verbose "[Get-AzDoGitPermission] Organization Name: $OrganizationName"
+    Write-Verbose "[Get-AzDoGitPermission] Project Name: $ProjectName"
 
-    if ([String]::IsNullOrEmpty($ProjectName)) {
-        Write-Warning "[Get-AzDoGitPermission] Project Name not specified. Defaulting to top-level Project permissions"
-        $ProjectName = $null
+
+    if ([String]::IsNullOrEmpty($RepositoryName)) {
+        Write-Warning "[Get-AzDoGitPermission] RepositoryName not specified. Defaulting to top-level Project permissions"
+        $RepositoryName = $null
     } else {
-        Write-Verbose "[Get-AzDoGitPermission] Project Name: $ProjectName"
+        Write-Verbose "[Get-AzDoGitPermission] Repository Name: $RepositoryName"
     }
 
     #
@@ -115,8 +117,11 @@ Function Get-AzDoGitPermission
         return $getGroupResult
     }
 
-    # Test if the ProjectName was specified
-    if ($null -ne $ProjectName) {
+    # Test if the RepositoryName was specified
+    if ($RepositoryName) {
+
+        #
+        Write-Verbose "[Get-AzDoGitPermission] Repository Name: $RepositoryName is not null."
 
         #
         # Perform a Lookup within the Cache for the Repository
@@ -174,9 +179,11 @@ Function Get-AzDoGitPermission
 
     # Filter the ACLs for the Repository
     # If the Repository is not specified, return the GitProject ACLs
-    if ($null -eq $ProjectName) {
+    if (-not $RepositoryName) {
         # Filter the ACLs for the top-level GitProject
-        $DifferenceACLs = $DifferenceACLs | Where-Object { ($_.Token.Type -eq 'GitProject') -and ($_.Token.ProjectId -eq $projectCache.id) }
+        $DifferenceACLs = $DifferenceACLs | Where-Object {
+            ($_.Token.Type -eq 'GitProject') -and ($_.Token.ProjectId -eq $projectCache.id)
+        }
     } else {
         # Filter the ACLs for the GitRepository
         $DifferenceACLs = $DifferenceACLs | Where-Object {
@@ -195,7 +202,7 @@ Function Get-AzDoGitPermission
         isInherited         = $isInherited
         OrganizationName    = $OrganizationName
         TokenName           = $(
-                                if ($null -eq $ProjectName) {
+                                if (-not $RepositoryName) {
                                     'repoV2\{0}' -f $ProjectName
                                 } else {
                                     '[{0}]\{1}' -f $ProjectName, $RepositoryName

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Get-AzDoGitPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Get-AzDoGitPermission.ps1
@@ -80,8 +80,10 @@ Function Get-AzDoGitPermission
 
 
     if ([String]::IsNullOrEmpty($RepositoryName)) {
+
         Write-Warning "[Get-AzDoGitPermission] RepositoryName not specified. Defaulting to top-level Project permissions"
         $RepositoryName = $null
+
     } else {
         Write-Verbose "[Get-AzDoGitPermission] Repository Name: $RepositoryName"
     }

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/New-AzDoGitPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/New-AzDoGitPermission.ps1
@@ -39,7 +39,7 @@ Function New-AzDoGitPermission
         [Parameter(Mandatory = $true)]
         [string]$ProjectName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [string]$RepositoryName,
 
         [Parameter(Mandatory = $true)]
@@ -60,6 +60,15 @@ Function New-AzDoGitPermission
     )
 
     Write-Verbose "[New-AzDoGitPermission] Started."
+
+    #
+    # Test if the Repository is specified
+    if ([String]::IsNullOrEmpty($RepositoryName))
+    {
+        Write-Warning "[New-AzDoGitPermission] Repository Name not specified. Defaulting to top-level Project permissions."
+        Write-Warning "[New-AzDoGitPermission] STOPPING. It is not possible add permissions to a top-level Project."
+        return
+    }
 
     #
     # Security Namespace ID

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Remove-AzDoGitPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Remove-AzDoGitPermission.ps1
@@ -5,7 +5,7 @@ Function Remove-AzDoGitPermission
         [Parameter(Mandatory = $true)]
         [string]$ProjectName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [string]$RepositoryName,
 
         [Parameter(Mandatory = $true)]
@@ -26,6 +26,15 @@ Function Remove-AzDoGitPermission
     )
 
     Write-Verbose "[New-AzDoGitPermission] Started."
+
+    #
+    # Test if the Repository is specified
+    if ([String]::IsNullOrEmpty($RepositoryName))
+    {
+        Write-Warning "[New-AzDoGitPermission] Repository Name not specified. Defaulting to top-level Project permissions."
+        Write-Warning "[New-AzDoGitPermission] STOPPING. It is not possible to remove permissions from a top-level Project."
+        return
+    }
 
     #
     # Security Namespace ID

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Set-AzDoGitPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Set-AzDoGitPermission.ps1
@@ -5,7 +5,7 @@ Function Set-AzDoGitPermission
         [Parameter(Mandatory = $true)]
         [string]$ProjectName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [string]$RepositoryName,
 
         [Parameter(Mandatory = $true)]
@@ -48,6 +48,7 @@ Function Set-AzDoGitPermission
     #
     # Serialize the ACLs
 
+    # More work is needed here.
     $serializeACLParams = @{
         ReferenceACLs = $LookupResult.propertiesChanged
         DescriptorACLList = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Set-AzDoGitPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Set-AzDoGitPermission.ps1
@@ -62,8 +62,18 @@ Function Set-AzDoGitPermission
     }
 
     #
+    # If the Repository is not specified, this dictates that the permissions are for the Project.
+    # Because of this we need to remove the ACE's that need to be removed prior to setting the new permissions.
+    if (-not $RepositoryName) {
+        Write-Verbose "[Set-AzDoPermission] Clearing ACEs."
+        $params.ClearACEs = $true
+        $params.DifferenceACLs = $LookupResult.DifferenceACLs
+    }
+
+    #
     # Set the Git Repository Permissions
 
+    Write-Verbose "[Set-AzDoPermission] Parameters: $($params | ConvertTo-Json -Depth 5)"
     Set-AzDoPermission @params
 
 }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ACE/Clear-AzDoACE.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ACE/Clear-AzDoACE.tests.ps1
@@ -1,0 +1,105 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Clear-AzDoACE Tests' {
+
+    BeforeAll {
+
+        # Load the functions to test
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Clear-AzDoACE.tests.ps1'
+        }
+
+        # Load the functions to test
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) {
+            . $file.FullName
+        }
+
+        # Mock the Get-AzDevOpsApiVersion function to return a fixed API version
+        Mock -CommandName Get-AzDevOpsApiVersion { return "6.0" }
+
+        # Mock the Invoke-AzDevOpsApiRestMethod function to simulate API behavior
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod { Write-Output "API Called" }
+        Mock -CommandName Write-Warning
+
+    }
+
+
+    # Test case: Ensure the function handles valid input correctly
+    It 'Should call Invoke-AzDevOpsApiRestMethod with correct parameters' {
+        # Arrange
+        $OrganizationName = "MyOrg"
+        $SecurityNamespaceID = "12345"
+        $DifferenceACLs = @{
+            token = @{ _token = "sampleToken" }
+            aces = @{
+                Identity = @{
+                    value = @{
+                        ACLIdentity = @{
+                            descriptor = @("Descriptor1", "Descriptor2")
+                        }
+                    }
+                }
+            }
+        }
+
+        # Act
+        Clear-AzDoACE -OrganizationName $OrganizationName -SecurityNamespaceID $SecurityNamespaceID -DifferenceACLs $DifferenceACLs
+
+        # Assert
+        Assert-MockCalled -Exactly 1 -CommandName Invoke-AzDevOpsApiRestMethod -Scope It
+    }
+
+    # Test case: Handle empty subdescriptors
+    It 'Should not call Invoke-AzDevOpsApiRestMethod if there are no subdescriptors' {
+        # Arrange
+        $OrganizationName = "MyOrg"
+        $SecurityNamespaceID = "12345"
+        $DifferenceACLs = @{
+            token = @{ _token = "sampleToken" }
+            aces = @{
+                Identity = @{
+                    value = @{
+                        ACLIdentity = @{
+                            descriptor = @()
+                        }
+                    }
+                }
+            }
+        }
+
+        # Act
+        Clear-AzDoACE -OrganizationName $OrganizationName -SecurityNamespaceID $SecurityNamespaceID -DifferenceACLs $DifferenceACLs
+
+        # Assert
+        Assert-MockCalled -Exactly 0 -CommandName Invoke-AzDevOpsApiRestMethod -Scope It
+    }
+
+    # Test case: Ensure error handling works
+    It 'Should handle exceptions gracefully and output error message' {
+        # Arrange
+        Mock Invoke-AzDevOpsApiRestMethod { throw "API Call Failed" }
+        Mock Write-Error
+
+        $OrganizationName = "MyOrg"
+        $SecurityNamespaceID = "12345"
+        $DifferenceACLs = @{
+            token = @{ _token = "sampleToken" }
+            aces = @{
+                Identity = @{
+                    value = @{
+                        ACLIdentity = @{
+                            descriptor = @("Descriptor1")
+                        }
+                    }
+                }
+            }
+        }
+
+        # Capture error output
+        { Clear-AzDoACE -OrganizationName $OrganizationName -SecurityNamespaceID $SecurityNamespaceID -DifferenceACLs $DifferenceACLs } | Should -Not -Throw
+
+        # Assert
+        Assert-MockCalled -Exactly 1 -CommandName Write-Error -Scope It
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/AzDoPermission/Set-AzDoPermission.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/AzDoPermission/Set-AzDoPermission.tests.ps1
@@ -17,6 +17,7 @@ Describe 'Set-AzDoPermission Tests' -Tags "Unit", "API" {
 
         Mock -CommandName Get-AzDevOpsApiVersion { return '6.0-preview.1' }
         Mock -CommandName Invoke-AzDevOpsApiRestMethod { return $null }
+        Mock -CommandName Clear-AzDoACE { return $null }
 
         $OrganizationName = "TestOrg"
         $SecurityNamespaceID = "TestNamespace"
@@ -37,6 +38,14 @@ Describe 'Set-AzDoPermission Tests' -Tags "Unit", "API" {
                 $Method -eq 'POST'
                 $Body -eq $SerializedACLs
             }
+        }
+    }
+
+    Context 'When ClearACEs switch is provided' {
+        It 'Should call Clear-AzDoACE' {
+            Set-AzDoPermission -OrganizationName $OrganizationName -SecurityNamespaceID $SecurityNamespaceID -SerializedACLs $SerializedACLs -ClearACEs -DifferenceACLs $SerializedACLs
+
+            Assert-MockCalled -CommandName Clear-AzDoACE -Exactly 1
         }
     }
 

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-ACL.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-ACL.tests.ps1
@@ -24,7 +24,7 @@ Describe "ConvertTo-ACL" -Tags "Unit", "ACL", "Helper" {
             )
         }
         Mock -CommandName Group-ACEs -MockWith { param($ACEs) return $ACEs }
-
+        Mock -CommandName
         $permissions = @(
             @{
                 Identity    = 'User1'

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Group-ACEs.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Group-ACEs.tests.ps1
@@ -62,7 +62,8 @@ Describe 'Group-ACEs' -Tags "Unit", "ACL", "Helper" {
     }
 
     It 'Processes single identity ACE' {
-        $result = Group-ACEs -ACEs @($ace1)
+        $result = @(Group-ACEs -ACEs @($ace1))
+        $result.Count | Should -Be 1
         $result.Identity.value.originId | Should -Be "user1"
         $result.Permissions.Deny | Should -Be 0,1
         $result.Permissions.Allow | Should -Be 2,3
@@ -70,7 +71,7 @@ Describe 'Group-ACEs' -Tags "Unit", "ACL", "Helper" {
 
     It 'Groups multiple identities correctly' {
 
-        $result = Group-ACEs -ACEs @($ace1, $ace2, $ace3)
+        $result = @(Group-ACEs -ACEs @($ace1, $ace2, $ace3))
         $result.Count | Should -Be 2
         $user1 = $result | Where-Object { $_.Identity.value.originId -eq "user1" }
         $user2 = $result | Where-Object { $_.Identity.value.originId -eq "user2" }
@@ -83,7 +84,7 @@ Describe 'Group-ACEs' -Tags "Unit", "ACL", "Helper" {
     }
 
     It "Doesn't group single identity ACE" {
-        $result = Group-ACEs -ACEs @($ace1)
+        $result = @(Group-ACEs -ACEs @($ace1))
         @($result).Count | Should -Be 1
     }
 

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Get-AzDevOpsApiVersion.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Get-AzDevOpsApiVersion.tests.ps1
@@ -22,7 +22,7 @@ Describe 'Get-AzDevOpsApiVersion Tests' {
     }
 
     It 'Should return default API version when -Default is specified' {
-        $expected = '7.0-preview.1'
+        $expected = '7.1'
         $result = Get-AzDevOpsApiVersion -Default
         $result | Should -Be $expected
     }


### PR DESCRIPTION
# Overview
This pull request introduces an adjustment to the AzDoGitPermission resource, enabling the setting of project-level permissions when the RepositoryName property is not specified.

# Changes Made
Feature Update: Modified the AzDoGitPermission resource to apply Git permissions at the project level if the RepositoryName property is omitted.

# Detailed Description
The following changes have been implemented:

## Optional Property Handling:
The RepositoryName property is now optional. When it is not provided, the system will default to applying permissions at the project level instead of the repository level.

# Testing
Verified that permissions are correctly applied at the project level when the RepositoryName property is absent.
Ensured backward compatibility by maintaining existing functionality when RepositoryName is specified.