### PR TITLE
chore: Resync fork with dsccommunity/AzureDevOpsDsc upstream

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/powershell
+{
+    "name": "PowerShell",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/powershell:lts-debian-11",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "true",
+            "username": "vscode",
+            "upgradePackages": "false",
+            "nonFreePackages": "true"
+        }
+    },
+
+    "postCreateCommand": "sudo chsh vscode -s \"$(which pwsh)\"",
+
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "pwsh"
+            },
+
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "ms-vscode.powershell"
+            ]
+        }
+    }
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,12 +3,7 @@
     "MD029": {
         "style": "one"
     },
-    "MD013": {
-        "line_length": 80,
-        "headers": false,
-        "code_blocks":false,
-        "tables": false
-    },
+    "MD013": true,
     "MD024": false,
     "MD034": false,
     "no-hard-tabs": true

--- a/.vscode/analyzersettings.psd1
+++ b/.vscode/analyzersettings.psd1
@@ -1,44 +1,73 @@
 @{
-    CustomRulePath      = '.\output\RequiredModules\DscResource.AnalyzerRules'
+    CustomRulePath      = @(
+        '.\output\RequiredModules\DscResource.AnalyzerRules'
+        '.\output\RequiredModules\Indented.ScriptAnalyzerRules'
+    )
     includeDefaultRules = $true
-    IncludeRules   = @(
-        # DSC Resource Kit style guideline rules.
-        'PSAvoidDefaultValueForMandatoryParameter',
-        'PSAvoidDefaultValueSwitchParameter',
-        'PSAvoidInvokingEmptyMembers',
-        'PSAvoidNullOrEmptyHelpMessageAttribute',
-        'PSAvoidUsingCmdletAliases',
-        'PSAvoidUsingComputerNameHardcoded',
-        'PSAvoidUsingDeprecatedManifestFields',
-        'PSAvoidUsingEmptyCatchBlock',
-        'PSAvoidUsingInvokeExpression',
-        'PSAvoidUsingPositionalParameters',
-        'PSAvoidShouldContinueWithoutForce',
-        'PSAvoidUsingWMICmdlet',
-        'PSAvoidUsingWriteHost',
-        'PSDSCReturnCorrectTypesForDSCFunctions',
-        'PSDSCStandardDSCFunctionsInResource',
-        'PSDSCUseIdenticalMandatoryParametersForDSC',
-        'PSDSCUseIdenticalParametersForDSC',
-        'PSMisleadingBacktick',
-        'PSMissingModuleManifestField',
-        'PSPossibleIncorrectComparisonWithNull',
-        'PSProvideCommentHelp',
-        'PSReservedCmdletChar',
-        'PSReservedParams',
-        'PSUseApprovedVerbs',
-        'PSUseCmdletCorrectly',
-        'PSUseOutputTypeCorrectly',
-        'PSAvoidGlobalVars',
-        'PSAvoidUsingConvertToSecureStringWithPlainText',
-        'PSAvoidUsingPlainTextForPassword',
-        'PSAvoidUsingUsernameAndPasswordParams',
-        'PSDSCUseVerboseMessageInDSCResource',
-        'PSShouldProcess',
-        'PSUseDeclaredVarsMoreThanAssignments',
-        'PSUsePSCredentialType',
+    IncludeRules        = @(
+        # DSC Community style guideline rules from the module ScriptAnalyzer.
+        'PSAvoidDefaultValueForMandatoryParameter'
+        'PSAvoidDefaultValueSwitchParameter'
+        'PSAvoidInvokingEmptyMembers'
+        'PSAvoidNullOrEmptyHelpMessageAttribute'
+        'PSAvoidUsingCmdletAliases'
+        'PSAvoidUsingComputerNameHardcoded'
+        'PSAvoidUsingDeprecatedManifestFields'
+        'PSAvoidUsingEmptyCatchBlock'
+        'PSAvoidUsingInvokeExpression'
+        'PSAvoidUsingPositionalParameters'
+        'PSAvoidShouldContinueWithoutForce'
+        'PSAvoidUsingWMICmdlet'
+        'PSAvoidUsingWriteHost'
+        'PSDSCReturnCorrectTypesForDSCFunctions'
+        'PSDSCStandardDSCFunctionsInResource'
+        'PSDSCUseIdenticalMandatoryParametersForDSC'
+        'PSDSCUseIdenticalParametersForDSC'
+        'PSMisleadingBacktick'
+        'PSMissingModuleManifestField'
+        'PSPossibleIncorrectComparisonWithNull'
+        'PSProvideCommentHelp'
+        'PSReservedCmdletChar'
+        'PSReservedParams'
+        'PSUseApprovedVerbs'
+        'PSUseCmdletCorrectly'
+        'PSUseOutputTypeCorrectly'
+        'PSAvoidGlobalVars'
+        'PSAvoidUsingConvertToSecureStringWithPlainText'
+        'PSAvoidUsingPlainTextForPassword'
+        'PSAvoidUsingUsernameAndPasswordParams'
+        'PSDSCUseVerboseMessageInDSCResource'
+        'PSShouldProcess'
+        'PSUseDeclaredVarsMoreThanAssignments'
+        'PSUsePSCredentialType'
 
+        # Additional rules from the module ScriptAnalyzer
+        'PSUseConsistentWhitespace'
+        'UseCorrectCasing'
+        'PSPlaceOpenBrace'
+        'PSPlaceCloseBrace'
+        'AlignAssignmentStatement'
+        'AvoidUsingDoubleQuotesForConstantString'
+        'UseShouldProcessForStateChangingFunctions'
+
+        # Rules from the modules DscResource.AnalyzerRules
         'Measure-*'
+
+        # Rules from the module Indented.ScriptAnalyzerRules
+        'AvoidCreatingObjectsFromAnEmptyString'
+        'AvoidDashCharacters'
+        'AvoidEmptyNamedBlocks'
+        'AvoidFilter'
+        'AvoidHelpMessage'
+        'AvoidNestedFunctions'
+        'AvoidNewObjectToCreatePSObject'
+        'AvoidParameterAttributeDefaultValues'
+        'AvoidProcessWithoutPipeline'
+        'AvoidSmartQuotes'
+        'AvoidThrowOutsideOfTry'
+        'AvoidWriteErrorStop'
+        'AvoidWriteOutput'
+        'UseSyntacticallyCorrectExamples'
     )
 
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+    "recommendations": [
+        "streetsidesoftware.code-spell-checker",
+        "usernamehw.errorlens",
+        "davidanson.vscode-markdownlint",
+        "pspester.pester-test",
+        "ms-vscode.powershell",
+        "redhat.vscode-yaml",
+        "gruntfuggly.todo-tree",
+        "codecov.codecov"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,9 +14,13 @@
     "files.insertFinalNewline": true,
     "powershell.scriptAnalysis.settingsPath": ".vscode\\analyzersettings.psd1",
     "powershell.scriptAnalysis.enable": true,
+    "files.trimFinalNewlines": true,
     "files.associations": {
         "*.ps1xml": "xml"
     },
+    "cSpell.dictionaries": [
+        "powershell"
+    ],
     "cSpell.words": [
         "COMPANYNAME",
         "ICONURI",
@@ -32,8 +36,21 @@
         "pscmdlet",
         "steppable"
     ],
+    "cSpell.ignorePaths": [
+        ".git"
+    ],
     "[markdown]": {
         "files.trimTrailingWhitespace": false,
         "files.encoding": "utf8"
-    }
+    },
+    "powershell.pester.useLegacyCodeLens": false,
+    "pester.testFilePath": [
+        "[tT]ests/[qQ][aA]/*.[tT]ests.[pP][sS]1",
+        "[tT]ests/[uU]nit/**/*.[tT]ests.[pP][sS]1",
+        "[tT]ests/[uU]nit/*.[tT]ests.[pP][sS]1"
+    ],
+    "pester.runTestsInNewProcess": true,
+    "pester.pesterModulePath": "./output/RequiredModules/Pester",
+    "powershell.pester.codeLens": true,
+    "pester.suppressCodeLensNotice": true,
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     for more information).
   - Updated pipeline file `RequiredModules.ps1` to latest pipeline pattern.
   - Updated pipeline file `build.yaml` to latest pipeline pattern.
+  - Updated pipeline file `azure-pipelines.yml` to use correct images (hosted runners)
+    and correct task for artifacts.
 - AzDevOpsProject
   - Added a validate set to the parameter `SourceControlType` to (for now)
     limit the parameter to the values `Git` and `Tfvc`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `WikiSource` will be published to the GitHub repository wiki. The markdown
     file `Home.md` will be updated with the correct module version on each
     publish to gallery (including preview).
+  - CodeCov integration.
 - AzureDevOpsDsc.Common
   - Added 'wrapper' functionality around the [Azure DevOps REST API](https://docs.microsoft.com/en-us/rest/api/azure/devops/)
 
@@ -47,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update comment-based help to remove text which the valid values are
     since that is now add automatically to the documentation (conceptual
     help and wiki documentation).
+- Repository Updates
+  - Update repository files to latest versions.
+    - Resolve-Dependency
+    - build.yml
+    - Sampler files
+    - azure-pipelines
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # AzureDevOpsDsc
 
+> Note - This repo is mostly unmaintained and as such you may be better looking at [this new DSCv3 version by @mimachniak](https://github.com/mimachniak/AzureDevOpsDscv3)
+> As such @kilasuit who is looking for a replacement maintainer in https://github.com/dsccommunity/AzureDevOpsDsc/issues/44 is recommending this repo be archived unless another maintainer steps up.
+
+
 The **AzureDevOpsDsc** module contains DSC Resources for deployment and
 configuration of Azure DevOps and Azure DevOps Server.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ configuration of Azure DevOps and Azure DevOps Server.
 [![Build Status](https://dev.azure.com/dsccommunity/AzureDevOpsDsc/_apis/build/status/dsccommunity.AzureDevOpsDsc?branchName=main)](https://dev.azure.com/dsccommunity/AzureDevOpsDsc/_build/latest?definitionId=41&branchName=main)
 ![Azure DevOps coverage (branch)](https://img.shields.io/azure-devops/coverage/dsccommunity/AzureDevOpsDsc/41/main)
 [![Azure DevOps tests](https://img.shields.io/azure-devops/tests/dsccommunity/AzureDevOpsDsc/41/main)](https://dsccommunity.visualstudio.com/AzureDevOpsDsc/_test/analytics?definitionId=41&contextType=build)
+[![codecov](https://codecov.io/gh/dsccommunity/AzureDevOpsDsc/branch/main/graph/badge.svg)](https://codecov.io/gh/dsccommunity/AzureDevOpsDsc)
 [![PowerShell Gallery (with prereleases)](https://img.shields.io/powershellgallery/vpre/AzureDevOpsDsc?label=AzureDevOpsDsc%20Preview)](https://www.powershellgallery.com/packages/AzureDevOpsDsc/)
 [![PowerShell Gallery](https://img.shields.io/powershellgallery/v/AzureDevOpsDsc?label=AzureDevOpsDsc)](https://www.powershellgallery.com/packages/AzureDevOpsDsc/)
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -1,24 +1,42 @@
 @{
-    PSDependOptions             = @{
+    PSDependOptions                = @{
         AddToPath  = $true
         Target     = 'output\RequiredModules'
-        Parameters = @{}
+        Parameters = @{
+            Repository = 'PSGallery'
+        }
     }
 
-    InvokeBuild                 = 'latest'
-    PSScriptAnalyzer            = 'latest'
-    Pester                      = '4.10.1'
-    Plaster                     = 'latest'
-    ModuleBuilder               = 'latest'
-    ChangelogManagement         = 'latest'
-    Sampler                     = 'latest'
-    MarkdownLinkCheck           = 'latest'
-    'DscResource.Test'          = 'latest'
-    'DscResource.AnalyzerRules' = 'latest'
-    xDscResourceDesigner        = 'latest'
-    'DscResource.DocGenerator'  = 'latest'
-    'DscResource.Common'        = 'latest'
+    InvokeBuild                    = 'latest'
+    PSScriptAnalyzer               = 'latest'
+    Pester                         = '4.10.1'
+    Plaster                        = 'latest'
+    ModuleBuilder                  = 'latest'
+    ChangelogManagement            = 'latest'
+    Sampler                        = 'latest'
+    'Sampler.GitHubTasks'          = 'latest'
+    MarkdownLinkCheck              = 'latest'
+    'DscResource.Test'             = 'latest'
+    xDscResourceDesigner           = 'latest'
+    'DscResource.Common'           = 'latest'
+
+    'DscResource.AnalyzerRules'    = @{
+        Version    = 'latest'
+        Parameters = @{
+            AllowPrerelease = $true
+        }
+    }
+    'Indented.ScriptAnalyzerRules' = 'latest'
+
+    # Prerequisite modules for documentation.
+    'DscResource.DocGenerator'     = @{
+        Version    = 'latest'
+        Parameters = @{
+            AllowPrerelease = $true
+        }
+    }
+    PlatyPS                        = 'latest'
 
     # Prerequisites modules needed for examples or integration tests
-    PSDscResources              = '2.12.0.0'
+    PSDscResources                 = '2.12.0.0'
 }

--- a/Resolve-Dependency.ps1
+++ b/Resolve-Dependency.ps1
@@ -1,288 +1,1060 @@
+<#
+    .DESCRIPTION
+        Bootstrap script for PSDepend.
+
+    .PARAMETER DependencyFile
+        Specifies the configuration file for the this script. The default value is
+        'RequiredModules.psd1' relative to this script's path.
+
+    .PARAMETER PSDependTarget
+        Path for PSDepend to be bootstrapped and save other dependencies.
+        Can also be CurrentUser or AllUsers if you wish to install the modules in
+        such scope. The default value is 'output/RequiredModules' relative to
+        this script's path.
+
+    .PARAMETER Proxy
+        Specifies the URI to use for Proxy when attempting to bootstrap
+        PackageProvider and PowerShellGet.
+
+    .PARAMETER ProxyCredential
+        Specifies the credential to contact the Proxy when provided.
+
+    .PARAMETER Scope
+        Specifies the scope to bootstrap the PackageProvider and PSGet if not available.
+        THe default value is 'CurrentUser'.
+
+    .PARAMETER Gallery
+        Specifies the gallery to use when bootstrapping PackageProvider, PSGet and
+        when calling PSDepend (can be overridden in Dependency files). The default
+        value is 'PSGallery'.
+
+    .PARAMETER GalleryCredential
+        Specifies the credentials to use with the Gallery specified above.
+
+    .PARAMETER AllowOldPowerShellGetModule
+        Allow you to use a locally installed version of PowerShellGet older than
+        1.6.0 (not recommended). Default it will install the latest PowerShellGet
+        if an older version than 2.0 is detected.
+
+    .PARAMETER MinimumPSDependVersion
+        Allow you to specify a minimum version fo PSDepend, if you're after specific
+        features.
+
+    .PARAMETER AllowPrerelease
+        Not yet written.
+
+    .PARAMETER WithYAML
+        Not yet written.
+
+    .PARAMETER UseModuleFast
+        Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
+        faster.
+
+    .PARAMETER ModuleFastBleedingEdge
+        Specifies to use ModuleFast code that is in the ModuleFast's main branch
+        in its GitHub repository. The parameter UseModuleFast must also be set to
+        true.
+
+    .PARAMETER UsePSResourceGet
+        Specifies to use the new PSResourceGet module instead of the (now legacy) PowerShellGet module.
+
+    .PARAMETER PSResourceGetVersion
+        String specifying the module version for PSResourceGet if the `UsePSResourceGet` switch is utilized.
+
+    .NOTES
+        Load defaults for parameters values from Resolve-Dependency.psd1 if not
+        provided as parameter.
+#>
 [CmdletBinding()]
 param
 (
     [Parameter()]
-    [String]
+    [System.String]
     $DependencyFile = 'RequiredModules.psd1',
 
     [Parameter()]
-    [String]
-    # Path for PSDepend to be bootstrapped and save other dependencies.
-    # Can also be CurrentUser or AllUsers if you wish to install the modules in such scope
-    # Default to $PWD.Path/output/modules
-    $PSDependTarget = (Join-Path $PSScriptRoot './output/RequiredModules'),
+    [System.String]
+    $PSDependTarget = (Join-Path -Path $PSScriptRoot -ChildPath 'output/RequiredModules'),
 
     [Parameter()]
-    [uri]
-    # URI to use for Proxy when attempting to Bootstrap PackageProvider & PowerShellGet
+    [System.Uri]
     $Proxy,
 
     [Parameter()]
-    # Credential to contact the Proxy when provided
-    [PSCredential]$ProxyCredential,
+    [System.Management.Automation.PSCredential]
+    $ProxyCredential,
 
     [Parameter()]
     [ValidateSet('CurrentUser', 'AllUsers')]
-    [String]
-    # Scope to bootstrap the PackageProvider and PSGet if not available
+    [System.String]
     $Scope = 'CurrentUser',
 
     [Parameter()]
-    [String]
-    # Gallery to use when bootstrapping PackageProvider, PSGet and when calling PSDepend (can be overridden in Dependency files)
+    [System.String]
     $Gallery = 'PSGallery',
 
     [Parameter()]
-    [PSCredential]
-    # Credentials to use with the Gallery specified above
+    [System.Management.Automation.PSCredential]
     $GalleryCredential,
 
-
     [Parameter()]
-    [switch]
-    # Allow you to use a locally installed version of PowerShellGet older than 1.6.0 (not recommended, default to $False)
+    [System.Management.Automation.SwitchParameter]
     $AllowOldPowerShellGetModule,
 
     [Parameter()]
-    [String]
-    # Allow you to specify a minimum version fo PSDepend, if you're after specific features.
+    [System.String]
     $MinimumPSDependVersion,
 
     [Parameter()]
-    [Switch]
+    [System.Management.Automation.SwitchParameter]
     $AllowPrerelease,
 
     [Parameter()]
-    [Switch]
-    $WithYAML
+    [System.Management.Automation.SwitchParameter]
+    $WithYAML,
+
+    [Parameter()]
+    [System.Collections.Hashtable]
+    $RegisterGallery,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UseModuleFast,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $ModuleFastBleedingEdge,
+
+    [Parameter()]
+    [System.String]
+    $ModuleFastVersion,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePSResourceGet,
+
+    [Parameter()]
+    [System.String]
+    $PSResourceGetVersion,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePowerShellGetCompatibilityModule,
+
+    [Parameter()]
+    [System.String]
+    $UsePowerShellGetCompatibilityModuleVersion
 )
 
-# Load Defaults for parameters values from Resolve-Dependency.psd1 if not provided as parameter
 try
 {
-    Write-Verbose -Message "Importing Bootstrap default parameters from '$PSScriptRoot/Resolve-Dependency.psd1'."
-    $ResolveDependencyDefaults = Import-PowerShellDataFile -Path (Join-Path $PSScriptRoot '.\Resolve-Dependency.psd1' -Resolve -ErrorAction Stop)
-    $ParameterToDefault = $MyInvocation.MyCommand.ParameterSets.Where{ $_.Name -eq $PSCmdlet.ParameterSetName }.Parameters.Keys
-    if ($ParameterToDefault.Count -eq 0)
+    if ($PSVersionTable.PSVersion.Major -le 5)
     {
-        $ParameterToDefault = $MyInvocation.MyCommand.Parameters.Keys
-    }
-    # Set the parameters available in the Parameter Set, or it's not possible to choose yet, so all parameters are an option
-    foreach ($ParamName in $ParameterToDefault)
-    {
-        if (-Not $PSBoundParameters.Keys.Contains($ParamName) -and $ResolveDependencyDefaults.ContainsKey($ParamName))
+        if (-not (Get-Command -Name 'Import-PowerShellDataFile' -ErrorAction 'SilentlyContinue'))
         {
-            Write-Verbose -Message "Setting $ParamName with $($ResolveDependencyDefaults[$ParamName])"
+            Import-Module -Name Microsoft.PowerShell.Utility -RequiredVersion '3.1.0.0'
+        }
+    }
+
+    Write-Verbose -Message 'Importing Bootstrap default parameters from ''$PSScriptRoot/Resolve-Dependency.psd1''.'
+
+    $resolveDependencyConfigPath = Join-Path -Path $PSScriptRoot -ChildPath '.\Resolve-Dependency.psd1' -Resolve -ErrorAction 'Stop'
+
+    $resolveDependencyDefaults = Import-PowerShellDataFile -Path $resolveDependencyConfigPath
+
+    $parameterToDefault = $MyInvocation.MyCommand.ParameterSets.Where{ $_.Name -eq $PSCmdlet.ParameterSetName }.Parameters.Keys
+
+    if ($parameterToDefault.Count -eq 0)
+    {
+        $parameterToDefault = $MyInvocation.MyCommand.Parameters.Keys
+    }
+
+    # Set the parameters available in the Parameter Set, or it's not possible to choose yet, so all parameters are an option.
+    foreach ($parameterName in $parameterToDefault)
+    {
+        if (-not $PSBoundParameters.Keys.Contains($parameterName) -and $resolveDependencyDefaults.ContainsKey($parameterName))
+        {
+            Write-Verbose -Message "Setting parameter '$parameterName' to value '$($resolveDependencyDefaults[$parameterName])'."
+
             try
             {
-                $variableValue = $ResolveDependencyDefaults[$ParamName]
-                if ($variableValue -is [string])
+                $variableValue = $resolveDependencyDefaults[$parameterName]
+
+                if ($variableValue -is [System.String])
                 {
                     $variableValue = $ExecutionContext.InvokeCommand.ExpandString($variableValue)
                 }
-                $PSBoundParameters.Add($ParamName, $variableValue)
-                Set-Variable -Name $ParamName -value $variableValue -Force -ErrorAction SilentlyContinue
+
+                $PSBoundParameters.Add($parameterName, $variableValue)
+
+                Set-Variable -Name $parameterName -Value $variableValue -Force -ErrorAction 'SilentlyContinue'
             }
             catch
             {
-                Write-Verbose -Message "Error adding default for $ParamName : $($_.Exception.Message)"
+                Write-Verbose -Message "Error adding default for $parameterName : $($_.Exception.Message)."
             }
         }
     }
 }
 catch
 {
-    Write-Warning -Message "Error attempting to import Bootstrap's default parameters from $(Join-Path $PSScriptRoot '.\Resolve-Dependency.psd1'): $($_.Exception.Message)."
+    Write-Warning -Message "Error attempting to import Bootstrap's default parameters from '$resolveDependencyConfigPath': $($_.Exception.Message)."
 }
 
-Write-Progress -Activity "Bootstrap:" -PercentComplete 0 -CurrentOperation "NuGet Bootstrap"
-
-if (!(Get-PackageProvider -Name NuGet -ForceBootstrap -ErrorAction SilentlyContinue))
+# Handle when both ModuleFast and PSResourceGet is configured or/and passed as parameter.
+if ($UseModuleFast -and $UsePSResourceGet)
 {
-    $providerBootstrapParams = @{
-        Name           = 'nuget'
-        force          = $true
-        ForceBootstrap = $true
-        ErrorAction    = 'Stop'
-    }
+    Write-Information -MessageData 'Both ModuleFast and PSResourceGet is configured or/and passed as parameter.' -InformationAction 'Continue'
 
-    switch ($PSBoundParameters.Keys)
+    if ($PSVersionTable.PSVersion -ge '7.2')
     {
-        'Proxy'
-        {
-            $providerBootstrapParams.Add('Proxy', $Proxy)
-        }
-        'ProxyCredential'
-        {
-            $providerBootstrapParams.Add('ProxyCredential', $ProxyCredential)
-        }
-        'Scope'
-        {
-            $providerBootstrapParams.Add('Scope', $Scope)
-        }
-    }
+        $UsePSResourceGet = $false
 
-    if ($AllowPrerelease)
+        Write-Information -MessageData 'PowerShell 7.2 or higher being used, prefer ModuleFast over PSResourceGet.' -InformationAction 'Continue'
+    }
+    else
     {
-        $providerBootstrapParams.Add('AllowPrerelease', $true)
-    }
+        $UseModuleFast = $false
 
-    Write-Information "Bootstrap: Installing NuGet Package Provider from the web (Make sure Microsoft addresses/ranges are allowed)"
-    $null = Install-PackageProvider @providerBootstrapParams
-    $latestNuGetVersion = (Get-PackageProvider -Name NuGet -ListAvailable | Select-Object -First 1).Version.ToString()
-    Write-Information "Bootstrap: Importing NuGet Package Provider version $latestNuGetVersion to current session."
-    $Null = Import-PackageProvider -Name NuGet -RequiredVersion $latestNuGetVersion -Force
+        Write-Information -MessageData 'Windows PowerShell or PowerShell <=7.1 is being used, prefer PSResourceGet since ModuleFast is not supported on this version of PowerShell.' -InformationAction 'Continue'
+    }
 }
 
-Write-Progress -Activity "Bootstrap:" -PercentComplete 10 -CurrentOperation "Ensuring Gallery $Gallery is trusted"
-
-# Fail if the given PSGallery is not Registered
-$Policy = (Get-PSRepository $Gallery -ErrorAction Stop).InstallationPolicy
-Set-PSRepository -Name $Gallery -InstallationPolicy Trusted -ErrorAction Ignore
-try
+# Only bootstrap ModuleFast if it is not already imported.
+if ($UseModuleFast -and -not (Get-Module -Name 'ModuleFast'))
 {
-    Write-Progress -Activity "Bootstrap:" -PercentComplete 25 -CurrentOperation "Checking PowerShellGet"
-    # Ensure the module is loaded and retrieve the version you have
-    $PowerShellGetVersion = (Import-Module PowerShellGet -PassThru -ErrorAction SilentlyContinue).Version
-
-    Write-Verbose "Bootstrap: The PowerShellGet version is $PowerShellGetVersion"
-    # Versions below 1.6.0 are considered old, unreliable & not recommended
-    if (!$PowerShellGetVersion -or ($PowerShellGetVersion -lt [System.version]'1.6.0' -and !$AllowOldPowerShellGetModule))
+    try
     {
-        Write-Progress -Activity "Bootstrap:" -PercentComplete 40 -CurrentOperation "Installing newer version of PowerShellGet"
-        $InstallPSGetParam = @{
-            Name               = 'PowerShellGet'
-            Force              = $True
-            SkipPublisherCheck = $true
-            AllowClobber       = $true
-            Scope              = $Scope
-            Repository         = $Gallery
+        $moduleFastBootstrapScriptBlockParameters = @{}
+
+        if ($ModuleFastBleedingEdge)
+        {
+            Write-Information -MessageData 'ModuleFast is configured to use Bleeding Edge (directly from ModuleFast''s main branch).' -InformationAction 'Continue'
+
+            $moduleFastBootstrapScriptBlockParameters.UseMain = $true
+        }
+        elseif($ModuleFastVersion)
+        {
+            if ($ModuleFastVersion -notmatch 'v')
+            {
+                $ModuleFastVersion = 'v{0}' -f $ModuleFastVersion
+            }
+
+            Write-Information -MessageData ('ModuleFast is configured to use version {0}.' -f $ModuleFastVersion) -InformationAction 'Continue'
+
+            $moduleFastBootstrapScriptBlockParameters.Release = $ModuleFastVersion
+        }
+        else
+        {
+            Write-Information -MessageData 'ModuleFast is configured to use latest released version.' -InformationAction 'Continue'
+        }
+
+        $moduleFastBootstrapUri = 'bit.ly/modulefast' # cSpell: disable-line
+
+        Write-Debug -Message ('Using bootstrap script at {0}' -f $moduleFastBootstrapUri)
+
+        $invokeWebRequestParameters = @{
+            Uri         = $moduleFastBootstrapUri
+            ErrorAction = 'Stop'
+        }
+
+        $moduleFastBootstrapScript = Invoke-WebRequest @invokeWebRequestParameters
+
+        $moduleFastBootstrapScriptBlock = [ScriptBlock]::Create($moduleFastBootstrapScript)
+
+        & $moduleFastBootstrapScriptBlock @moduleFastBootstrapScriptBlockParameters
+    }
+    catch
+    {
+        Write-Warning -Message ('ModuleFast could not be bootstrapped. Reverting to PSResourceGet. Error: {0}' -f $_.Exception.Message)
+
+        $UseModuleFast = $false
+        $UsePSResourceGet = $true
+    }
+}
+
+if ($UsePSResourceGet)
+{
+    $psResourceGetModuleName = 'Microsoft.PowerShell.PSResourceGet'
+
+    # If PSResourceGet was used prior it will be locked and we can't replace it.
+    if ((Test-Path -Path "$PSDependTarget/$psResourceGetModuleName" -PathType 'Container') -and (Get-Module -Name $psResourceGetModuleName))
+    {
+        Write-Information -MessageData ('{0} is already bootstrapped and imported into the session. If there is a need to refresh the module, open a new session and resolve dependencies again.' -f $psResourceGetModuleName) -InformationAction 'Continue'
+    }
+    else
+    {
+        Write-Debug -Message ('{0} do not exist, saving the module to RequiredModules.' -f $psResourceGetModuleName)
+
+        $psResourceGetDownloaded = $false
+
+        try
+        {
+            if (-not $PSResourceGetVersion)
+            {
+                # Default to latest version if no version is passed in parameter or specified in configuration.
+                $psResourceGetUri = "https://www.powershellgallery.com/api/v2/package/$psResourceGetModuleName"
+            }
+            else
+            {
+                $psResourceGetUri = "https://www.powershellgallery.com/api/v2/package/$psResourceGetModuleName/$PSResourceGetVersion"
+            }
+
+            $invokeWebRequestParameters = @{
+                # TODO: Should support proxy parameters passed to the script.
+                Uri         = $psResourceGetUri
+                OutFile     = "$PSDependTarget/$psResourceGetModuleName.nupkg" # cSpell: ignore nupkg
+                ErrorAction = 'Stop'
+            }
+
+            $previousProgressPreference = $ProgressPreference
+            $ProgressPreference = 'SilentlyContinue'
+
+            # Bootstrapping Microsoft.PowerShell.PSResourceGet.
+            Invoke-WebRequest @invokeWebRequestParameters
+
+            $ProgressPreference = $previousProgressPreference
+
+            $psResourceGetDownloaded = $true
+        }
+        catch
+        {
+            Write-Warning -Message ('{0} could not be bootstrapped. Reverting to PowerShellGet. Error: {1}' -f $psResourceGetModuleName, $_.Exception.Message)
+        }
+
+        $UsePSResourceGet = $false
+
+        if ($psResourceGetDownloaded)
+        {
+            # On Windows PowerShell the command Expand-Archive do not like .nupkg as a zip archive extension.
+            $zipFileName = ((Split-Path -Path $invokeWebRequestParameters.OutFile -Leaf) -replace 'nupkg', 'zip')
+
+            $renameItemParameters = @{
+                Path    = $invokeWebRequestParameters.OutFile
+                NewName = $zipFileName
+                Force   = $true
+            }
+
+            Rename-Item @renameItemParameters
+
+            $psResourceGetZipArchivePath = Join-Path -Path (Split-Path -Path $invokeWebRequestParameters.OutFile -Parent) -ChildPath $zipFileName
+
+            $expandArchiveParameters = @{
+                Path            = $psResourceGetZipArchivePath
+                DestinationPath = "$PSDependTarget/$psResourceGetModuleName"
+                Force           = $true
+            }
+
+            Expand-Archive @expandArchiveParameters
+
+            Remove-Item -Path $psResourceGetZipArchivePath
+
+            Import-Module -Name $expandArchiveParameters.DestinationPath -Force
+
+            # Successfully bootstrapped PSResourceGet, so let's use it.
+            $UsePSResourceGet = $true
+        }
+    }
+
+    if ($UsePSResourceGet)
+    {
+        $psResourceGetModule = Get-Module -Name $psResourceGetModuleName
+
+        $psResourceGetModuleVersion = $psResourceGetModule.Version.ToString()
+
+        if ($psResourceGetModule.PrivateData.PSData.Prerelease)
+        {
+            $psResourceGetModuleVersion += '-{0}' -f $psResourceGetModule.PrivateData.PSData.Prerelease
+        }
+
+        Write-Information -MessageData ('Using {0} v{1}.' -f $psResourceGetModuleName, $psResourceGetModuleVersion) -InformationAction 'Continue'
+
+        if ($UsePowerShellGetCompatibilityModule)
+        {
+            $savePowerShellGetParameters = @{
+                Name            = 'PowerShellGet'
+                Path            = $PSDependTarget
+                Repository      = 'PSGallery'
+                TrustRepository = $true
+            }
+
+            if ($UsePowerShellGetCompatibilityModuleVersion)
+            {
+                $savePowerShellGetParameters.Version = $UsePowerShellGetCompatibilityModuleVersion
+
+                # Check if the version is a prerelease.
+                if ($UsePowerShellGetCompatibilityModuleVersion -match '\d+\.\d+\.\d+-.*')
+                {
+                    $savePowerShellGetParameters.Prerelease = $true
+                }
+            }
+
+            Save-PSResource @savePowerShellGetParameters
+
+            Import-Module -Name "$PSDependTarget/PowerShellGet"
+        }
+    }
+}
+
+# Check if legacy PowerShellGet and PSDepend must be bootstrapped.
+if (-not ($UseModuleFast -or $UsePSResourceGet))
+{
+    if ($PSVersionTable.PSVersion.Major -le 5)
+    {
+        <#
+            Making sure the imported PackageManagement module is not from PS7 module
+            path. The VSCode PS extension is changing the $env:PSModulePath and
+            prioritize the PS7 path. This is an issue with PowerShellGet because
+            it loads an old version if available (or fail to load latest).
+        #>
+        Get-Module -ListAvailable PackageManagement |
+            Where-Object -Property 'ModuleBase' -NotMatch 'powershell.7' |
+            Select-Object -First 1 |
+            Import-Module -Force
+    }
+
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 0 -CurrentOperation 'NuGet Bootstrap'
+
+    $importModuleParameters = @{
+        Name           = 'PowerShellGet'
+        MinimumVersion = '2.0'
+        MaximumVersion = '2.8.999'
+        ErrorAction    = 'SilentlyContinue'
+        PassThru       = $true
+    }
+
+    if ($AllowOldPowerShellGetModule)
+    {
+        $importModuleParameters.Remove('MinimumVersion')
+    }
+
+    $powerShellGetModule = Import-Module @importModuleParameters
+
+    # Install the package provider if it is not available.
+    $nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable -ErrorAction 'SilentlyContinue' |
+        Select-Object -First 1
+
+    if (-not $powerShellGetModule -and -not $nuGetProvider)
+    {
+        $providerBootstrapParameters = @{
+            Name           = 'NuGet'
+            Force          = $true
+            ForceBootstrap = $true
+            ErrorAction    = 'Stop'
+            Scope          = $Scope
         }
 
         switch ($PSBoundParameters.Keys)
         {
             'Proxy'
             {
-                $InstallPSGetParam.Add('Proxy', $Proxy)
+                $providerBootstrapParameters.Add('Proxy', $Proxy)
             }
+
             'ProxyCredential'
             {
-                $InstallPSGetParam.Add('ProxyCredential', $ProxyCredential)
+                $providerBootstrapParameters.Add('ProxyCredential', $ProxyCredential)
             }
-            'GalleryCredential'
+
+            'AllowPrerelease'
             {
-                $InstallPSGetParam.Add('Credential', $GalleryCredential)
+                $providerBootstrapParameters.Add('AllowPrerelease', $AllowPrerelease)
             }
         }
 
-        Install-Module @InstallPSGetParam
-        Remove-Module PowerShellGet -force -ErrorAction SilentlyContinue
-        Import-Module PowerShellGet -Force
-        $NewLoadedVersion = (Get-Module PowerShellGet).Version.ToString()
-        Write-Information "Bootstrap: PowerShellGet version loaded is $NewLoadedVersion"
-        Write-Progress -Activity "Bootstrap:" -PercentComplete 60 -CurrentOperation "Installing newer version of PowerShellGet"
+        Write-Information -MessageData 'Bootstrap: Installing NuGet Package Provider from the web (Make sure Microsoft addresses/ranges are allowed).'
+
+        $null = Install-PackageProvider @providerBootstrapParameters
+
+        $nuGetProvider = Get-PackageProvider -Name 'NuGet' -ListAvailable | Select-Object -First 1
+
+        $nuGetProviderVersion = $nuGetProvider.Version.ToString()
+
+        Write-Information -MessageData "Bootstrap: Importing NuGet Package Provider version $nuGetProviderVersion to current session."
+
+        $Null = Import-PackageProvider -Name 'NuGet' -RequiredVersion $nuGetProviderVersion -Force
     }
 
-    # Try to import the PSDepend module from the available modules
-    try
+    if ($RegisterGallery)
     {
-        $ImportPSDependParam = @{
+        if ($RegisterGallery.ContainsKey('Name') -and -not [System.String]::IsNullOrEmpty($RegisterGallery.Name))
+        {
+            $Gallery = $RegisterGallery.Name
+        }
+        else
+        {
+            $RegisterGallery.Name = $Gallery
+        }
+
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 7 -CurrentOperation "Verifying private package repository '$Gallery'" -Completed
+
+        $previousRegisteredRepository = Get-PSRepository -Name $Gallery -ErrorAction 'SilentlyContinue'
+
+        if ($previousRegisteredRepository.SourceLocation -ne $RegisterGallery.SourceLocation)
+        {
+            if ($previousRegisteredRepository)
+            {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 9 -CurrentOperation "Re-registrering private package repository '$Gallery'" -Completed
+
+                Unregister-PSRepository -Name $Gallery
+
+                $unregisteredPreviousRepository = $true
+            }
+            else
+            {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 9 -CurrentOperation "Registering private package repository '$Gallery'" -Completed
+            }
+
+            Register-PSRepository @RegisterGallery
+        }
+    }
+
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 10 -CurrentOperation "Ensuring Gallery $Gallery is trusted"
+
+    # Fail if the given PSGallery is not registered.
+    $previousGalleryInstallationPolicy = (Get-PSRepository -Name $Gallery -ErrorAction 'Stop').Trusted
+
+    $updatedGalleryInstallationPolicy = $false
+
+    if ($previousGalleryInstallationPolicy -ne $true)
+    {
+        $updatedGalleryInstallationPolicy = $true
+
+        # Only change policy if the repository is not trusted
+        Set-PSRepository -Name $Gallery -InstallationPolicy 'Trusted' -ErrorAction 'Ignore'
+    }
+}
+
+try
+{
+    # Check if legacy PowerShellGet and PSDepend must be used.
+    if (-not ($UseModuleFast -or $UsePSResourceGet))
+    {
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 25 -CurrentOperation 'Checking PowerShellGet'
+
+        # Ensure the module is loaded and retrieve the version you have.
+        $powerShellGetVersion = (Import-Module -Name 'PowerShellGet' -PassThru -ErrorAction 'SilentlyContinue').Version
+
+        Write-Verbose -Message "Bootstrap: The PowerShellGet version is $powerShellGetVersion"
+
+        # Versions below 2.0 are considered old, unreliable & not recommended
+        if (-not $powerShellGetVersion -or ($powerShellGetVersion -lt [System.Version] '2.0' -and -not $AllowOldPowerShellGetModule))
+        {
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 40 -CurrentOperation 'Fetching newer version of PowerShellGet'
+
+            # PowerShellGet module not found, installing or saving it.
+            if ($PSDependTarget -in 'CurrentUser', 'AllUsers')
+            {
+                Write-Debug -Message "PowerShellGet module not found. Attempting to install from Gallery $Gallery."
+
+                Write-Warning -Message "Installing PowerShellGet in $PSDependTarget Scope."
+
+                $installPowerShellGetParameters = @{
+                    Name               = 'PowerShellGet'
+                    Force              = $true
+                    SkipPublisherCheck = $true
+                    AllowClobber       = $true
+                    Scope              = $Scope
+                    Repository         = $Gallery
+                    MaximumVersion     = '2.8.999'
+                }
+
+                switch ($PSBoundParameters.Keys)
+                {
+                    'Proxy'
+                    {
+                        $installPowerShellGetParameters.Add('Proxy', $Proxy)
+                    }
+
+                    'ProxyCredential'
+                    {
+                        $installPowerShellGetParameters.Add('ProxyCredential', $ProxyCredential)
+                    }
+
+                    'GalleryCredential'
+                    {
+                        $installPowerShellGetParameters.Add('Credential', $GalleryCredential)
+                    }
+                }
+
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation 'Installing newer version of PowerShellGet'
+
+                Install-Module @installPowerShellGetParameters
+            }
+            else
+            {
+                Write-Debug -Message "PowerShellGet module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
+
+                $saveModuleParameters = @{
+                    Name           = 'PowerShellGet'
+                    Repository     = $Gallery
+                    Path           = $PSDependTarget
+                    Force          = $true
+                    MaximumVersion = '2.8.999'
+                }
+
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 60 -CurrentOperation "Saving PowerShellGet from $Gallery to $Scope"
+
+                Save-Module @saveModuleParameters
+            }
+
+            Write-Debug -Message 'Removing previous versions of PowerShellGet and PackageManagement from session'
+
+            Get-Module -Name 'PowerShellGet' -All | Remove-Module -Force -ErrorAction 'SilentlyContinue'
+            Get-Module -Name 'PackageManagement' -All | Remove-Module -Force
+
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 65 -CurrentOperation 'Loading latest version of PowerShellGet'
+
+            Write-Debug -Message 'Importing latest PowerShellGet and PackageManagement versions into session'
+
+            if ($AllowOldPowerShellGetModule)
+            {
+                $powerShellGetModule = Import-Module -Name 'PowerShellGet' -Force -PassThru
+            }
+            else
+            {
+                Import-Module -Name 'PackageManagement' -MinimumVersion '1.4.8.1' -Force
+
+                $powerShellGetModule = Import-Module -Name 'PowerShellGet' -MinimumVersion '2.2.5' -Force -PassThru
+            }
+
+            $powerShellGetVersion = $powerShellGetModule.Version.ToString()
+
+            Write-Information -MessageData "Bootstrap: PowerShellGet version loaded is $powerShellGetVersion"
+        }
+
+        # Try to import the PSDepend module from the available modules.
+        $getModuleParameters = @{
+            Name          = 'PSDepend'
+            ListAvailable = $true
+        }
+
+        $psDependModule = Get-Module @getModuleParameters
+
+        if ($PSBoundParameters.ContainsKey('MinimumPSDependVersion'))
+        {
+            try
+            {
+                $psDependModule = $psDependModule | Where-Object -FilterScript { $_.Version -ge $MinimumPSDependVersion }
+            }
+            catch
+            {
+                throw ('There was a problem finding the minimum version of PSDepend. Error: {0}' -f $_)
+            }
+        }
+
+        if (-not $psDependModule)
+        {
+            Write-Debug -Message 'PSDepend module not found.'
+
+            # PSDepend module not found, installing or saving it.
+            if ($PSDependTarget -in 'CurrentUser', 'AllUsers')
+            {
+                Write-Debug -Message "Attempting to install from Gallery '$Gallery'."
+
+                Write-Warning -Message "Installing PSDepend in $PSDependTarget Scope."
+
+                $installPSDependParameters = @{
+                    Name               = 'PSDepend'
+                    Repository         = $Gallery
+                    Force              = $true
+                    Scope              = $PSDependTarget
+                    SkipPublisherCheck = $true
+                    AllowClobber       = $true
+                }
+
+                if ($MinimumPSDependVersion)
+                {
+                    $installPSDependParameters.Add('MinimumVersion', $MinimumPSDependVersion)
+                }
+
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 75 -CurrentOperation "Installing PSDepend from $Gallery"
+
+                Install-Module @installPSDependParameters
+            }
+            else
+            {
+                Write-Debug -Message "Attempting to Save from Gallery $Gallery to $PSDependTarget"
+
+                $saveModuleParameters = @{
+                    Name       = 'PSDepend'
+                    Repository = $Gallery
+                    Path       = $PSDependTarget
+                    Force      = $true
+                }
+
+                if ($MinimumPSDependVersion)
+                {
+                    $saveModuleParameters.add('MinimumVersion', $MinimumPSDependVersion)
+                }
+
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 75 -CurrentOperation "Saving PSDepend from $Gallery to $PSDependTarget"
+
+                Save-Module @saveModuleParameters
+            }
+        }
+
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 80 -CurrentOperation 'Importing PSDepend'
+
+        $importModulePSDependParameters = @{
             Name        = 'PSDepend'
             ErrorAction = 'Stop'
             Force       = $true
         }
 
-        if ($MinimumPSDependVersion)
+        if ($PSBoundParameters.ContainsKey('MinimumPSDependVersion'))
         {
-            $ImportPSDependParam.add('MinimumVersion', $MinimumPSDependVersion)
+            $importModulePSDependParameters.Add('MinimumVersion', $MinimumPSDependVersion)
         }
-        $null = Import-Module @ImportPSDependParam
-    }
-    catch
-    {
-        # PSDepend module not found, installing or saving it
-        if ($PSDependTarget -in 'CurrentUser', 'AllUsers')
+
+        # We should have successfully bootstrapped PSDepend. Fail if not available.
+        $null = Import-Module @importModulePSDependParameters
+
+        Write-Progress -Activity 'Bootstrap:' -PercentComplete 81 -CurrentOperation 'Invoke PSDepend'
+
+        if ($WithYAML)
         {
-            Write-Debug "PSDepend module not found. Attempting to install from Gallery $Gallery"
-            Write-Warning "Installing PSDepend in $PSDependTarget Scope"
-            $InstallPSDependParam = @{
-                Name               = 'PSDepend'
-                Repository         = $Gallery
-                Force              = $true
-                Scope              = $PSDependTarget
-                SkipPublisherCheck = $true
-                AllowClobber       = $true
-            }
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 82 -CurrentOperation 'Verifying PowerShell module PowerShell-Yaml'
 
-            if ($MinimumPSDependVersion)
+            if (-not (Get-Module -ListAvailable -Name 'PowerShell-Yaml'))
             {
-                $InstallPSDependParam.add('MinimumVersion', $MinimumPSDependVersion)
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 85 -CurrentOperation 'Installing PowerShell module PowerShell-Yaml'
+
+                Write-Verbose -Message "PowerShell-Yaml module not found. Attempting to Save from Gallery '$Gallery' to '$PSDependTarget'."
+
+                $SaveModuleParam = @{
+                    Name       = 'PowerShell-Yaml'
+                    Repository = $Gallery
+                    Path       = $PSDependTarget
+                    Force      = $true
+                }
+
+                Save-Module @SaveModuleParam
+            }
+            else
+            {
+                Write-Verbose -Message 'PowerShell-Yaml is already available'
             }
 
-            Write-Progress -Activity "Bootstrap:" -PercentComplete 75 -CurrentOperation "Installing PSDepend from $Gallery"
-            Install-Module @InstallPSDependParam
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 88 -CurrentOperation 'Importing PowerShell module PowerShell-Yaml'
+        }
+    }
+
+    if (Test-Path -Path $DependencyFile)
+    {
+        if ($UseModuleFast -or $UsePSResourceGet)
+        {
+            $requiredModules = Import-PowerShellDataFile -Path $DependencyFile
+
+            $requiredModules = $requiredModules.GetEnumerator() |
+                Where-Object -FilterScript { $_.Name -ne 'PSDependOptions' }
+
+            if ($UseModuleFast)
+            {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking ModuleFast'
+
+                Write-Progress -Activity 'ModuleFast:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
+
+                $modulesToSave = @(
+                    'PSDepend' # Always include PSDepend for backward compatibility.
+                )
+
+                if ($WithYAML)
+                {
+                    $modulesToSave += 'PowerShell-Yaml'
+                }
+
+                if ($UsePowerShellGetCompatibilityModule)
+                {
+                    Write-Debug -Message 'PowerShellGet compatibility module is configured to be used.'
+
+                    # This is needed to ensure that the PowerShellGet compatibility module works.
+                    $psResourceGetModuleName = 'Microsoft.PowerShell.PSResourceGet'
+
+                    if ($PSResourceGetVersion)
+                    {
+                        $modulesToSave += ('{0}:[{1}]' -f $psResourceGetModuleName, $PSResourceGetVersion)
+                    }
+                    else
+                    {
+                        $modulesToSave += $psResourceGetModuleName
+                    }
+
+                    $powerShellGetCompatibilityModuleName = 'PowerShellGet'
+
+                    if ($UsePowerShellGetCompatibilityModuleVersion)
+                    {
+                        $modulesToSave += ('{0}:[{1}]' -f $powerShellGetCompatibilityModuleName, $UsePowerShellGetCompatibilityModuleVersion)
+                    }
+                    else
+                    {
+                        $modulesToSave += $powerShellGetCompatibilityModuleName
+                    }
+                }
+
+                foreach ($requiredModule in $requiredModules)
+                {
+                    # If the RequiredModules.psd1 entry is an Hashtable then special handling is needed.
+                    if ($requiredModule.Value -is [System.Collections.Hashtable])
+                    {
+                        if (-not $requiredModule.Value.Version)
+                        {
+                            $requiredModuleVersion = 'latest'
+                        }
+                        else
+                        {
+                            $requiredModuleVersion = $requiredModule.Value.Version
+                        }
+
+                        if ($requiredModuleVersion -eq 'latest')
+                        {
+                            $moduleNameSuffix = ''
+
+                            if ($requiredModule.Value.Parameters.AllowPrerelease -eq $true)
+                            {
+                                <#
+                                    Adding '!' to the module name indicate to ModuleFast
+                                    that is should also evaluate pre-releases.
+                                #>
+                                $moduleNameSuffix = '!'
+                            }
+
+                            $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $moduleNameSuffix)
+                        }
+                        else
+                        {
+                            $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModuleVersion)
+                        }
+                    }
+                    else
+                    {
+                        if ($requiredModule.Value -eq 'latest')
+                        {
+                            $modulesToSave += $requiredModule.Name
+                        }
+                        else
+                        {
+                            # Handle different nuget version operators already present.
+                            if ($requiredModule.Value -match '[!|:|[|(|,|>|<|=]')
+                            {
+                                $modulesToSave += ('{0}{1}' -f $requiredModule.Name, $requiredModule.Value)
+                            }
+                            else
+                            {
+                                # Assuming the version is a fixed version.
+                                $modulesToSave += ('{0}:[{1}]' -f $requiredModule.Name, $requiredModule.Value)
+                            }
+                        }
+                    }
+                }
+
+                Write-Debug -Message ("Required modules to retrieve plan for:`n{0}" -f ($modulesToSave | Out-String))
+
+                $installModuleFastParameters = @{
+                    Destination          = $PSDependTarget
+                    DestinationOnly      = $true
+                    NoPSModulePathUpdate = $true
+                    NoProfileUpdate      = $true
+                    Update               = $true
+                    Confirm              = $false
+                }
+
+                $moduleFastPlan = Install-ModuleFast -Specification $modulesToSave -Plan @installModuleFastParameters
+
+                Write-Debug -Message ("Missing modules that need to be saved:`n{0}" -f ($moduleFastPlan | Out-String))
+
+                if ($moduleFastPlan)
+                {
+                    # Clear all modules in plan from the current session so they can be fetched again.
+                    $moduleFastPlan.Name | Get-Module | Remove-Module -Force
+
+                    $moduleFastPlan | Install-ModuleFast @installModuleFastParameters
+                }
+                else
+                {
+                    Write-Verbose -Message 'All required modules were already up to date'
+                }
+
+                Write-Progress -Activity 'ModuleFast:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
+            }
+
+            if ($UsePSResourceGet)
+            {
+                Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking PSResourceGet'
+
+                $modulesToSave = @(
+                    @{
+                        Name = 'PSDepend'  # Always include PSDepend for backward compatibility.
+                    }
+                )
+
+                if ($WithYAML)
+                {
+                    $modulesToSave += @{
+                        Name = 'PowerShell-Yaml'
+                    }
+                }
+
+                # Prepare hashtable that can be concatenated to the Save-PSResource parameters.
+                foreach ($requiredModule in $requiredModules)
+                {
+                    # If the RequiredModules.psd1 entry is an Hashtable then special handling is needed.
+                    if ($requiredModule.Value -is [System.Collections.Hashtable])
+                    {
+                        $saveModuleHashtable = @{
+                            Name = $requiredModule.Name
+                        }
+
+                        if ($requiredModule.Value.Version -and $requiredModule.Value.Version -ne 'latest')
+                        {
+                            $saveModuleHashtable.Version = $requiredModule.Value.Version
+                        }
+
+                        if ($requiredModule.Value.Parameters.AllowPrerelease -eq $true)
+                        {
+                            $saveModuleHashtable.Prerelease = $true
+                        }
+
+                        $modulesToSave += $saveModuleHashtable
+                    }
+                    else
+                    {
+                        if ($requiredModule.Value -eq 'latest')
+                        {
+                            $modulesToSave += @{
+                                Name = $requiredModule.Name
+                            }
+                        }
+                        else
+                        {
+                            $modulesToSave += @{
+                                Name    = $requiredModule.Name
+                                Version = $requiredModule.Value
+                            }
+                        }
+                    }
+                }
+
+                $percentagePerModule = [System.Math]::Floor(100 / $modulesToSave.Length)
+
+                $progressPercentage = 0
+
+                Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies'
+
+                foreach ($currentModule in $modulesToSave)
+                {
+                    Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies' -Status ('Saving module {0}' -f $savePSResourceParameters.Name)
+
+                    $savePSResourceParameters = @{
+                        Path            = $PSDependTarget
+                        TrustRepository = $true
+                        Confirm         = $false
+                    }
+
+                    # Concatenate the module parameters to the Save-PSResource parameters.
+                    $savePSResourceParameters += $currentModule
+
+                    # Modules that Sampler depend on that cannot be refreshed without a new session.
+                    $skipModule = @('PowerShell-Yaml')
+
+                    if ($savePSResourceParameters.Name -in $skipModule -and (Get-Module -Name $savePSResourceParameters.Name))
+                    {
+                        Write-Progress -Activity 'PSResourceGet:' -PercentComplete $progressPercentage -CurrentOperation 'Restoring Build Dependencies' -Status ('Skipping module {0}' -f $savePSResourceParameters.Name)
+
+                        Write-Information -MessageData ('Skipping the module {0} since it cannot be refresh while loaded into the session. To refresh the module open a new session and resolve dependencies again.' -f $savePSResourceParameters.Name) -InformationAction 'Continue'
+                    }
+                    else
+                    {
+                        # Clear all module from the current session so any new version fetched will be re-imported.
+                        Get-Module -Name $savePSResourceParameters.Name | Remove-Module -Force
+
+                        Save-PSResource @savePSResourceParameters -ErrorVariable 'savePSResourceError'
+
+                        if ($savePSResourceError)
+                        {
+                            Write-Warning -Message 'Save-PSResource could not save (replace) one or more dependencies. This can be due to the module is loaded into the session (and referencing assemblies). Close the current session and open a new session and try again.'
+                        }
+                    }
+
+                    $progressPercentage += $percentagePerModule
+                }
+
+                Write-Progress -Activity 'PSResourceGet:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
+            }
         }
         else
         {
-            Write-Debug "PSDepend module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
-            $SaveModuleParam = @{
-                Name       = 'PSDepend'
-                Repository = $Gallery
-                Path       = $PSDependTarget
+            Write-Progress -Activity 'Bootstrap:' -PercentComplete 90 -CurrentOperation 'Invoking PSDepend'
+
+            Write-Progress -Activity 'PSDepend:' -PercentComplete 0 -CurrentOperation 'Restoring Build Dependencies'
+
+            $psDependParameters = @{
+                Force = $true
+                Path  = $DependencyFile
             }
 
-            if ($MinimumPSDependVersion)
-            {
-                $SaveModuleParam.add('MinimumVersion', $MinimumPSDependVersion)
-            }
+            # TODO: Handle when the Dependency file is in YAML, and -WithYAML is specified.
+            Invoke-PSDepend @psDependParameters
 
-            Write-Progress -Activity "Bootstrap:" -PercentComplete 75 -CurrentOperation "Saving & Importing PSDepend from $Gallery to $Scope"
-            Save-Module @SaveModuleParam
+            Write-Progress -Activity 'PSDepend:' -PercentComplete 100 -CurrentOperation 'Dependencies restored' -Completed
         }
     }
-    finally
+    else
     {
-        Write-Progress -Activity "Bootstrap:" -PercentComplete 100 -CurrentOperation "Loading PSDepend"
-        # We should have successfully bootstrapped PSDepend. Fail if not available
-        Import-Module PSDepend -ErrorAction Stop
+        Write-Warning -Message "The dependency file '$DependencyFile' could not be found."
     }
 
-    if ($WithYAML)
-    {
-        if (-Not (Get-Module -ListAvailable -Name 'PowerShell-Yaml'))
-        {
-            Write-Verbose "PowerShell-Yaml module not found. Attempting to Save from Gallery $Gallery to $PSDependTarget"
-            $SaveModuleParam = @{
-                Name       = 'PowerShell-Yaml'
-                Repository = $Gallery
-                Path       = $PSDependTarget
-            }
-
-            Save-Module @SaveModuleParam
-            Import-Module "PowerShell-Yaml" -ErrorAction Stop
-        }
-        else
-        {
-            Write-Verbose "PowerShell-Yaml is already available"
-        }
-    }
-
-    Write-Progress -Activity "PSDepend:" -PercentComplete 0 -CurrentOperation "Restoring Build Dependencies"
-    if (Test-Path $DependencyFile)
-    {
-        $PSDependParams = @{
-            Force = $true
-            Path  = $DependencyFile
-        }
-
-        # TODO: Handle when the Dependency file is in YAML, and -WithYAML is specified
-        Invoke-PSDepend @PSDependParams
-    }
-    Write-Progress -Activity "PSDepend:" -PercentComplete 100 -CurrentOperation "Dependencies restored" -Completed
+    Write-Progress -Activity 'Bootstrap:' -PercentComplete 100 -CurrentOperation 'Bootstrap complete' -Completed
 }
 finally
 {
-    # Reverting the Installation Policy for the given gallery
-    Set-PSRepository -Name $Gallery -InstallationPolicy $Policy
-    Write-Verbose "Project Bootstrapped, returning to Invoke-Build"
+    if ($RegisterGallery)
+    {
+        Write-Verbose -Message "Removing private package repository '$Gallery'."
+        Unregister-PSRepository -Name $Gallery
+    }
+
+    if ($unregisteredPreviousRepository)
+    {
+        Write-Verbose -Message "Reverting private package repository '$Gallery' to previous location URI:s."
+
+        $registerPSRepositoryParameters = @{
+            Name               = $previousRegisteredRepository.Name
+            InstallationPolicy = $previousRegisteredRepository.InstallationPolicy
+        }
+
+        if ($previousRegisteredRepository.SourceLocation)
+        {
+            $registerPSRepositoryParameters.SourceLocation = $previousRegisteredRepository.SourceLocation
+        }
+
+        if ($previousRegisteredRepository.PublishLocation)
+        {
+            $registerPSRepositoryParameters.PublishLocation = $previousRegisteredRepository.PublishLocation
+        }
+
+        if ($previousRegisteredRepository.ScriptSourceLocation)
+        {
+            $registerPSRepositoryParameters.ScriptSourceLocation = $previousRegisteredRepository.ScriptSourceLocation
+        }
+
+        if ($previousRegisteredRepository.ScriptPublishLocation)
+        {
+            $registerPSRepositoryParameters.ScriptPublishLocation = $previousRegisteredRepository.ScriptPublishLocation
+        }
+
+        Register-PSRepository @registerPSRepositoryParameters
+    }
+
+    if ($updatedGalleryInstallationPolicy -eq $true -and $previousGalleryInstallationPolicy -ne $true)
+    {
+        # Only try to revert installation policy if the repository exist
+        if ((Get-PSRepository -Name $Gallery -ErrorAction 'SilentlyContinue'))
+        {
+            # Reverting the Installation Policy for the given gallery if it was not already trusted
+            Set-PSRepository -Name $Gallery -InstallationPolicy 'Untrusted'
+        }
+    }
+
+    Write-Verbose -Message 'Project Bootstrapped, returning to Invoke-Build.'
 }

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -1,6 +1,15 @@
 @{
-    Gallery = 'PSGallery'
-    AllowPrerelease = $false
-    WithYAML        = $true # Will also bootstrap PowerShell-Yaml to read other config files
-}
+    Gallery                                    = 'PSGallery'
+    AllowPrerelease                            = $false
+    WithYAML                                   = $true # Will also bootstrap PowerShell-Yaml to read other config files
 
+    #UseModuleFast = $true
+    #ModuleFastVersion = '0.1.2'
+    #ModuleFastBleedingEdge = $true
+
+    UsePSResourceGet                           = $true
+    #PSResourceGetVersion = '1.0.1'
+
+    UsePowerShellGetCompatibilityModule        = $true
+    UsePowerShellGetCompatibilityModuleVersion = '3.0.23-beta23'
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,19 +1,22 @@
 trigger:
   branches:
     include:
-    - main
+      - main
   paths:
     include:
-    - source/*
+      - source/*
   tags:
     include:
-    - "v*"
+      - 'v*'
     exclude:
-    - "*-*"
+      - '*-*'
 
 variables:
   buildFolderName: output
   buildArtifactName: output
+  testResultFolderName: testResults
+  sourceFolderName: source
+  defaultBranch: main
 
 stages:
   - stage: Build
@@ -55,8 +58,8 @@ stages:
       - job: Test_HQRM
         displayName: 'HQRM'
         pool:
-          vmImage: 'windows-2019'
-        timeoutInMinutes: 0
+          vmImage: 'windows-latest'
+        timeoutInMinutes: '0'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Build Artifact'
@@ -82,7 +85,7 @@ stages:
       - job: test_unit_linux
         condition: succeededOrFailed()
         displayName: 'Linux - Unit Tests'
-        timeoutInMinutes: 0
+        timeoutInMinutes: '0'
         pool:
           vmImage: 'ubuntu-latest'
         steps:
@@ -93,13 +96,6 @@ stages:
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
 
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: dscBuildVariable
-            displayName: 'Set Environment Variables'
-
           - task: PowerShell@2
             name: test
             displayName: 'Run Unit Tests'
@@ -112,21 +108,20 @@ stages:
             condition: succeededOrFailed()
             inputs:
               testResultsFormat: 'NUnit'
-              testResultsFiles: 'output/testResults/NUnit*.xml'
+              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
               testRunTitle: 'Linux - Unit'
 
-          - task: PublishCodeCoverageResults@1
-            displayName: 'Publish Code Coverage'
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish Test Artifact'
             condition: succeededOrFailed()
             inputs:
-              codeCoverageTool: 'JaCoCo'
-              summaryFileLocation: 'output/testResults/CodeCov*.xml'
-              pathToSources: '$(Build.SourcesDirectory)/output/$(dscBuildVariable.RepositoryName)'
+              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
+              artifactName: 'CodeCoverageLinux_$(System.JobAttempt)'
 
       - job: test_unit_windows_core
         condition: succeededOrFailed()
         displayName: 'Windows (PowerShell Core) - Unit Tests'
-        timeoutInMinutes: 0
+        timeoutInMinutes: '0'
         pool:
           vmImage: 'windows-latest'
         steps:
@@ -136,13 +131,6 @@ stages:
               buildType: 'current'
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
-
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: dscBuildVariable
-            displayName: 'Set Environment Variables'
 
           - task: PowerShell@2
             name: test
@@ -157,73 +145,64 @@ stages:
             condition: succeededOrFailed()
             inputs:
               testResultsFormat: 'NUnit'
-              testResultsFiles: 'output/testResults/NUnit*.xml'
+              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
               testRunTitle: 'Windows Server Core (PowerShell Core) - Unit'
 
-          - task: PublishCodeCoverageResults@1
-            displayName: 'Publish Code Coverage'
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish Test Artifact'
             condition: succeededOrFailed()
             inputs:
-              codeCoverageTool: 'JaCoCo'
-              summaryFileLocation: 'output/testResults/CodeCov*.xml'
-              pathToSources: '$(Build.SourcesDirectory)/output/$(dscBuildVariable.RepositoryName)'
+              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
+              artifactName: 'CodeCoverageWinPS7_$(System.JobAttempt)'
 
-      - job: test_integration_windows_core
-        displayName: 'Windows (PowerShell Core) - Integration Tests'
-        timeoutInMinutes: 0
-        variables:
-          # This sets environment variable $env:CI.
-          CI: true
-          # This sets environment variable $env:CONFIGURATION.
-          configuration: Integration
-        pool:
-          vmImage: 'windows-latest'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Build Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
+      # - job: test_integration_windows_core
+      #   displayName: 'Windows (PowerShell Core) - Integration Tests'
+      #   timeoutInMinutes: 0
+      #   variables:
+      #     # This sets environment variable $env:CI.
+      #     CI: true
+      #     # This sets environment variable $env:CONFIGURATION.
+      #     configuration: Integration
+      #   pool:
+      #     vmImage: 'windows-latest'
+      #   steps:
+      #     - task: DownloadPipelineArtifact@2
+      #       displayName: 'Download Build Artifact'
+      #       inputs:
+      #         buildType: 'current'
+      #         artifactName: $(buildArtifactName)
+      #         targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
 
-          - task: PowerShell@2
-            name: configureWinRM
-            displayName: 'Configure WinRM'
-            inputs:
-              targetType: 'inline'
-              script: 'winrm quickconfig -quiet'
-              pwsh: false
+      #     - task: PowerShell@2
+      #       name: configureWinRM
+      #       displayName: 'Configure WinRM'
+      #       inputs:
+      #         targetType: 'inline'
+      #         script: 'winrm quickconfig -quiet'
+      #         pwsh: false
 
-          - powershell: |
-              ./build.ps1 -Tasks test -CodeCoverageThreshold 0 -PesterScript @(
-                'tests/Integration/'
-              )
-            name: test
-            displayName: 'Run Integration Tests'
-            env:
-              azureDevOpsIntegrationApiUri: $(AzureDevOps.Integration.ApiUri)
-              azureDevOpsIntegrationPat: $(AzureDevOps.Integration.Pat)
+      #     - powershell: |
+      #         ./build.ps1 -Tasks test -CodeCoverageThreshold 0 -PesterScript @(
+      #           'tests/Integration/'
+      #         )
+      #       name: test
+      #       displayName: 'Run Integration Tests'
+      #       env:
+      #         azureDevOpsIntegrationApiUri: $(AzureDevOps.Integration.ApiUri)
+      #         azureDevOpsIntegrationPat: $(AzureDevOps.Integration.Pat)
 
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: 'output/testResults/NUnit*.xml'
-              testRunTitle: 'Windows Server Core (PowerShell Core) - Integration'
-
-          - task: PublishCodeCoverageResults@1
-            displayName: 'Publish Code Coverage'
-            condition: succeededOrFailed()
-            inputs:
-              codeCoverageTool: 'JaCoCo'
-              summaryFileLocation: 'output/testResults/CodeCov*.xml'
-              pathToSources: '$(Build.SourcesDirectory)/output/$(dscBuildVariable.RepositoryName)'
+      #     - task: PublishTestResults@2
+      #       displayName: 'Publish Test Results'
+      #       condition: succeededOrFailed()
+      #       inputs:
+      #         testResultsFormat: 'NUnit'
+      #         testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
+      #         testRunTitle: 'Windows Server Core (PowerShell Core) - Integration'
 
       - job: test_unit_windows_ps
         condition: succeededOrFailed()
         displayName: 'Windows (Windows PowerShell) - Unit Tests'
-        timeoutInMinutes: 0
+        timeoutInMinutes: '0'
         pool:
           vmImage: 'windows-latest'
         steps:
@@ -233,20 +212,13 @@ stages:
               buildType: 'current'
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
-
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: dscBuildVariable
-            displayName: 'Set Environment Variables'
 
           - task: PowerShell@2
             name: test
             displayName: 'Run Unit Tests'
             inputs:
               filePath: './build.ps1'
-              arguments: '-tasks test -CodeCoverageThreshold 0'  # See note below regarding 'CoderCoverage'
+              arguments: '-tasks test'
               pwsh: false
 
           - task: PublishTestResults@2
@@ -254,23 +226,20 @@ stages:
             condition: succeededOrFailed()
             inputs:
               testResultsFormat: 'NUnit'
-              testResultsFiles: 'output/testResults/NUnit*.xml'
+              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
               testRunTitle: 'Windows Server Core (Windows PowerShell) - Unit'
 
-          # NOTE: CodeCoverage disabled on this, specific job due to poor performance. Still runs on other jobs within build.
-          #       See: https://github.com/pester/Pester/issues/1318
-          #- task: PublishCodeCoverageResults@1
-          #  displayName: 'Publish Code Coverage'
-          #  condition: succeededOrFailed()
-          #  inputs:
-          #    codeCoverageTool: 'JaCoCo'
-          #    summaryFileLocation: 'output/testResults/CodeCov*.xml'
-          #    pathToSources: '$(Build.SourcesDirectory)/output/$(dscBuildVariable.RepositoryName)'
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish Test Artifact'
+            condition: succeededOrFailed()
+            inputs:
+              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
+              artifactName: 'CodeCoverageWinPS51_$(System.JobAttempt)'
 
       - job: test_unit_macos
         condition: succeededOrFailed()
         displayName: 'macOS - Unit Tests'
-        timeoutInMinutes: 0
+        timeoutInMinutes: '0'
         pool:
           vmImage: 'macos-latest'
         steps:
@@ -281,13 +250,6 @@ stages:
               artifactName: $(buildArtifactName)
               targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
 
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: dscBuildVariable
-            displayName: 'Set Environment Variables'
-
           - task: PowerShell@2
             name: test
             displayName: 'Run Unit Tests'
@@ -301,20 +263,83 @@ stages:
             condition: succeededOrFailed()
             inputs:
               testResultsFormat: 'NUnit'
-              testResultsFiles: 'output/testResults/NUnit*.xml'
+              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
               testRunTitle: 'MacOS - Unit'
 
-          - task: PublishCodeCoverageResults@1
-            displayName: 'Publish Code Coverage'
+          - task: PublishPipelineArtifact@1
+            displayName: 'Publish Test Artifact'
             condition: succeededOrFailed()
             inputs:
+              targetPath: '$(buildFolderName)/$(testResultFolderName)/'
+              artifactName: 'CodeCoverageMacOS_$(System.JobAttempt)'
+
+      - job: Code_Coverage
+        displayName: 'Publish Code Coverage'
+        dependsOn:
+          - test_unit_macos
+          - test_unit_linux
+          - test_unit_windows_core
+          - test_unit_windows_ps
+        pool:
+          vmImage: 'ubuntu-latest'
+        timeoutInMinutes: '0'
+        steps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Build Artifact'
+            inputs:
+              buildType: 'current'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
+
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact macOS'
+            inputs:
+              buildType: 'current'
+              artifactName: 'CodeCoverageMacOS_$(System.JobAttempt)'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverageMacOS'
+
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact Linux'
+            inputs:
+              buildType: 'current'
+              artifactName: 'CodeCoverageLinux_$(System.JobAttempt)'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverageLinux'
+
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact Windows (PS 5.1)'
+            inputs:
+              buildType: 'current'
+              artifactName: 'CodeCoverageWinPS51_$(System.JobAttempt)'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverageWinPS51'
+
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Test Artifact Windows (PS7)'
+            inputs:
+              buildType: 'current'
+              artifactName: 'CodeCoverageWinPS7_$(System.JobAttempt)'
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/CodeCoverageWinPS7'
+
+          - task: PowerShell@2
+            name: merge
+            displayName: 'Merge Code Coverage files'
+            inputs:
+              filePath: './build.ps1'
+              arguments: '-tasks merge'
+              pwsh: true
+
+          - task: PublishCodeCoverageResults@1
+            displayName: 'Publish Code Coverage to Azure DevOps'
+            inputs:
               codeCoverageTool: 'JaCoCo'
-              summaryFileLocation: 'output/testResults/CodeCov*.xml'
-              pathToSources: '$(Build.SourcesDirectory)/output/$(dscBuildVariable.RepositoryName)'
+              summaryFileLocation: '$(Build.SourcesDirectory)/$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml'
+              pathToSources: '$(Build.SourcesDirectory)/$(sourceFolderName)/'
+
+          - script: |
+              bash <(curl -s https://codecov.io/bash) -f "./$(buildFolderName)/$(testResultFolderName)/JaCoCo_coverage.xml"
+            displayName: 'Upload to Codecov.io'
 
   - stage: Deploy
     dependsOn: Test
-    # Only execute deploy stage if we're on master and previous stage succeeded
     condition: |
       and(
         succeeded(),
@@ -331,7 +356,7 @@ stages:
           vmImage: 'ubuntu-latest'
         steps:
           - task: DownloadPipelineArtifact@2
-            displayName: 'Download Build Artifact'
+            displayName: 'Download Pipeline Artifact'
             inputs:
               buildType: 'current'
               artifactName: $(buildArtifactName)
@@ -346,8 +371,8 @@ stages:
             env:
               GitHubToken: $(GitHubToken)
               GalleryApiToken: $(GalleryApiToken)
-              ReleaseBranch: main
-              MainGitBranch: main
+              ReleaseBranch: $(defaultBranch)
+              MainGitBranch: $(defaultBranch)
           - task: PowerShell@2
             name: sendChangelogPR
             displayName: 'Send Changelog PR'
@@ -357,5 +382,5 @@ stages:
               pwsh: true
             env:
               GitHubToken: $(GitHubToken)
-              ReleaseBranch: main
-              MainGitBranch: main
+              ReleaseBranch: $(defaultBranch)
+              MainGitBranch: $(defaultBranch)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,13 +3,17 @@ trigger:
     include:
     - main
   paths:
-    exclude:
-    - CHANGELOG.md
+    include:
+    - source/*
   tags:
     include:
     - "v*"
     exclude:
     - "*-*"
+
+variables:
+  buildFolderName: output
+  buildArtifactName: output
 
 stages:
   - stage: Build
@@ -17,15 +21,17 @@ stages:
       - job: Package_Module
         displayName: 'Package Module'
         pool:
-          vmImage: 'ubuntu 16.04'
+          vmImage: 'windows-latest'
         steps:
-          - task: GitVersion@5
-            name: gitVersion
-            displayName: 'Evaluate Next Version'
-            inputs:
-              runtime: 'core'
-              configFilePath: 'GitVersion.yml'
-
+          - pwsh: |
+              dotnet tool install --global GitVersion.Tool
+              $gitVersionObject = dotnet-gitversion | ConvertFrom-Json
+              $gitVersionObject.PSObject.Properties.ForEach{
+                  Write-Host -Object "Setting Task Variable '$($_.Name)' with value '$($_.Value)'."
+                  Write-Host -Object "##vso[task.setvariable variable=$($_.Name);]$($_.Value)"
+              }
+              Write-Host -Object "##vso[build.updatebuildnumber]$($gitVersionObject.FullSemVer)"
+            displayName: Calculate ModuleVersion (GitVersion)
           - task: PowerShell@2
             name: package
             displayName: 'Build & Package Module'
@@ -34,14 +40,14 @@ stages:
               arguments: '-ResolveDependency -tasks pack'
               pwsh: true
             env:
-              ModuleVersion: $(gitVersion.NuGetVersionV2)
-
-          - task: PublishBuildArtifacts@1
+              ModuleVersion: $(NuGetVersionV2)
+          - task: PublishPipelineArtifact@1
             displayName: 'Publish Build Artifact'
             inputs:
-              pathToPublish: 'output/'
-              artifactName: 'output'
-              publishLocation: 'Container'
+              targetPath: '$(buildFolderName)/'
+              artifact: $(buildArtifactName)
+              publishLocation: 'pipeline'
+              parallel: true
 
   - stage: Test
     dependsOn: Build
@@ -52,13 +58,12 @@ stages:
           vmImage: 'windows-2019'
         timeoutInMinutes: 0
         steps:
-          - task: DownloadBuildArtifacts@0
+          - task: DownloadPipelineArtifact@2
             displayName: 'Download Build Artifact'
             inputs:
               buildType: 'current'
-              downloadType: 'single'
-              artifactName: 'output'
-              downloadPath: '$(Build.SourcesDirectory)'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
           - task: PowerShell@2
             name: test
             displayName: 'Run HQRM Test'
@@ -73,20 +78,20 @@ stages:
               testResultsFormat: 'NUnit'
               testResultsFiles: 'output/testResults/NUnit*.xml'
               testRunTitle: 'HQRM'
+
       - job: test_unit_linux
         condition: succeededOrFailed()
         displayName: 'Linux - Unit Tests'
         timeoutInMinutes: 0
         pool:
-          vmImage: 'ubuntu 16.04'
+          vmImage: 'ubuntu-latest'
         steps:
-          - task: DownloadBuildArtifacts@0
+          - task: DownloadPipelineArtifact@2
             displayName: 'Download Build Artifact'
             inputs:
               buildType: 'current'
-              downloadType: 'single'
-              artifactName: 'output'
-              downloadPath: '$(Build.SourcesDirectory)'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
 
           - powershell: |
               $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
@@ -123,15 +128,14 @@ stages:
         displayName: 'Windows (PowerShell Core) - Unit Tests'
         timeoutInMinutes: 0
         pool:
-          vmImage: 'windows-2019'
+          vmImage: 'windows-latest'
         steps:
-          - task: DownloadBuildArtifacts@0
+          - task: DownloadPipelineArtifact@2
             displayName: 'Download Build Artifact'
             inputs:
               buildType: 'current'
-              downloadType: 'single'
-              artifactName: 'output'
-              downloadPath: '$(Build.SourcesDirectory)'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
 
           - powershell: |
               $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
@@ -173,15 +177,14 @@ stages:
           # This sets environment variable $env:CONFIGURATION.
           configuration: Integration
         pool:
-          vmImage: 'windows-2019'
+          vmImage: 'windows-latest'
         steps:
-          - task: DownloadBuildArtifacts@0
+          - task: DownloadPipelineArtifact@2
             displayName: 'Download Build Artifact'
             inputs:
               buildType: 'current'
-              downloadType: 'single'
-              artifactName: 'output'
-              downloadPath: '$(Build.SourcesDirectory)'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
 
           - task: PowerShell@2
             name: configureWinRM
@@ -222,15 +225,14 @@ stages:
         displayName: 'Windows (Windows PowerShell) - Unit Tests'
         timeoutInMinutes: 0
         pool:
-          vmImage: 'windows-2019'
+          vmImage: 'windows-latest'
         steps:
-          - task: DownloadBuildArtifacts@0
+          - task: DownloadPipelineArtifact@2
             displayName: 'Download Build Artifact'
             inputs:
               buildType: 'current'
-              downloadType: 'single'
-              artifactName: 'output'
-              downloadPath: '$(Build.SourcesDirectory)'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
 
           - powershell: |
               $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
@@ -272,13 +274,12 @@ stages:
         pool:
           vmImage: 'macos-latest'
         steps:
-          - task: DownloadBuildArtifacts@0
+          - task: DownloadPipelineArtifact@2
             displayName: 'Download Build Artifact'
             inputs:
               buildType: 'current'
-              downloadType: 'single'
-              artifactName: 'output'
-              downloadPath: '$(Build.SourcesDirectory)'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
 
           - powershell: |
               $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
@@ -327,15 +328,14 @@ stages:
       - job: Deploy_Module
         displayName: 'Deploy Module'
         pool:
-          vmImage: 'ubuntu 16.04'
+          vmImage: 'ubuntu-latest'
         steps:
-          - task: DownloadBuildArtifacts@0
+          - task: DownloadPipelineArtifact@2
             displayName: 'Download Build Artifact'
             inputs:
               buildType: 'current'
-              downloadType: 'single'
-              artifactName: 'output'
-              downloadPath: '$(Build.SourcesDirectory)'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildFolderName)'
           - task: PowerShell@2
             name: publishRelease
             displayName: 'Publish Release'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ stages:
           vmImage: 'windows-latest'
         steps:
           - pwsh: |
-              dotnet tool install --global GitVersion.Tool
+              dotnet tool install --global GitVersion.Tool --version 5.*
               $gitVersionObject = dotnet-gitversion | ConvertFrom-Json
               $gitVersionObject.PSObject.Properties.ForEach{
                   Write-Host -Object "Setting Task Variable '$($_.Name)' with value '$($_.Value)'."

--- a/build.ps1
+++ b/build.ps1
@@ -1,381 +1,538 @@
 <#
+    .DESCRIPTION
+        Bootstrap and build script for PowerShell module CI/CD pipeline.
 
-.DESCRIPTION
- Bootstrap and build script for PowerShell module pipeline
+    .PARAMETER Tasks
+        The task or tasks to run. The default value is '.' (runs the default task).
 
+    .PARAMETER CodeCoverageThreshold
+        The code coverage target threshold to uphold. Set to 0 to disable.
+        The default value is '' (empty string).
+
+    .PARAMETER BuildConfig
+        Not yet written.
+
+    .PARAMETER OutputDirectory
+        Specifies the folder to build the artefact into. The default value is 'output'.
+
+    .PARAMETER BuiltModuleSubdirectory
+        Subdirectory name to build the module (under $OutputDirectory). The default
+        value is '' (empty string).
+
+    .PARAMETER RequiredModulesDirectory
+        Can be a path (relative to $PSScriptRoot or absolute) to tell Resolve-Dependency
+        and PSDepend where to save the required modules. It is also possible to use
+        'CurrentUser' och 'AllUsers' to install missing dependencies. You can override
+        the value for PSDepend in the Build.psd1 build manifest. The default value is
+        'output/RequiredModules'.
+
+    .PARAMETER PesterScript
+        One or more paths that will override the Pester configuration in build
+        configuration file when running the build task Invoke_Pester_Tests.
+
+        If running Pester 5 test, use the alias PesterPath to be future-proof.
+
+    .PARAMETER PesterTag
+        Filter which tags to run when invoking Pester tests. This is used in the
+        Invoke-Pester.pester.build.ps1 tasks.
+
+    .PARAMETER PesterExcludeTag
+        Filter which tags to exclude when invoking Pester tests. This is used in
+        the Invoke-Pester.pester.build.ps1 tasks.
+
+    .PARAMETER DscTestTag
+        Filter which tags to run when invoking DSC Resource tests. This is used
+        in the DscResource.Test.build.ps1 tasks.
+
+    .PARAMETER DscTestExcludeTag
+        Filter which tags to exclude when invoking DSC Resource tests. This is
+        used in the DscResource.Test.build.ps1 tasks.
+
+    .PARAMETER ResolveDependency
+        Not yet written.
+
+    .PARAMETER BuildInfo
+        The build info object from ModuleBuilder. Defaults to an empty hashtable.
+
+    .PARAMETER AutoRestore
+        Not yet written.
+
+    .PARAMETER UseModuleFast
+        Specifies to use ModuleFast instead of PowerShellGet to resolve dependencies
+        faster.
+
+    .PARAMETER UsePSResourceGet
+        Specifies to use PSResourceGet instead of PowerShellGet to resolve dependencies
+        faster. This can also be configured in Resolve-Dependency.psd1.
+
+    .PARAMETER UsePowerShellGetCompatibilityModule
+        Specifies to use the compatibility module PowerShellGet. This parameter
+        only works then the method of downloading dependencies is PSResourceGet.
+        This can also be configured in Resolve-Dependency.psd1.
 #>
 [CmdletBinding()]
 param
 (
     [Parameter(Position = 0)]
-    [string[]]$Tasks = '.',
+    [System.String[]]
+    $Tasks = '.',
 
     [Parameter()]
-    [String]
+    [System.String]
     $CodeCoverageThreshold = '',
 
     [Parameter()]
-    [validateScript(
+    [System.String]
+    [ValidateScript(
         { Test-Path -Path $_ }
     )]
     $BuildConfig,
 
     [Parameter()]
-    # A Specific folder to build the artefact into.
+    [System.String]
     $OutputDirectory = 'output',
 
     [Parameter()]
-    # Subdirectory name to build the module (under $OutputDirectory)
+    [System.String]
     $BuiltModuleSubdirectory = '',
 
-    # Can be a path (relative to $PSScriptRoot or absolute) to tell Resolve-Dependency & PSDepend where to save the required modules,
-    # or use CurrentUser, AllUsers to target where to install missing dependencies
-    # You can override the value for PSDepend in the Build.psd1 build manifest
-    # This defaults to $OutputDirectory/modules (by default: ./output/modules)
     [Parameter()]
+    [System.String]
     $RequiredModulesDirectory = $(Join-Path 'output' 'RequiredModules'),
 
     [Parameter()]
-    [object[]]
+    # This alias is to prepare for the rename of this parameter to PesterPath when Pester 4 support is removed
+    [Alias('PesterPath')]
+    [System.Object[]]
     $PesterScript,
 
-    # Filter which tags to run when invoking Pester tests
-    # This is used in the Invoke-Pester.pester.build.ps1 tasks
     [Parameter()]
-    [string[]]
+    [System.String[]]
     $PesterTag,
 
-    # Filter which tags to exclude when invoking Pester tests
-    # This is used in the Invoke-Pester.pester.build.ps1 tasks
     [Parameter()]
-    [string[]]
+    [System.String[]]
     $PesterExcludeTag,
 
-    # Filter which tags to run when invoking DSC Resource tests
-    # This is used in the DscResource.Test.build.ps1 tasks
     [Parameter()]
-    [string[]]
+    [System.String[]]
     $DscTestTag,
 
-    # Filter which tags to exclude when invoking DSC Resource tests
-    # This is used in the DscResource.Test.build.ps1 tasks
     [Parameter()]
-    [string[]]
+    [System.String[]]
     $DscTestExcludeTag,
 
     [Parameter()]
     [Alias('bootstrap')]
-    [switch]$ResolveDependency,
+    [System.Management.Automation.SwitchParameter]
+    $ResolveDependency,
 
     [Parameter(DontShow)]
     [AllowNull()]
+    [System.Collections.Hashtable]
     $BuildInfo,
 
     [Parameter()]
-    [switch]
-    $AutoRestore
+    [System.Management.Automation.SwitchParameter]
+    $AutoRestore,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UseModuleFast,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePSResourceGet,
+
+    [Parameter()]
+    [System.Management.Automation.SwitchParameter]
+    $UsePowerShellGetCompatibilityModule
 )
 
-# The BEGIN block (at the end of this file) handles the Bootstrap of the Environment before Invoke-Build can run the tasks
-# if the -ResolveDependency (aka Bootstrap) is specified, the modules are already available, and can be auto loaded
+<#
+    The BEGIN block (at the end of this file) handles the Bootstrap of the Environment
+    before Invoke-Build can run the tasks if the parameter ResolveDependency (or
+    parameter alias Bootstrap) is specified.
+#>
 
 process
 {
-
     if ($MyInvocation.ScriptName -notLike '*Invoke-Build.ps1')
     {
-        # Only run the process block through InvokeBuild (Look at the Begin block at the bottom of this script)
+        # Only run the process block through InvokeBuild (look at the Begin block at the bottom of this script).
         return
     }
 
-    # Execute the Build Process from the .build.ps1 path.
-    Push-Location -Path $PSScriptRoot -StackName BeforeBuild
+    # Execute the Build process from the .build.ps1 path.
+    Push-Location -Path $PSScriptRoot -StackName 'BeforeBuild'
 
     try
     {
-        Write-Host -ForeGroundColor magenta "[build] Parsing defined tasks"
+        Write-Host -Object "[build] Parsing defined tasks" -ForeGroundColor Magenta
 
-        # Load Default BuildInfo if not provided as parameter
-        if (!$PSBoundParameters.ContainsKey('BuildInfo'))
+        # Load the default BuildInfo if the parameter BuildInfo is not set.
+        if (-not $PSBoundParameters.ContainsKey('BuildInfo'))
         {
             try
             {
-                if (Test-Path $BuildConfig)
+                if (Test-Path -Path $BuildConfig)
                 {
-                    $ConfigFile = (Get-Item -Path $BuildConfig)
-                    Write-Host "[build] Loading Configuration from $ConfigFile"
-                    $BuildInfo = switch -Regex ($ConfigFile.Extension)
+                    $configFile = Get-Item -Path $BuildConfig
+
+                    Write-Host -Object "[build] Loading Configuration from $configFile"
+
+                    $BuildInfo = switch -Regex ($configFile.Extension)
                     {
                         # Native Support for PSD1
                         '\.psd1'
                         {
+                            if (-not (Get-Command -Name Import-PowerShellDataFile -ErrorAction SilentlyContinue))
+                            {
+                                Import-Module -Name Microsoft.PowerShell.Utility -RequiredVersion 3.1.0.0
+                            }
+
                             Import-PowerShellDataFile -Path $BuildConfig
                         }
+
                         # Support for yaml when module PowerShell-Yaml is available
                         '\.[yaml|yml]'
                         {
-                            Import-Module -ErrorAction Stop -Name 'powershell-yaml'
-                            ConvertFrom-Yaml -Yaml (Get-Content -Raw $ConfigFile)
+                            Import-Module -Name 'powershell-yaml' -ErrorAction Stop
+
+                            ConvertFrom-Yaml -Yaml (Get-Content -Raw $configFile)
                         }
-                        # Native Support for JSON and JSONC (by Removing comments)
+
+                        # Support for JSON and JSONC (by Removing comments) when module PowerShell-Yaml is available
                         '\.[json|jsonc]'
                         {
-                            $JSONC = (Get-Content -Raw -Path $ConfigFile)
-                            $JSON = $JSONC -replace '(?m)\s*//.*?$' -replace '(?ms)/\*.*?\*/'
-                            # This should probably be converted to hashtable for splatting
-                            $JSON | ConvertFrom-Json
+                            $jsonFile = Get-Content -Raw -Path $configFile
+
+                            $jsonContent = $jsonFile -replace '(?m)\s*//.*?$' -replace '(?ms)/\*.*?\*/'
+
+                            # Yaml is superset of JSON.
+                            ConvertFrom-Yaml -Yaml $jsonContent
                         }
+
+                        # Unknown extension, return empty hashtable.
                         default
                         {
-                            Write-Error "Extension '$_' not supported. using @{}"
+                            Write-Error -Message "Extension '$_' not supported. using @{}"
+
                             @{ }
                         }
                     }
                 }
                 else
                 {
-                    Write-Host -Object "Configuration file $BuildConfig not found" -ForegroundColor Red
+                    Write-Host -Object "Configuration file '$($BuildConfig.FullName)' not found" -ForegroundColor Red
+
+                    # No config file was found, return empty hashtable.
                     $BuildInfo = @{ }
                 }
             }
             catch
             {
-                Write-Host -Object "Error loading Config $ConfigFile.`r`n Are you missing dependencies?" -ForegroundColor Yellow
-                Write-Host -Object "Make sure you run './build.ps1 -ResolveDependency -tasks noop' to restore the Required modules the first time" -ForegroundColor Yellow
+                $logMessage = "Error loading Config '$($BuildConfig.FullName)'.`r`nAre you missing dependencies?`r`nMake sure you run './build.ps1 -ResolveDependency -tasks noop' before running build to restore the required modules."
+
+                Write-Host -Object $logMessage -ForegroundColor Yellow
+
                 $BuildInfo = @{ }
-                Write-Error $_.Exception.Message
+
+                Write-Error -Message $_.Exception.Message
             }
         }
 
-        # If the Invoke-Build Task Header is specified in the Build Info, set it
+        # If the Invoke-Build Task Header is specified in the Build Info, set it.
         if ($BuildInfo.TaskHeader)
         {
-            Set-BuildHeader ([scriptblock]::Create($BuildInfo.TaskHeader))
+            Set-BuildHeader -Script ([scriptblock]::Create($BuildInfo.TaskHeader))
         }
 
-        # Import Tasks from modules via their exported aliases when defined in BUild Manifest
-        # https://github.com/nightroman/Invoke-Build/tree/master/Tasks/Import#example-2-import-from-a-module-with-tasks
-        if ($BuildInfo.containsKey('ModuleBuildTasks'))
-        {
-            foreach ($Module in $BuildInfo['ModuleBuildTasks'].Keys)
-            {
-                try
-                {
-                    Write-Host -ForegroundColor DarkGray -Verbose "Importing tasks from module $Module"
-                    $LoadedModule = Import-Module $Module -PassThru -ErrorAction Stop
-                    foreach ($TaskToExport in $BuildInfo['ModuleBuildTasks'].($Module))
-                    {
-                        $LoadedModule.ExportedAliases.GetEnumerator().Where{
-                            # using -like to support wildcard
-                            Write-Host -ForegroundColor DarkGray "`t Loading $($_.Key)..."
-                            $_.Key -like $TaskToExport
-                        }.ForEach{
-                            # Dot sourcing the Tasks via their exported aliases
-                            . (Get-Alias $_.Key)
-                        }
-                    }
-                }
-                catch
-                {
-                    Write-Host -ForegroundColor Red -Object "Could not load tasks for module $Module."
-                    Write-Error $_
-                }
-            }
-        }
-
-        # Loading Build Tasks defined in the .build/ folder (will override the ones imported above if same task name)
-        Get-ChildItem -Path ".build/" -Recurse -Include *.ps1 -ErrorAction Ignore | ForEach-Object {
-            "Importing file $($_.BaseName)" | Write-Verbose
-            . $_.FullName
-        }
-
-        # Synopsis: Empty task, useful to test the bootstrap process
-        task noop { }
-
-        # Define default task sequence ("."), can be overridden in the $BuildInfo
-        task . {
-            Write-Build Yellow "No sequence currently defined for the default task"
-        }
-
-        # Load Invoke-Build task sequences/workflows from $BuildInfo
-        Write-Host -ForegroundColor DarkGray "Adding Workflow from configuration:"
-        foreach ($Workflow in $BuildInfo.BuildWorkflow.keys)
-        {
-            Write-Verbose "Creating Build Workflow '$Workflow' with tasks $($BuildInfo.BuildWorkflow.($Workflow) -join ', ')"
-            $WorkflowItem = $BuildInfo.BuildWorkflow.($Workflow)
-            if ($WorkflowItem.Trim() -match '^\{(?<sb>[\w\W]*)\}$')
-            {
-                $WorkflowItem = [ScriptBlock]::Create($Matches['sb'])
-            }
-            Write-Host -ForegroundColor DarkGray "  +-> $Workflow"
-            task $Workflow $WorkflowItem
-        }
-
-        Write-Host -ForeGroundColor magenta "[build] Executing requested workflow: $($Tasks -join ', ')"
-
-    }
-    finally
-    {
-        Pop-Location -StackName BeforeBuild
-    }
-}
-
-Begin
-{
-    # Find build config if not specified
-    if (-not $BuildConfig) {
-        $config = Get-ChildItem -Path "$PSScriptRoot\*" -Include 'build.y*ml', 'build.psd1', 'build.json*' -ErrorAction:Ignore
-        if (-not $config -or ($config -is [array] -and $config.Length -le 0)) {
-            throw "No build configuration found. Specify path via -BuildConfig"
-        }
-        elseif ($config -is [array]) {
-            if ($config.Length -gt 1) {
-                throw "More than one build configuration found. Specify which one to use via -BuildConfig"
-            }
-            $BuildConfig = $config[0]
-        }
-        else {
-            $BuildConfig = $config
-        }
-    }
-    # Bootstrapping the environment before using Invoke-Build as task runner
-
-    if ($MyInvocation.ScriptName -notLike '*Invoke-Build.ps1')
-    {
-        Write-Host -foregroundColor Green "[pre-build] Starting Build Init"
-        Push-Location $PSScriptRoot -StackName BuildModule
-    }
-
-    if ($RequiredModulesDirectory -in @('CurrentUser', 'AllUsers'))
-    {
-        # Installing modules instead of saving them
-        Write-Host -foregroundColor Green "[pre-build] Required Modules will be installed for $RequiredModulesDirectory, not saved."
-        # Tell Resolve-Dependency to use provided scope as the -PSDependTarget if not overridden in Build.psd1
-        $PSDependTarget = $RequiredModulesDirectory
-    }
-    else
-    {
-        if (-Not (Split-Path -IsAbsolute -Path $OutputDirectory))
-        {
-            $OutputDirectory = Join-Path -Path $PSScriptRoot -ChildPath $OutputDirectory
-        }
-
-        # Resolving the absolute path to save the required modules to
-        if (-Not (Split-Path -IsAbsolute -Path $RequiredModulesDirectory))
-        {
-            $RequiredModulesDirectory = Join-Path -Path $PSScriptRoot -ChildPath $RequiredModulesDirectory
-        }
-
-        # Create the output/modules folder if not exists, or resolve the Absolute path otherwise
-        if (Resolve-Path $RequiredModulesDirectory -ErrorAction SilentlyContinue)
-        {
-            Write-Debug "[pre-build] Required Modules path already exist at $RequiredModulesDirectory"
-            $RequiredModulesPath = Convert-Path $RequiredModulesDirectory
-        }
-        else
-        {
-            Write-Host -foregroundColor Green "[pre-build] Creating required modules directory $RequiredModulesDirectory."
-            $RequiredModulesPath = (New-Item -ItemType Directory -Force -Path $RequiredModulesDirectory).FullName
-        }
-
-        # Prepending $RequiredModulesPath folder to PSModulePath to resolve from this folder FIRST
-        if ($RequiredModulesDirectory -notIn @('CurrentUser', 'AllUsers') -and
-            (($Env:PSModulePath -split [io.path]::PathSeparator) -notContains $RequiredModulesDirectory))
-        {
-            Write-Host -foregroundColor Green "[pre-build] Prepending '$RequiredModulesDirectory' folder to PSModulePath"
-            $Env:PSModulePath = $RequiredModulesDirectory + [io.path]::PathSeparator + $Env:PSModulePath
-        }
-
-        # Checking if the user should -ResolveDependency
-        if ((!(Get-Module -ListAvailable powershell-yaml) -or !(Get-Module -ListAvailable InvokeBuild) -or !(Get-Module -ListAvailable PSDepend)) -and !$ResolveDependency)
-        {
-            if ($AutoRestore -or !$PSBoundParameters.ContainsKey('Tasks') -or $Tasks -contains 'build')
-            {
-                Write-Host -ForegroundColor Yellow "[pre-build] Dependency missing, running './build.ps1 -ResolveDependency -Tasks noop' for you `r`n"
-                $ResolveDependency = $true
-            }
-            else
-            {
-                Write-Warning "Some required Modules are missing, make sure you first run with the '-ResolveDependency' parameter."
-                Write-Warning "Running 'build.ps1 -ResolveDependency -Tasks noop' will pull required modules without running the build task."
-            }
-        }
-
+        <#
+            Add BuildModuleOutput to PSModule Path environment variable.
+            Moved here (not in begin block) because build file can contains BuiltSubModuleDirectory value.
+        #>
         if ($BuiltModuleSubdirectory)
         {
-            if (-Not (Split-Path -IsAbsolute $BuiltModuleSubdirectory))
+            if (-not (Split-Path -IsAbsolute -Path $BuiltModuleSubdirectory))
             {
-                $BuildModuleOutput = Join-Path $OutputDirectory $BuiltModuleSubdirectory
+                $BuildModuleOutput = Join-Path -Path $OutputDirectory -ChildPath $BuiltModuleSubdirectory
             }
             else
             {
                 $BuildModuleOutput = $BuiltModuleSubdirectory
             }
+        } # test if BuiltModuleSubDirectory set in build config file
+        elseif ($BuildInfo.ContainsKey('BuiltModuleSubDirectory'))
+        {
+            $BuildModuleOutput = Join-Path -Path $OutputDirectory -ChildPath $BuildInfo['BuiltModuleSubdirectory']
         }
         else
         {
             $BuildModuleOutput = $OutputDirectory
         }
 
-        # Prepending $BuildModuleOutput folder to PSModulePath to resolve built module from this folder
-        if (($Env:PSModulePath -split [io.path]::PathSeparator) -notContains $BuildModuleOutput)
+        # Pre-pending $BuildModuleOutput folder to PSModulePath to resolve built module from this folder.
+        if ($powerShellModulePaths -notcontains $BuildModuleOutput)
         {
-            Write-Host -foregroundColor Green "[pre-build] Prepending '$BuildModuleOutput' folder to PSModulePath"
-            $Env:PSModulePath = $BuildModuleOutput + [io.path]::PathSeparator + $Env:PSModulePath
+            Write-Host -Object "[build] Pre-pending '$BuildModuleOutput' folder to PSModulePath" -ForegroundColor Green
+
+            $env:PSModulePath = $BuildModuleOutput + [System.IO.Path]::PathSeparator + $env:PSModulePath
         }
 
-        # Tell Resolve-Dependency to use $RequiredModulesPath as -PSDependTarget if not overridden in Build.psd1
-        $PSDependTarget = $RequiredModulesPath
-    }
-
-    if ($ResolveDependency)
-    {
-        Write-Host -Object "[pre-build] Resolving dependencies." -foregroundColor Green
-        $ResolveDependencyParams = @{ }
-
-        # If BuildConfig is a Yaml file, bootstrap powershell-yaml via ResolveDependency
-        if ($BuildConfig -match '\.[yaml|yml]$')
+        <#
+            Import Tasks from modules via their exported aliases when defined in Build Manifest.
+            https://github.com/nightroman/Invoke-Build/tree/master/Tasks/Import#example-2-import-from-a-module-with-tasks
+        #>
+        if ($BuildInfo.ContainsKey('ModuleBuildTasks'))
         {
-            $ResolveDependencyParams.add('WithYaml', $True)
-        }
-
-        $ResolveDependencyAvailableParams = (Get-Command -Name '.\Resolve-Dependency.ps1').parameters.keys
-        foreach ($CmdParameter in $ResolveDependencyAvailableParams)
-        {
-
-            # The parameter has been explicitly used for calling the .build.ps1
-            if ($MyInvocation.BoundParameters.ContainsKey($CmdParameter))
+            foreach ($module in $BuildInfo['ModuleBuildTasks'].Keys)
             {
-                $ParamValue = $MyInvocation.BoundParameters.ContainsKey($CmdParameter)
-                Write-Debug " adding  $CmdParameter :: $ParamValue [from user-provided parameters to Build.ps1]"
-                $ResolveDependencyParams.Add($CmdParameter, $ParamValue)
-            }
-            # Use defaults parameter value from Build.ps1, if any
-            else
-            {
-                if ($ParamValue = Get-Variable -Name $CmdParameter -ValueOnly -ErrorAction Ignore)
+                try
                 {
-                    Write-Debug " adding  $CmdParameter :: $ParamValue [from default Build.ps1 variable]"
-                    $ResolveDependencyParams.add($CmdParameter, $ParamValue)
+                    Write-Host -Object "Importing tasks from module $module" -ForegroundColor DarkGray
+
+                    $loadedModule = Import-Module -Name $module -PassThru -ErrorAction Stop
+
+                    foreach ($TaskToExport in $BuildInfo['ModuleBuildTasks'].($module))
+                    {
+                        $loadedModule.ExportedAliases.GetEnumerator().Where{
+                            Write-Host -Object "`t Loading $($_.Key)..." -ForegroundColor DarkGray
+
+                            # Using -like to support wildcard.
+                            $_.Key -like $TaskToExport
+                        }.ForEach{
+                            # Dot-sourcing the Tasks via their exported aliases.
+                            . (Get-Alias $_.Key)
+                        }
+                    }
+                }
+                catch
+                {
+                    Write-Host -Object "Could not load tasks for module $module." -ForegroundColor Red
+
+                    Write-Error -Message $_
                 }
             }
         }
 
-        Write-Host -foregroundColor Green "[pre-build] Starting bootstrap process."
-        .\Resolve-Dependency.ps1 @ResolveDependencyParams
+        # Loading Build Tasks defined in the .build/ folder (will override the ones imported above if same task name).
+        Get-ChildItem -Path '.build/' -Recurse -Include '*.ps1' -ErrorAction Ignore |
+            ForEach-Object {
+                "Importing file $($_.BaseName)" | Write-Verbose
+
+                . $_.FullName
+            }
+
+        # Synopsis: Empty task, useful to test the bootstrap process.
+        task noop { }
+
+        # Define default task sequence ("."), can be overridden in the $BuildInfo.
+        task . {
+            Write-Build -Object 'No sequence currently defined for the default task' -ForegroundColor Yellow
+        }
+
+        Write-Host -Object 'Adding Workflow from configuration:' -ForegroundColor DarkGray
+
+        # Load Invoke-Build task sequences/workflows from $BuildInfo.
+        foreach ($workflow in $BuildInfo.BuildWorkflow.keys)
+        {
+            Write-Verbose -Message "Creating Build Workflow '$Workflow' with tasks $($BuildInfo.BuildWorkflow.($Workflow) -join ', ')."
+
+            $workflowItem = $BuildInfo.BuildWorkflow.($workflow)
+
+            if ($workflowItem.Trim() -match '^\{(?<sb>[\w\W]*)\}$')
+            {
+                $workflowItem = [ScriptBlock]::Create($Matches['sb'])
+            }
+
+            Write-Host -Object "  +-> $workflow" -ForegroundColor DarkGray
+
+            task $workflow $workflowItem
+        }
+
+        Write-Host -Object "[build] Executing requested workflow: $($Tasks -join ', ')" -ForeGroundColor Magenta
+
+    }
+    finally
+    {
+        Pop-Location -StackName 'BeforeBuild'
+    }
+}
+
+begin
+{
+    # Find build config if not specified.
+    if (-not $BuildConfig)
+    {
+        $config = Get-ChildItem -Path "$PSScriptRoot\*" -Include 'build.y*ml', 'build.psd1', 'build.json*' -ErrorAction Ignore
+
+        if (-not $config -or ($config -is [System.Array] -and $config.Length -le 0))
+        {
+            throw 'No build configuration found. Specify path via parameter BuildConfig.'
+        }
+        elseif ($config -is [System.Array])
+        {
+            if ($config.Length -gt 1)
+            {
+                throw 'More than one build configuration found. Specify which path to use via parameter BuildConfig.'
+            }
+
+            $BuildConfig = $config[0]
+        }
+        else
+        {
+            $BuildConfig = $config
+        }
     }
 
-    if ($MyInvocation.ScriptName -notLike '*Invoke-Build.ps1')
+    # Bootstrapping the environment before using Invoke-Build as task runner
+
+    if ($MyInvocation.ScriptName -notlike '*Invoke-Build.ps1')
     {
-        Write-Verbose "Bootstrap completed. Handing back to InvokeBuild."
+        Write-Host -Object "[pre-build] Starting Build Init" -ForegroundColor Green
+
+        Push-Location $PSScriptRoot -StackName 'BuildModule'
+    }
+
+    if ($RequiredModulesDirectory -in @('CurrentUser', 'AllUsers'))
+    {
+        # Installing modules instead of saving them.
+        Write-Host -Object "[pre-build] Required Modules will be installed to the PowerShell module path that is used for $RequiredModulesDirectory." -ForegroundColor Green
+
+        <#
+            The variable $PSDependTarget will be used below when building the splatting
+            variable before calling Resolve-Dependency.ps1, unless overridden in the
+            file Resolve-Dependency.psd1.
+        #>
+        $PSDependTarget = $RequiredModulesDirectory
+    }
+    else
+    {
+        if (-not (Split-Path -IsAbsolute -Path $OutputDirectory))
+        {
+            $OutputDirectory = Join-Path -Path $PSScriptRoot -ChildPath $OutputDirectory
+        }
+
+        # Resolving the absolute path to save the required modules to.
+        if (-not (Split-Path -IsAbsolute -Path $RequiredModulesDirectory))
+        {
+            $RequiredModulesDirectory = Join-Path -Path $PSScriptRoot -ChildPath $RequiredModulesDirectory
+        }
+
+        # Create the output/modules folder if not exists, or resolve the Absolute path otherwise.
+        if (Resolve-Path -Path $RequiredModulesDirectory -ErrorAction SilentlyContinue)
+        {
+            Write-Debug -Message "[pre-build] Required Modules path already exist at $RequiredModulesDirectory"
+
+            $requiredModulesPath = Convert-Path -Path $RequiredModulesDirectory
+        }
+        else
+        {
+            Write-Host -Object "[pre-build] Creating required modules directory $RequiredModulesDirectory." -ForegroundColor Green
+
+            $requiredModulesPath = (New-Item -ItemType Directory -Force -Path $RequiredModulesDirectory).FullName
+        }
+
+        $powerShellModulePaths = $env:PSModulePath -split [System.IO.Path]::PathSeparator
+
+        # Pre-pending $requiredModulesPath folder to PSModulePath to resolve from this folder FIRST.
+        if ($RequiredModulesDirectory -notin @('CurrentUser', 'AllUsers') -and
+            ($powerShellModulePaths -notcontains $RequiredModulesDirectory))
+        {
+            Write-Host -Object "[pre-build] Pre-pending '$RequiredModulesDirectory' folder to PSModulePath" -ForegroundColor Green
+
+            $env:PSModulePath = $RequiredModulesDirectory + [System.IO.Path]::PathSeparator + $env:PSModulePath
+        }
+
+        $powerShellYamlModule = Get-Module -Name 'powershell-yaml' -ListAvailable
+        $invokeBuildModule = Get-Module -Name 'InvokeBuild' -ListAvailable
+        $psDependModule = Get-Module -Name 'PSDepend' -ListAvailable
+
+        # Checking if the user should -ResolveDependency.
+        if (-not ($powerShellYamlModule -and $invokeBuildModule -and $psDependModule) -and -not $ResolveDependency)
+        {
+            if ($AutoRestore -or -not $PSBoundParameters.ContainsKey('Tasks') -or $Tasks -contains 'build')
+            {
+                Write-Host -Object "[pre-build] Dependency missing, running './build.ps1 -ResolveDependency -Tasks noop' for you `r`n" -ForegroundColor Yellow
+
+                $ResolveDependency = $true
+            }
+            else
+            {
+                Write-Warning -Message "Some required Modules are missing, make sure you first run with the '-ResolveDependency' parameter. Running 'build.ps1 -ResolveDependency -Tasks noop' will pull required modules without running the build task."
+            }
+        }
+
+        <#
+            The variable $PSDependTarget will be used below when building the splatting
+            variable before calling Resolve-Dependency.ps1, unless overridden in the
+            file Resolve-Dependency.psd1.
+        #>
+        $PSDependTarget = $requiredModulesPath
+    }
+
+    if ($ResolveDependency)
+    {
+        Write-Host -Object "[pre-build] Resolving dependencies using preferred method." -ForegroundColor Green
+
+        $resolveDependencyParams = @{ }
+
+        # If BuildConfig is a Yaml file, bootstrap powershell-yaml via ResolveDependency.
+        if ($BuildConfig -match '\.[yaml|yml]$')
+        {
+            $resolveDependencyParams.Add('WithYaml', $true)
+        }
+
+        $resolveDependencyAvailableParams = (Get-Command -Name '.\Resolve-Dependency.ps1').Parameters.Keys
+
+        foreach ($cmdParameter in $resolveDependencyAvailableParams)
+        {
+            # The parameter has been explicitly used for calling the .build.ps1
+            if ($MyInvocation.BoundParameters.ContainsKey($cmdParameter))
+            {
+                $paramValue = $MyInvocation.BoundParameters.Item($cmdParameter)
+
+                Write-Debug " adding  $cmdParameter :: $paramValue [from user-provided parameters to Build.ps1]"
+
+                $resolveDependencyParams.Add($cmdParameter, $paramValue)
+            }
+            # Use defaults parameter value from Build.ps1, if any
+            else
+            {
+                $paramValue = Get-Variable -Name $cmdParameter -ValueOnly -ErrorAction Ignore
+
+                if ($paramValue)
+                {
+                    Write-Debug " adding  $cmdParameter :: $paramValue [from default Build.ps1 variable]"
+
+                    $resolveDependencyParams.Add($cmdParameter, $paramValue)
+                }
+            }
+        }
+
+        Write-Host -Object "[pre-build] Starting bootstrap process." -ForegroundColor Green
+
+        .\Resolve-Dependency.ps1 @resolveDependencyParams
+    }
+
+    if ($MyInvocation.ScriptName -notlike '*Invoke-Build.ps1')
+    {
+        Write-Verbose -Message "Bootstrap completed. Handing back to InvokeBuild."
+
         if ($PSBoundParameters.ContainsKey('ResolveDependency'))
         {
-            Write-Verbose "Dependency already resolved. Removing task"
+            Write-Verbose -Message "Dependency already resolved. Removing task."
+
             $null = $PSBoundParameters.Remove('ResolveDependency')
         }
-        Write-Host -foregroundColor Green "[build] Starting build with InvokeBuild."
+
+        Write-Host -Object "[build] Starting build with InvokeBuild." -ForegroundColor Green
+
         Invoke-Build @PSBoundParameters -Task $Tasks -File $MyInvocation.MyCommand.Path
-        Pop-Location -StackName BuildModule
+
+        Pop-Location -StackName 'BuildModule'
+
         return
     }
 }

--- a/build.yaml
+++ b/build.yaml
@@ -2,19 +2,42 @@
 ####################################################
 #          ModuleBuilder Configuration             #
 ####################################################
+
 CopyPaths:
   - en-US
   - Modules
-Encoding: UTF8
-VersionedOutputDirectory: true
-
 # '.psm1' Prefix and Suffixes
 Prefix: prefix.ps1
 #Suffix: suffix.ps1
+Encoding: UTF8
+VersionedOutputDirectory: true
+BuiltModuleSubdirectory: builtModule
+
+ModuleBuildTasks:
+  Sampler:
+    - '*.build.Sampler.ib.tasks'
+  Sampler.GitHubTasks:
+    - '*.ib.tasks'
+  DscResource.DocGenerator:
+    - 'Task.*'
+  DscResource.Test:
+    - 'Task.*'
+
+TaskHeader: |
+  param($Path)
+  ""
+  "=" * 79
+  Write-Build Cyan "`t`t`t$($Task.Name.replace("_"," ").ToUpper())"
+  Write-Build DarkGray  "$(Get-BuildSynopsis $Task)"
+  "-" * 79
+  Write-Build DarkGray "  $Path"
+  Write-Build DarkGray "  $($Task.InvocationInfo.ScriptName):$($Task.InvocationInfo.ScriptLineNumber)"
+  ""
 
 ####################################################
 #     Dependent Modules Configuration (Sampler)    #
 ####################################################
+
 NestedModule:
   DscResource.Common:
     CopyOnly: true
@@ -25,6 +48,7 @@ NestedModule:
 ####################################################
 #            Pipeline Configuration                #
 ####################################################
+
 BuildWorkflow:
   '.':
     - build
@@ -35,19 +59,30 @@ BuildWorkflow:
     - Build_Module_ModuleBuilder
     - Build_NestedModules_ModuleBuilder
     - Create_changelog_release_output
+
+  docs:
     - Generate_Conceptual_Help
     - Generate_Wiki_Content
+    - Generate_Wiki_Sidebar
+    - Clean_Markdown_Metadata
+    - Package_Wiki_Content
 
   pack:
     - build
+    - docs
     - package_module_nupkg
 
   hqrmtest:
     - DscResource_Tests_Stop_On_Fail
+    #- Invoke_HQRM_Tests_Stop_On_Fail #Pester 5
 
   test:
     - Pester_Tests_Stop_On_Fail
+    - Convert_Pester_Coverage
     - Pester_if_Code_Coverage_Under_Threshold
+
+  merge:
+    - Merge_CodeCoverage_Files
 
   publish:
     - Publish_release_to_GitHub
@@ -71,31 +106,35 @@ Pester:
   CodeCoverageOutputFile: CodeCoverage.JaCoCo.xml
   CodeCoverageOutputFileEncoding: ascii
 
+####################################################
+#           Code Coverage Configuration            #
+####################################################
+
+CodeCoverage:
+  # Filename of the file that will be outputted by the task Merge_CodeCoverage_Files.
+  CodeCoverageMergedOutputFile: JaCoCo_coverage.xml
+  # File pattern used to search for files under the ./output/testResults folder
+  # by task Merge_CodeCoverage_Files.
+  CodeCoverageFilePattern: Codecov*.xml
+
+####################################################
+#      Pester Configuration (DscResource.Test)     #
+####################################################
+
 DscTest:
   ExcludeTag:
-    - "Common Tests - New Error-Level Script Analyzer Rules"
+    - 'Common Tests - New Error-Level Script Analyzer Rules'
+    - 'Common Tests - PS Script Analyzer on Resource Files' #Temp to pass build and resource is fixed
   Tag:
   ExcludeSourceFile:
     - output
   ExcludeModuleFile:
+    - Modules/DscResource.Common
   MainGitBranch: main
 
-ModuleBuildTasks:
-  Sampler:
-    - '*.build.Sampler.ib.tasks'
-  DscResource.DocGenerator:
-    - 'Task.*'
-
-TaskHeader: |
-  param($Path)
-  ""
-  "=" * 79
-  Write-Build Cyan "`t`t`t$($Task.Name.replace("_"," ").ToUpper())"
-  Write-Build DarkGray  "$(Get-BuildSynopsis $Task)"
-  "-" * 79
-  Write-Build DarkGray "  $Path"
-  Write-Build DarkGray "  $($Task.InvocationInfo.ScriptName):$($Task.InvocationInfo.ScriptLineNumber)"
-  ""
+####################################################
+#               GitHub Configuration               #
+####################################################
 
 GitHubConfig:
   GitHubFilesToAdd:
@@ -107,6 +146,7 @@ GitHubConfig:
 ####################################################
 #      DscResource.DocGenerator Configuration      #
 ####################################################
+
 DscResource.DocGenerator:
   Generate_Conceptual_Help:
     MarkdownCodeRegularExpression:
@@ -116,3 +156,15 @@ DscResource.DocGenerator:
       - '_(.+?)_' # Match Italic (underscore)
       - '\*\*(.+?)\*\*' # Match bold
       - '\*(.+?)\*' # Match Italic (asterisk)
+  Generate_Markdown_For_DSC_Resources:
+    MofResourceMetadata:
+      Type: MofResource
+      Category: Resources
+    ClassResourceMetadata:
+      Type: ClassResource
+      Category: Resources
+    CompositeResourceMetadata:
+      Type: CompositeResource
+      Category: Resources
+  Generate_Wiki_Sidebar:
+    AlwaysOverwrite: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,38 @@
+codecov:
+  require_ci_to_pass: no
+  # main should be the baseline for reporting
+  branch: main
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  show_carryforward_flags: true
+
+coverage:
+  range: 50..80
+  round: down
+  precision: 0
+
+  status:
+    project:
+      default:
+        # Set the overall project code coverage requirement to 70%
+        target: 70
+        flags:
+          - unit
+    patch:
+      default:
+        # Set the pull request requirement to not regress overall coverage by more than 5%
+        # and let codecov.io set the goal for the code changed in the patch.
+        target: auto
+        threshold: 5
+        flags:
+          - unit
+flags:
+  unit:
+    paths:
+      - source/
+    carryforward: true
+
+fixes:
+  - '^\d+\.\d+\.\d+::source'  # move path "X.Y.Z" => "source"

--- a/source/AzureDevOpsDsc.psd1
+++ b/source/AzureDevOpsDsc.psd1
@@ -1,51 +1,51 @@
 @{
-    RootModule = 'AzureDevOpsDsc.psm1'
+    RootModule           = 'AzureDevOpsDsc.psm1'
 
     # Version number of this module.
-    moduleVersion      = '0.0.0'
+    moduleVersion        = '0.0.0'
 
     # ID used to uniquely identify this module
-    GUID               = '3f8bbada-0fa9-4d80-b3d8-f019c3c60230'
+    GUID                 = '3f8bbada-0fa9-4d80-b3d8-f019c3c60230'
 
     # Author of this module
-    Author             = 'DSC Community'
+    Author               = 'DSC Community'
 
     # Company or vendor of this module
-    CompanyName        = 'DSC Community'
+    CompanyName          = 'DSC Community'
 
     # Copyright statement for this module
-    Copyright          = 'Copyright the DSC Community contributors. All rights reserved.'
+    Copyright            = 'Copyright the DSC Community contributors. All rights reserved.'
 
     # Description of the functionality provided by this module
-    Description        = 'Module with DSC Resources for deployment and configuration of Azure DevOps Server/Services.'
+    Description          = 'Module with DSC Resources for deployment and configuration of Azure DevOps Server/Services.'
 
     # Minimum version of the Windows PowerShell engine required by this module
-    PowerShellVersion  = '5.0'
+    PowerShellVersion    = '5.0'
 
     # Minimum version of the common language runtime (CLR) required by this module
-    CLRVersion         = '4.0'
+    CLRVersion           = '4.0'
 
     # Functions to export from this module
-    FunctionsToExport  = @()
+    FunctionsToExport    = @()
 
     # Cmdlets to export from this module
-    CmdletsToExport    = @()
+    CmdletsToExport      = @()
 
     # Variables to export from this module
-    VariablesToExport  = @()
+    VariablesToExport    = @()
 
     # Aliases to export from this module
-    AliasesToExport    = @()
+    AliasesToExport      = @()
 
     # Import all the 'DSCClassResource', modules as part of this module
-    NestedModules = @()
+    NestedModules        = @()
 
-    DscResourcesToExport = @('AzDevOpsProject')
+    DscResourcesToExport = @()
 
-    RequiredAssemblies = @()
+    RequiredAssemblies   = @()
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
-    PrivateData        = @{
+    PrivateData          = @{
 
         PSData = @{
             # Set to a prerelease string value if the release should be a prerelease.

--- a/source/AzureDevOpsDsc.psm1
+++ b/source/AzureDevOpsDsc.psm1
@@ -1,2 +1,0 @@
-
-# Note: This content will get replaced as part of the module build. Do not add to this file.

--- a/source/prefix.ps1
+++ b/source/prefix.ps1
@@ -1,4 +1,6 @@
 
+$script:dscResourceCommonModulePath = Join-Path -Path $PSScriptRoot -ChildPath 'Modules\DscResource.Common'
+Import-Module -Name $script:dscResourceCommonModulePath
 
 # Import nested, 'AzureDevOpsDsc.Common' module
 $script:azureDevOpsDscCommonModulePath = Join-Path -Path $PSScriptRoot -ChildPath 'Modules\AzureDevOpsDsc.Common'

--- a/tests/Integration/DSCClassResources/AzDevOpsProject.config.ps1
+++ b/tests/Integration/DSCClassResources/AzDevOpsProject.config.ps1
@@ -70,7 +70,7 @@ Configuration AzDevOpsProject_EnsureGitProjectAbsent1_Config
             ProjectName         = 'TestGitProjectName'
             #ProjectDescription  = 'TestGitProjectDescription'
 
-            #SourceControlType   = 'Git'
+            SourceControlType   = 'Git'
 
             Ensure              = 'Absent'
         }

--- a/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceFunctionName.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceFunctionName.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceId.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceId.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceIdPropertyName.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceIdPropertyName.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceKey.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceKey.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceKeyPropertyName.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceKeyPropertyName.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceName.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsApiDscResourceBase/GetResourceName.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsDscResourceBase/AzDevOpsDscResourceBase.Initialization.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsDscResourceBase/AzDevOpsDscResourceBase.Initialization.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function 'Classes'
 . $PSScriptRoot\..\Classes.TestInitialization.ps1

--- a/tests/Unit/Classes/AzDevOpsDscResourceBase/GetDscCurrentStateObject.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsDscResourceBase/GetDscCurrentStateObject.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsDscResourceBase/GetDscCurrentStateObjectGetParameters.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsDscResourceBase/GetDscCurrentStateObjectGetParameters.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsDscResourceBase/GetDscCurrentStateResourceObject.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsDscResourceBase/GetDscCurrentStateResourceObject.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsDscResourceBase/GetPostSetWaitTimeSeconds.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsDscResourceBase/GetPostSetWaitTimeSeconds.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsDscResourceBase/Set.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsDscResourceBase/Set.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsDscResourceBase/SetToDesiredState.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsDscResourceBase/SetToDesiredState.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsDscResourceBase/Test.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsDscResourceBase/Test.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/AzDevOpsDscResourceBase/TestDesiredState.Tests.ps1
+++ b/tests/Unit/Classes/AzDevOpsDscResourceBase/TestDesiredState.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/DscResourceBase/GetDscResourceKey.Tests.ps1
+++ b/tests/Unit/Classes/DscResourceBase/GetDscResourceKey.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/DscResourceBase/GetDscResourceKeyPropertyName.Tests.ps1
+++ b/tests/Unit/Classes/DscResourceBase/GetDscResourceKeyPropertyName.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/DscResourceBase/GetDscResourcePropertyNames.Tests.ps1
+++ b/tests/Unit/Classes/DscResourceBase/GetDscResourcePropertyNames.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -11,7 +11,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Classes/DscResourceBase/GetDscResourcePropertyNamesWithNoSetSupport.Tests.ps1
+++ b/tests/Unit/Classes/DscResourceBase/GetDscResourcePropertyNamesWithNoSetSupport.Tests.ps1
@@ -1,4 +1,4 @@
-using module ..\..\..\..\output\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
+using module ..\..\..\..\output\builtModule\AzureDevOpsDsc\0.2.0\AzureDevOpsDsc.psm1
 
 # Initialize tests for module function
 . $PSScriptRoot\..\Classes.TestInitialization.ps1
@@ -10,8 +10,8 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
-    $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests', '')
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 
@@ -24,7 +24,7 @@ InModuleScope 'AzureDevOpsDsc' {
 
                 $dscResourceWithNoSetSupportProperties = [DscResourceBase]::new()
 
-                {$dscResourceWithNoSetSupportProperties.GetDscResourcePropertyNamesWithNoSetSupport()} | Should -Not -Throw
+                { $dscResourceWithNoSetSupportProperties.GetDscResourcePropertyNamesWithNoSetSupport() } | Should -Not -Throw
             }
 
             It 'Should return empty array' {

--- a/tests/Unit/DSCClassResources/AzDevOpsProject/AzDevOpsProject.Tests.ps1
+++ b/tests/Unit/DSCClassResources/AzDevOpsProject/AzDevOpsProject.Tests.ps1
@@ -9,7 +9,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/DSCClassResources/AzDevOpsProject/Get.Tests.ps1
+++ b/tests/Unit/DSCClassResources/AzDevOpsProject/Get.Tests.ps1
@@ -9,7 +9,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/DSCClassResources/AzDevOpsProject/GetDscCurrentStateProperties.Tests.ps1
+++ b/tests/Unit/DSCClassResources/AzDevOpsProject/GetDscCurrentStateProperties.Tests.ps1
@@ -9,7 +9,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/DSCClassResources/AzDevOpsProject/GetDscResourcePropertyNamesWithNoSetSupport.Tests.ps1
+++ b/tests/Unit/DSCClassResources/AzDevOpsProject/GetDscResourcePropertyNamesWithNoSetSupport.Tests.ps1
@@ -9,7 +9,7 @@ InModuleScope 'AzureDevOpsDsc' {
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:dscResourceName = Split-Path $PSScriptRoot -Leaf
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Classes\$script:dscResourceName\$script:dscResourceName.psm1"
     $script:tag = @($($script:commandName -replace '-'))
 
 

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiHttpRequestHeader.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiHttpRequestHeader.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiResource.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiResource.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiResourceName.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiResourceName.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiUriAreaName.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiUriAreaName.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiUriResourceName.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiUriResourceName.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiVersion.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiVersion.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiWaitIntervalMs.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiWaitIntervalMs.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiWaitTimeoutMs.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Get-AzDevOpsApiWaitTimeoutMs.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Invoke-AzDevOpsApiRestMethod.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Invoke-AzDevOpsApiRestMethod.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiHttpRequestHeader.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiHttpRequestHeader.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiResource.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiResource.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiResourceId.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiResourceId.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiResourceName.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiResourceName.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiTimeoutExceeded.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiTimeoutExceeded.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiUri.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiUri.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiVersion.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Test-AzDevOpsApiVersion.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Wait-AzDevOpsApiResource.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Wait-AzDevOpsApiResource.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Api\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Connection/Functions/Private/Test-AzDevOpsPatCredential.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Connection/Functions/Private/Test-AzDevOpsPatCredential.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Connection\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Connection\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsOperationId.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsOperationId.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsOrganizationName.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsOrganizationName.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsPat.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsPat.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsProjectDescription.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsProjectDescription.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsProjectId.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsProjectId.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsProjectName.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Test-AzDevOpsProjectName.Tests.ps1
@@ -9,8 +9,8 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:moduleVersion = $(Get-Module -Name $script:dscModuleName -ListAvailable | Select-Object -First 1).Version
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
-    $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
+    $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests', '')
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath
@@ -36,7 +36,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
                         It 'Should return $false - "*<ProjectName>*"' -TestCases $testCasesValidProjectNames {
                             param ([System.String]$ProjectName)
 
-                            Test-AzDevOpsProjectName -ProjectName $('*'+$ProjectName+'*') -IsValid | Should -BeFalse
+                            Test-AzDevOpsProjectName -ProjectName $('*' + $ProjectName + '*') -IsValid | Should -BeFalse
                         }
                     }
 
@@ -82,13 +82,13 @@ InModuleScope 'AzureDevOpsDsc.Common' {
                         It 'Should not throw - "*<ProjectName>*"' -TestCases $testCasesValidProjectNames {
                             param ([System.String]$ProjectName)
 
-                            { Test-AzDevOpsProjectName -ProjectName $('*'+$ProjectName+'*') -IsValid -AllowWildcard } | Should -Not -Throw
+                            { Test-AzDevOpsProjectName -ProjectName $('*' + $ProjectName + '*') -IsValid -AllowWildcard } | Should -Not -Throw
                         }
 
                         It 'Should return $true - "*<ProjectName>*"' -TestCases $testCasesValidProjectNames {
                             param ([System.String]$ProjectName)
 
-                            Test-AzDevOpsProjectName -ProjectName $('*'+$ProjectName+'*') -IsValid -AllowWildcard | Should -BeTrue
+                            Test-AzDevOpsProjectName -ProjectName $('*' + $ProjectName + '*') -IsValid -AllowWildcard | Should -BeTrue
                         }
                     }
 

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Wait-AzDevOpsOperation.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Private/Wait-AzDevOpsOperation.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Private\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/Get-AzDevOpsOperation.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/Get-AzDevOpsOperation.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Public\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Public\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/Get-AzDevOpsProject.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/Get-AzDevOpsProject.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Public\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Public\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/Test-AzDevOpsOperation.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/Test-AzDevOpsOperation.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Public\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Public\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/Test-AzDevOpsProject.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/Test-AzDevOpsProject.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Public\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Resources\Functions\Public\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Services/Functions/Public/Get-AzDevOpsServicesApiUri.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Services/Functions/Public/Get-AzDevOpsServicesApiUri.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
     $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Services\Functions\Public\$($script:commandName).ps1"
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Services\Functions\Public\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Services/Functions/Public/Get-AzDevOpsServicesUri.Tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Services/Functions/Public/Get-AzDevOpsServicesUri.Tests.ps1
@@ -9,8 +9,8 @@ InModuleScope 'AzureDevOpsDsc.Common' {
     $script:moduleVersion = $(Get-Module -Name $script:dscModuleName -ListAvailable | Select-Object -First 1).Version
     $script:subModuleName = 'AzureDevOpsDsc.Common'
     $script:subModuleBase = $(Get-Module $script:subModuleName).ModuleBase
-    $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests','')
-    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Services\Functions\Public\$($script:commandName).ps1"
+    $script:commandName = $(Get-Item $PSCommandPath).BaseName.Replace('.Tests', '')
+    $script:commandScriptPath = Join-Path "$PSScriptRoot\..\..\..\..\..\..\..\" -ChildPath "output\builtModule\$($script:dscModuleName)\$($script:moduleVersion)\Modules\$($script:subModuleName)\Services\Functions\Public\$($script:commandName).ps1"
     $script:tag = @($($script:commandName -replace '-'))
 
     . $script:commandScriptPath


### PR DESCRIPTION
## Summary

This PR resyncs the `ZanattaMichael/AzureDevOpsDsc` fork with the original upstream repository [`dsccommunity/AzureDevOpsDsc`](https://github.com/dsccommunity/AzureDevOpsDsc).

### Upstream commits being brought in

| SHA | Message |
|-----|---------|
| `35470b1` | Update README with maintenance status and recommendations |
| `bd9ab0d` | Update repo files ready for refactor (#39) |
| `c3e344f` | Fix pinning GitVersion to v5 |
| `12fd9c5` | Workaround bug in AzDevOpProject resource |
| `7d7c962` | Fix pipeline |

### Conflict notes

The fork has diverged significantly from upstream (10 custom commits including new resources, managed identity support, documentation, and build script improvements). A number of **merge conflicts** exist — primarily in:

- `CHANGELOG.md`
- `.devcontainer/devcontainer.json`
- `source/AzureDevOpsDsc.psd1`
- Several unit test files that were reorganized/deleted in the fork but modified in upstream

These conflicts will need to be resolved manually before this PR can be merged.

## Test plan

- [ ] Review conflict resolutions in `CHANGELOG.md`, `.devcontainer/devcontainer.json`, and `source/AzureDevOpsDsc.psd1`
- [ ] Decide which upstream test files to keep vs. the fork's restructured tests
- [ ] Confirm build pipeline passes after resolution

---
_Generated by [Claude Code](https://claude.ai/code/session_01UbbFoPzqDhPfU33zHW8Pwf)_