### PR TITLE
Add AzDoProcess and AzDoProcessPermission resources (+ docs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ LCM/Datum/*
 *.suo
 *.user
 *.coverage
+coverage.xml
 .vs
 .psproj
 .sln

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - AzDoGroupMember
   - AzDoGitRepository
   - AzDoGitPermission
+  - AzDoTeamSettings
+  - AzDoArtifactFeedSettings
+  - AzDoArtifactFeedView
+  - AzDoProcess
+  - AzDoProcessPermission
 - AzureDevOpsDsc.Common
   - Added New-AzDoAuthenticationProvider. This is invoked prior to the resource invocation.
   - Added 'wrapper' functionality around the [Azure DevOps REST API](https://docs.microsoft.com/en-us/rest/api/azure/devops/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - AzDoArtifactFeedView
   - AzDoProcess
   - AzDoProcessPermission
+  - AzDoAgentPool
+  - AzDoAgentPoolPermission
+  - AzDoAgentQueue
+  - AzDoAreaNodes
+  - AzDoAreaPermission
+  - AzDoArtifactFeed
+  - AzDoArtifactFeedPermission
+  - AzDoAuditStream
+  - AzDoBranchPolicy
+  - AzDoCheckConfiguration
+  - AzDoDeploymentGroup
+  - AzDoEnvironmentApproval
+  - AzDoEnvironmentPermission
+  - AzDoExtension
+  - AzDoIterationNodes
+  - AzDoIterationPermission
+  - AzDoNotificationSubscription
+  - AzDoOrganizationSettings
+  - AzDoPipeline
+  - AzDoPipelineEnvironment
+  - AzDoPipelinePermission
+  - AzDoProject
+  - AzDoProjectPermission
+  - AzDoProjectServices
+  - AzDoRepositorySettings
+  - AzDoSecurityNamespacePermission
+  - AzDoServiceConnection
+  - AzDoServiceConnectionPermission
+  - AzDoTaskGroup
+  - AzDoTeam
+  - AzDoTeamMember
+  - AzDoVariableGroup
+  - AzDoVariableGroupPermission
+  - AzDoWIPTags
+  - AzDoWiki
 - AzureDevOpsDsc.Common
   - Added New-AzDoAuthenticationProvider. This is invoked prior to the resource invocation.
   - Added 'wrapper' functionality around the [Azure DevOps REST API](https://docs.microsoft.com/en-us/rest/api/azure/devops/)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Each resource links to its example/usage documentation.
 | [AzDoGroupMember](source/Examples/Resources/AzDoGroupMember.md) | Manages membership of users, groups and service principals in a group. |
 | [AzDoTeam](source/Examples/Resources/AzDoTeam.md) | Creates and manages teams within a project. |
 | [AzDoTeamMember](source/Examples/Resources/AzDoTeamMember.md) | Manages membership of a team. |
+| [AzDoTeamSettings](source/Examples/Resources/AzDoTeamSettings.md) | Configures a team's iteration/area paths, working days and bug behaviour. |
 
 ### Repositories and policies
 
@@ -139,6 +140,7 @@ Each resource links to its example/usage documentation.
 | [AzDoVariableGroupPermission](source/Examples/Resources/AzDoVariableGroupPermission.md) | Manages variable group (library) permissions. |
 | [AzDoArtifactFeedPermission](source/Examples/Resources/AzDoArtifactFeedPermission.md) | Manages artifact feed permissions. |
 | [AzDoSecurityNamespacePermission](source/Examples/Resources/AzDoSecurityNamespacePermission.md) | Manages permissions for an arbitrary security namespace and token. |
+| [AzDoProcessPermission](source/Examples/Resources/AzDoProcessPermission.md) | Manages Process security namespace permissions, e.g. who can create inherited (child) processes. |
 | [AzDoGroupPermission](source/Examples/Resources/AzDoGroupPermission.md) | *(Not currently supported)* Manages group-level identity permissions. |
 
 ### Pipelines, environments and agents
@@ -163,6 +165,7 @@ Each resource links to its example/usage documentation.
 | [AzDoAreaNodes](source/Examples/Resources/AzDoAreaNodes.md) | Manages area path classification nodes. |
 | [AzDoIterationNodes](source/Examples/Resources/AzDoIterationNodes.md) | Manages iteration path classification nodes. |
 | [AzDoWIPTags](source/Examples/Resources/AzDoWIPTags.md) | Manages work item tags. |
+| [AzDoProcess](source/Examples/Resources/AzDoProcess.md) | Creates and manages inherited processes (process templates). |
 | [AzDoNotificationSubscription](source/Examples/Resources/AzDoNotificationSubscription.md) | Manages notification subscriptions. |
 
 ### Artifacts, wiki, extensions and auditing
@@ -170,6 +173,8 @@ Each resource links to its example/usage documentation.
 | Resource | Description |
 |---|---|
 | [AzDoArtifactFeed](source/Examples/Resources/AzDoArtifactFeed.md) | Creates and manages artifact feeds. |
+| [AzDoArtifactFeedSettings](source/Examples/Resources/AzDoArtifactFeedSettings.md) | Configures feed upstream sources, deleted-version hiding and retention policy. |
+| [AzDoArtifactFeedView](source/Examples/Resources/AzDoArtifactFeedView.md) | Creates and manages feed views (e.g. `@Release`). |
 | [AzDoWiki](source/Examples/Resources/AzDoWiki.md) | Creates and manages project and code wikis. |
 | [AzDoExtension](source/Examples/Resources/AzDoExtension.md) | Installs and uninstalls organization extensions. |
 | [AzDoAuditStream](source/Examples/Resources/AzDoAuditStream.md) | Manages audit log streaming. |

--- a/source/AzureDevOpsDsc.psd1
+++ b/source/AzureDevOpsDsc.psd1
@@ -86,7 +86,8 @@
       'AzDoTeamSettings',
       'AzDoArtifactFeedSettings',
       'AzDoArtifactFeedView',
-      'AzDoProcess'
+      'AzDoProcess',
+      'AzDoProcessPermissions'
     )
 
     RequiredAssemblies = @()

--- a/source/AzureDevOpsDsc.psd1
+++ b/source/AzureDevOpsDsc.psd1
@@ -82,7 +82,10 @@
       'AzDoWiki',
       'AzDoNotificationSubscription',
       'AzDoRepositorySettings',
-      'AzDoCheckConfiguration'
+      'AzDoCheckConfiguration',
+      'AzDoTeamSettings',
+      'AzDoArtifactFeedSettings',
+      'AzDoArtifactFeedView'
     )
 
     RequiredAssemblies = @()

--- a/source/AzureDevOpsDsc.psd1
+++ b/source/AzureDevOpsDsc.psd1
@@ -85,7 +85,8 @@
       'AzDoCheckConfiguration',
       'AzDoTeamSettings',
       'AzDoArtifactFeedSettings',
-      'AzDoArtifactFeedView'
+      'AzDoArtifactFeedView',
+      'AzDoProcess'
     )
 
     RequiredAssemblies = @()

--- a/source/AzureDevOpsDsc.psd1
+++ b/source/AzureDevOpsDsc.psd1
@@ -87,7 +87,7 @@
       'AzDoArtifactFeedSettings',
       'AzDoArtifactFeedView',
       'AzDoProcess',
-      'AzDoProcessPermissions'
+      'AzDoProcessPermission'
     )
 
     RequiredAssemblies = @()

--- a/source/Classes/093.AzDoTeamSettings.ps1
+++ b/source/Classes/093.AzDoTeamSettings.ps1
@@ -11,14 +11,14 @@
 class AzDoTeamSettings : AzDevOpsDscResourceBase
 {
     [DscProperty(Key, Mandatory)][System.String]$ProjectName
-    [DscProperty(Key, Mandatory)][System.String]$TeamName
+    [DscProperty(Mandatory)][System.String]$TeamName
     [DscProperty()][System.String]$BacklogIterationPath
     [DscProperty()][System.String]$DefaultIterationPath
     [DscProperty()][System.String[]]$IterationPaths
     [DscProperty()][System.String]$DefaultAreaPath
     [DscProperty()][System.String[]]$AreaPaths
     [DscProperty()][System.String[]]$WorkingDays
-    [DscProperty()][ValidateSet('asRequirements', 'asTasks', 'off')][System.String]$BugsBehavior
+    [DscProperty()][ValidateSet('', 'asRequirements', 'asTasks', 'off')][System.String]$BugsBehavior
 
     AzDoTeamSettings() { $this.Construct() }
     [AzDoTeamSettings] Get() { return [AzDoTeamSettings]$($this.GetDscCurrentStateProperties()) }

--- a/source/Classes/093.AzDoTeamSettings.ps1
+++ b/source/Classes/093.AzDoTeamSettings.ps1
@@ -1,0 +1,42 @@
+<#
+.SYNOPSIS
+    DSC resource for managing the iteration and area-path configuration of an Azure DevOps team.
+.DESCRIPTION
+    Allows the iteration paths (default iteration, backlog iteration and the iterations assigned to
+    the team) and the area paths (default area path and the team's area paths) to be declared as
+    part of how a team is configured.
+#>
+[DscResource()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSDSCStandardDSCFunctionsInResource', '', Justification='Test() and Set() method are inherited from base, "AzDevOpsDscResourceBase" class')]
+class AzDoTeamSettings : AzDevOpsDscResourceBase
+{
+    [DscProperty(Key, Mandatory)][System.String]$ProjectName
+    [DscProperty(Key, Mandatory)][System.String]$TeamName
+    [DscProperty()][System.String]$BacklogIterationPath
+    [DscProperty()][System.String]$DefaultIterationPath
+    [DscProperty()][System.String[]]$IterationPaths
+    [DscProperty()][System.String]$DefaultAreaPath
+    [DscProperty()][System.String[]]$AreaPaths
+    [DscProperty()][System.String[]]$WorkingDays
+    [DscProperty()][ValidateSet('asRequirements', 'asTasks', 'off')][System.String]$BugsBehavior
+
+    AzDoTeamSettings() { $this.Construct() }
+    [AzDoTeamSettings] Get() { return [AzDoTeamSettings]$($this.GetDscCurrentStateProperties()) }
+    hidden [System.String[]]GetDscResourcePropertyNamesWithNoSetSupport() { return @() }
+    hidden [Hashtable]GetDscCurrentStateProperties([PSCustomObject]$CurrentResourceObject) {
+        $properties = @{ Ensure = [Ensure]::Absent }
+        if ($null -eq $CurrentResourceObject) { return $properties }
+        $properties.ProjectName          = $CurrentResourceObject.ProjectName
+        $properties.TeamName             = $CurrentResourceObject.TeamName
+        $properties.BacklogIterationPath = $CurrentResourceObject.BacklogIterationPath
+        $properties.DefaultIterationPath = $CurrentResourceObject.DefaultIterationPath
+        $properties.IterationPaths       = $CurrentResourceObject.IterationPaths
+        $properties.DefaultAreaPath      = $CurrentResourceObject.DefaultAreaPath
+        $properties.AreaPaths            = $CurrentResourceObject.AreaPaths
+        $properties.WorkingDays          = $CurrentResourceObject.WorkingDays
+        $properties.BugsBehavior         = $CurrentResourceObject.BugsBehavior
+        $properties.LookupResult         = $CurrentResourceObject.LookupResult
+        $properties.Ensure               = $CurrentResourceObject.Ensure
+        return $properties
+    }
+}

--- a/source/Classes/094.AzDoArtifactFeedSettings.ps1
+++ b/source/Classes/094.AzDoArtifactFeedSettings.ps1
@@ -11,7 +11,7 @@
 class AzDoArtifactFeedSettings : AzDevOpsDscResourceBase
 {
     [DscProperty(Key, Mandatory)][System.String]$ProjectName
-    [DscProperty(Key, Mandatory)][System.String]$FeedName
+    [DscProperty(Mandatory)][System.String]$FeedName
     [DscProperty()][System.String[]]$UpstreamSources
     [DscProperty()][System.Boolean]$HideDeletedPackageVersions = $true
 

--- a/source/Classes/094.AzDoArtifactFeedSettings.ps1
+++ b/source/Classes/094.AzDoArtifactFeedSettings.ps1
@@ -1,0 +1,38 @@
+<#
+.SYNOPSIS
+    DSC resource for managing the settings of an Azure Artifacts feed.
+.DESCRIPTION
+    Manages the configurable settings of an existing feed: its upstream sources, whether deleted
+    package versions are hidden, and the artifact lifecycle (retention policy). Retention is only
+    managed when 'RetentionCountLimit' is greater than zero.
+#>
+[DscResource()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSDSCStandardDSCFunctionsInResource', '', Justification='Test() and Set() method are inherited from base, "AzDevOpsDscResourceBase" class')]
+class AzDoArtifactFeedSettings : AzDevOpsDscResourceBase
+{
+    [DscProperty(Key, Mandatory)][System.String]$ProjectName
+    [DscProperty(Key, Mandatory)][System.String]$FeedName
+    [DscProperty()][System.String[]]$UpstreamSources
+    [DscProperty()][System.Boolean]$HideDeletedPackageVersions = $true
+
+    # Artifact lifecycle / retention policy. A 'RetentionCountLimit' of 0 means retention is not managed.
+    [DscProperty()][System.Int32]$RetentionCountLimit = 0
+    [DscProperty()][System.Int32]$DaysToKeepRecentlyDownloadedPackages = 0
+
+    AzDoArtifactFeedSettings() { $this.Construct() }
+    [AzDoArtifactFeedSettings] Get() { return [AzDoArtifactFeedSettings]$($this.GetDscCurrentStateProperties()) }
+    hidden [System.String[]]GetDscResourcePropertyNamesWithNoSetSupport() { return @() }
+    hidden [Hashtable]GetDscCurrentStateProperties([PSCustomObject]$CurrentResourceObject) {
+        $properties = @{ Ensure = [Ensure]::Absent }
+        if ($null -eq $CurrentResourceObject) { return $properties }
+        $properties.ProjectName                          = $CurrentResourceObject.ProjectName
+        $properties.FeedName                             = $CurrentResourceObject.FeedName
+        $properties.UpstreamSources                      = $CurrentResourceObject.UpstreamSources
+        $properties.HideDeletedPackageVersions           = $CurrentResourceObject.HideDeletedPackageVersions
+        $properties.RetentionCountLimit                  = $CurrentResourceObject.RetentionCountLimit
+        $properties.DaysToKeepRecentlyDownloadedPackages = $CurrentResourceObject.DaysToKeepRecentlyDownloadedPackages
+        $properties.LookupResult                         = $CurrentResourceObject.LookupResult
+        $properties.Ensure                               = $CurrentResourceObject.Ensure
+        return $properties
+    }
+}

--- a/source/Classes/095.AzDoArtifactFeedView.ps1
+++ b/source/Classes/095.AzDoArtifactFeedView.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    DSC resource for managing a view on an Azure Artifacts feed.
+.DESCRIPTION
+    Manages a named view on an existing feed, including its type (e.g. 'release') and its visibility
+    (e.g. 'private', 'collection', 'organization', 'aadTenant').
+#>
+[DscResource()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSDSCStandardDSCFunctionsInResource', '', Justification='Test() and Set() method are inherited from base, "AzDevOpsDscResourceBase" class')]
+class AzDoArtifactFeedView : AzDevOpsDscResourceBase
+{
+    [DscProperty(Key, Mandatory)][System.String]$ProjectName
+    [DscProperty(Key, Mandatory)][System.String]$FeedName
+    [DscProperty(Key, Mandatory)][System.String]$ViewName
+    [DscProperty()][ValidateSet('release', 'implicit')][System.String]$ViewType = 'release'
+    [DscProperty()][ValidateSet('private', 'collection', 'organization', 'aadTenant')][System.String]$ViewVisibility = 'collection'
+
+    AzDoArtifactFeedView() { $this.Construct() }
+    [AzDoArtifactFeedView] Get() { return [AzDoArtifactFeedView]$($this.GetDscCurrentStateProperties()) }
+    hidden [System.String[]]GetDscResourcePropertyNamesWithNoSetSupport() { return @() }
+    hidden [Hashtable]GetDscCurrentStateProperties([PSCustomObject]$CurrentResourceObject) {
+        $properties = @{ Ensure = [Ensure]::Absent }
+        if ($null -eq $CurrentResourceObject) { return $properties }
+        $properties.ProjectName    = $CurrentResourceObject.ProjectName
+        $properties.FeedName       = $CurrentResourceObject.FeedName
+        $properties.ViewName       = $CurrentResourceObject.ViewName
+        $properties.ViewType       = $CurrentResourceObject.ViewType
+        $properties.ViewVisibility = $CurrentResourceObject.ViewVisibility
+        $properties.LookupResult   = $CurrentResourceObject.LookupResult
+        $properties.Ensure         = $CurrentResourceObject.Ensure
+        return $properties
+    }
+}

--- a/source/Classes/095.AzDoArtifactFeedView.ps1
+++ b/source/Classes/095.AzDoArtifactFeedView.ps1
@@ -10,8 +10,8 @@
 class AzDoArtifactFeedView : AzDevOpsDscResourceBase
 {
     [DscProperty(Key, Mandatory)][System.String]$ProjectName
-    [DscProperty(Key, Mandatory)][System.String]$FeedName
-    [DscProperty(Key, Mandatory)][System.String]$ViewName
+    [DscProperty(Mandatory)][System.String]$FeedName
+    [DscProperty(Mandatory)][System.String]$ViewName
     [DscProperty()][ValidateSet('release', 'implicit')][System.String]$ViewType = 'release'
     [DscProperty()][ValidateSet('private', 'collection', 'organization', 'aadTenant')][System.String]$ViewVisibility = 'collection'
 

--- a/source/Classes/096.AzDoProcess.ps1
+++ b/source/Classes/096.AzDoProcess.ps1
@@ -38,7 +38,6 @@ class AzDoProcess : AzDevOpsDscResourceBase
     [System.String]$ParentProcessName
 
     [DscProperty()]
-    [Alias('Description')]
     [System.String]$Description
 
     AzDoProcess()

--- a/source/Classes/096.AzDoProcess.ps1
+++ b/source/Classes/096.AzDoProcess.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+    DSC resource for managing Azure DevOps inherited processes.
+
+.DESCRIPTION
+    The AzDoProcess resource creates and manages inherited processes (process templates) derived from an
+    existing parent process. It inherits from the AzDevOpsDscResourceBase class. The parent process is
+    immutable once the process is created and therefore has no Set support.
+
+.PARAMETER ProcessName
+    The name of the inherited process.
+
+.PARAMETER ParentProcessName
+    The name of the parent (system or custom) process to inherit from, e.g. 'Agile', 'Scrum', 'CMMI', 'Basic'.
+
+.PARAMETER Description
+    The description of the inherited process.
+
+.EXAMPLE
+    AzDoProcess MyAgile
+    {
+        ProcessName       = 'Contoso Agile'
+        ParentProcessName = 'Agile'
+        Description        = 'Agile process customised for Contoso'
+        Ensure            = 'Present'
+    }
+#>
+
+[DscResource()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSDSCStandardDSCFunctionsInResource', '', Justification='Test() and Set() method are inherited from base, "AzDevOpsDscResourceBase" class')]
+class AzDoProcess : AzDevOpsDscResourceBase
+{
+    [DscProperty(Key, Mandatory)]
+    [Alias('Name')]
+    [System.String]$ProcessName
+
+    [DscProperty(Mandatory)]
+    [System.String]$ParentProcessName
+
+    [DscProperty()]
+    [Alias('Description')]
+    [System.String]$Description
+
+    AzDoProcess()
+    {
+        $this.Construct()
+    }
+
+    [AzDoProcess] Get()
+    {
+        return [AzDoProcess]$($this.GetDscCurrentStateProperties())
+    }
+
+    hidden [System.String[]]GetDscResourcePropertyNamesWithNoSetSupport()
+    {
+        return @('ParentProcessName')
+    }
+
+    hidden [Hashtable]GetDscCurrentStateProperties([PSCustomObject]$CurrentResourceObject)
+    {
+        $properties = @{
+            Ensure = [Ensure]::Absent
+        }
+
+        if ($null -eq $CurrentResourceObject)
+        {
+            return $properties
+        }
+
+        $properties.ProcessName       = $CurrentResourceObject.ProcessName
+        $properties.ParentProcessName = $CurrentResourceObject.ParentProcessName
+        $properties.Description        = $CurrentResourceObject.Description
+        $properties.LookupResult       = $CurrentResourceObject.LookupResult
+        $properties.Ensure             = $CurrentResourceObject.Ensure
+
+        return $properties
+    }
+}

--- a/source/Classes/097.AzDoProcessPermission.ps1
+++ b/source/Classes/097.AzDoProcessPermission.ps1
@@ -3,7 +3,7 @@
     DSC resource for managing Azure DevOps Process namespace permissions.
 
 .DESCRIPTION
-    The AzDoProcessPermissions resource manages ACEs in the Process security namespace. Use the sentinel
+    The AzDoProcessPermission resource manages ACEs in the Process security namespace. Use the sentinel
     process name 'AllProcesses' to manage the org-wide root scope ('$PROCESS') — this governs who can
     create, edit, delete and administer processes, including creating inherited (child) processes from
     existing ones. A specific inherited process name scopes permissions to that single process
@@ -22,7 +22,7 @@
 
 .EXAMPLE
     # Allow the 'Process Authors' group to create inherited processes org-wide.
-    AzDoProcessPermissions AllowCreate
+    AzDoProcessPermission AllowCreate
     {
         ProcessName = 'AllProcesses'
         Permissions = @(
@@ -36,7 +36,7 @@
 
 [DscResource()]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSDSCStandardDSCFunctionsInResource', '', Justification='Test() and Set() method are inherited from base, "AzDevOpsDscResourceBase" class')]
-class AzDoProcessPermissions : AzDevOpsDscResourceBase
+class AzDoProcessPermission : AzDevOpsDscResourceBase
 {
     [DscProperty(Key, Mandatory)]
     [System.String]$ProcessName
@@ -47,14 +47,14 @@ class AzDoProcessPermissions : AzDevOpsDscResourceBase
     [DscProperty()]
     [HashTable[]]$Permissions
 
-    AzDoProcessPermissions()
+    AzDoProcessPermission()
     {
         $this.Construct()
     }
 
-    [AzDoProcessPermissions] Get()
+    [AzDoProcessPermission] Get()
     {
-        return [AzDoProcessPermissions]$($this.GetDscCurrentStateProperties())
+        return [AzDoProcessPermission]$($this.GetDscCurrentStateProperties())
     }
 
     hidden [System.String[]]GetDscResourcePropertyNamesWithNoSetSupport()

--- a/source/Classes/097.AzDoProcessPermissions.ps1
+++ b/source/Classes/097.AzDoProcessPermissions.ps1
@@ -1,0 +1,76 @@
+<#
+.SYNOPSIS
+    DSC resource for managing Azure DevOps Process namespace permissions.
+
+.DESCRIPTION
+    The AzDoProcessPermissions resource manages ACEs in the Process security namespace. Use the sentinel
+    process name 'AllProcesses' to manage the org-wide root scope ('$PROCESS') — this governs who can
+    create, edit, delete and administer processes, including creating inherited (child) processes from
+    existing ones. A specific inherited process name scopes permissions to that single process
+    ('$PROCESS:{parentProcessTypeId}:{processTypeId}').
+
+    It inherits Test()/Set() from the AzDevOpsDscResourceBase class.
+
+.PARAMETER ProcessName
+    The process name, or the sentinel 'AllProcesses' for the org-wide root scope.
+
+.PARAMETER isInherited
+    Whether the ACL inherits permissions. Defaults to $true.
+
+.PARAMETER Permissions
+    An array of hashtables describing the desired ACEs, each with an 'Identity' and a 'Permission' map.
+
+.EXAMPLE
+    # Allow the 'Process Authors' group to create inherited processes org-wide.
+    AzDoProcessPermissions AllowCreate
+    {
+        ProcessName = 'AllProcesses'
+        Permissions = @(
+            @{
+                Identity   = '[MyOrg]\Process Authors'
+                Permission = @{ Create = 'Allow'; Edit = 'Allow' }
+            }
+        )
+    }
+#>
+
+[DscResource()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSDSCStandardDSCFunctionsInResource', '', Justification='Test() and Set() method are inherited from base, "AzDevOpsDscResourceBase" class')]
+class AzDoProcessPermissions : AzDevOpsDscResourceBase
+{
+    [DscProperty(Key, Mandatory)]
+    [System.String]$ProcessName
+
+    [DscProperty()]
+    [System.Boolean]$isInherited = $true
+
+    [DscProperty()]
+    [HashTable[]]$Permissions
+
+    AzDoProcessPermissions()
+    {
+        $this.Construct()
+    }
+
+    [AzDoProcessPermissions] Get()
+    {
+        return [AzDoProcessPermissions]$($this.GetDscCurrentStateProperties())
+    }
+
+    hidden [System.String[]]GetDscResourcePropertyNamesWithNoSetSupport()
+    {
+        return @()
+    }
+
+    hidden [Hashtable]GetDscCurrentStateProperties([PSCustomObject]$CurrentResourceObject)
+    {
+        $properties = @{ Ensure = [Ensure]::Absent }
+        if ($null -eq $CurrentResourceObject) { return $properties }
+        $properties.ProcessName  = $CurrentResourceObject.ProcessName
+        $properties.isInherited  = $CurrentResourceObject.isInherited
+        $properties.Permissions  = $CurrentResourceObject.Permissions
+        $properties.LookupResult = $CurrentResourceObject.LookupResult
+        $properties.Ensure       = $CurrentResourceObject.Ensure
+        return $properties
+    }
+}

--- a/source/Examples/Resources/AzDoArtifactFeedSettings.md
+++ b/source/Examples/Resources/AzDoArtifactFeedSettings.md
@@ -1,0 +1,108 @@
+# DSC AzDoArtifactFeedSettings Resource
+
+## Syntax
+
+```PowerShell
+AzDoArtifactFeedSettings [string] #ResourceName
+{
+    ProjectName                            = [String]$ProjectName
+    FeedName                               = [String]$FeedName
+    [ UpstreamSources                      = [String[]]$UpstreamSources ]
+    [ HideDeletedPackageVersions           = [Boolean]$HideDeletedPackageVersions ]
+    [ RetentionCountLimit                  = [Int32]$RetentionCountLimit ]
+    [ DaysToKeepRecentlyDownloadedPackages = [Int32]$DaysToKeepRecentlyDownloadedPackages ]
+    [ Ensure                               = [String] {'Present', 'Absent'} ]
+}
+```
+
+## Properties
+
+### Common Properties
+
+- **ProjectName**: The name of the Azure DevOps project. This property is mandatory and serves as the key property for the resource.
+- **FeedName**: The name of the artifact feed whose settings are managed. This property is mandatory. The feed itself is managed by the `AzDoArtifactFeed` resource.
+- **UpstreamSources**: The upstream sources configured on the feed. Only applied when supplied (a null/empty value leaves the existing upstream sources unchanged).
+- **HideDeletedPackageVersions**: Whether deleted package versions are hidden. Defaults to `$true`.
+- **RetentionCountLimit**: The maximum number of versions to retain per package. A value of `0` (the default) means the retention policy is not managed by this resource.
+- **DaysToKeepRecentlyDownloadedPackages**: The number of days to keep recently downloaded packages, used with the retention policy.
+- **Ensure**: Specifies the desired state. Feed settings cannot be removed, so `Absent` is a no-op.
+
+## Additional Information
+
+This resource configures settings on an existing Azure Artifacts feed: upstream sources, whether deleted package versions are hidden, and the retention policy. Because feed settings cannot be deleted, `Ensure = 'Absent'` is treated as a no-op.
+
+## Examples
+
+## Example 1: Sample Configuration using AzDoArtifactFeedSettings Resource
+
+``` PowerShell
+Configuration ExampleConfig {
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    Node localhost {
+        AzDoArtifactFeedSettings ConfigureFeed {
+            Ensure                               = 'Present'
+            ProjectName                          = 'MyProject'
+            FeedName                             = 'MyFeed'
+            HideDeletedPackageVersions           = $true
+            RetentionCountLimit                  = 100
+            DaysToKeepRecentlyDownloadedPackages = 30
+        }
+    }
+}
+
+Start-DscConfiguration -Path ./ExampleConfig -Wait -Verbose
+```
+
+## Example 2: Sample Configuration using Invoke-DSCResource
+
+``` PowerShell
+# Return the current configuration for AzDoArtifactFeedSettings
+$properties = @{
+    ProjectName = 'MyProject'
+    FeedName    = 'MyFeed'
+}
+
+Invoke-DscResource -Name 'AzDoArtifactFeedSettings' -Method Get -Property $properties -ModuleName 'AzureDevOpsDsc'
+```
+
+## Example 3: Sample Configuration using AzDO-DSC-LCM
+
+``` YAML
+parameters: {}
+
+variables: {
+  ProjectName: MyProject,
+  FeedName: MyFeed
+}
+
+resources:
+- name: Configure Feed Settings
+  type: AzureDevOpsDsc/AzDoArtifactFeedSettings
+  dependsOn:
+    - AzureDevOpsDsc/AzDoArtifactFeed/MyFeed
+  properties:
+    ProjectName: $ProjectName
+    FeedName: $FeedName
+    HideDeletedPackageVersions: true
+    RetentionCountLimit: 100
+    DaysToKeepRecentlyDownloadedPackages: 30
+    Ensure: Present
+```
+
+LCM Initialization:
+
+``` PowerShell
+
+$params = @{
+    AzureDevopsOrganizationName = "SampleAzDoOrgName"
+    ConfigurationDirectory      = "C:\Datum\DSCOutput\"
+    ConfigurationUrl            = 'https://configuration-path'
+    JITToken                    = 'SampleJITToken'
+    Mode                        = 'Set'
+    AuthenticationType          = 'ManagedIdentity'
+    ReportPath                  = 'C:\Datum\DSCOutput\Reports'
+}
+
+Invoke-AzDoLCM @params
+```

--- a/source/Examples/Resources/AzDoArtifactFeedSettings/1-ConfigureAzDoArtifactFeedSettings.ps1
+++ b/source/Examples/Resources/AzDoArtifactFeedSettings/1-ConfigureAzDoArtifactFeedSettings.ps1
@@ -1,0 +1,29 @@
+<#
+    .DESCRIPTION
+        This example shows how to configure the settings of an Azure Artifacts feed, including
+        upstream sources, hiding deleted package versions, and the artifact lifecycle (retention
+        policy). Use AzDoArtifactFeedPermission to manage who can read or contribute to the feed.
+#>
+
+New-AzDoAuthenticationProvider -OrganizationName 'test-organization' -PersonalAccessToken 'my-pat'
+
+Configuration Example
+{
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    node localhost
+    {
+        AzDoArtifactFeedSettings 'ConfigureMyFeed'
+        {
+            Ensure                               = 'Present'
+            ProjectName                          = 'MyProject'
+            FeedName                             = 'MyFeed'
+            UpstreamSources                      = @('npmjs', 'NuGet Gallery')
+            HideDeletedPackageVersions           = $true
+
+            # Artifact lifecycle (retention policy)
+            RetentionCountLimit                  = 100
+            DaysToKeepRecentlyDownloadedPackages = 30
+        }
+    }
+}

--- a/source/Examples/Resources/AzDoArtifactFeedView.md
+++ b/source/Examples/Resources/AzDoArtifactFeedView.md
@@ -1,0 +1,107 @@
+# DSC AzDoArtifactFeedView Resource
+
+## Syntax
+
+```PowerShell
+AzDoArtifactFeedView [string] #ResourceName
+{
+    ProjectName        = [String]$ProjectName
+    FeedName           = [String]$FeedName
+    ViewName           = [String]$ViewName
+    [ ViewType         = [String] {'release', 'implicit'} ]
+    [ ViewVisibility   = [String] {'private', 'collection', 'organization', 'aadTenant'} ]
+    [ Ensure          = [String] {'Present', 'Absent'} ]
+}
+```
+
+## Properties
+
+### Common Properties
+
+- **ProjectName**: The name of the Azure DevOps project. This property is mandatory and serves as the key property for the resource.
+- **FeedName**: The name of the artifact feed that owns the view. This property is mandatory. The feed itself is managed by the `AzDoArtifactFeed` resource.
+- **ViewName**: The name of the feed view. This property is mandatory.
+- **ViewType**: The type of view. Valid values are `release` and `implicit`. Defaults to `release`.
+- **ViewVisibility**: Who can see the view. Valid values are `private`, `collection`, `organization` and `aadTenant`. Defaults to `collection`.
+- **Ensure**: Specifies whether the view should exist. Valid values are `Present` and `Absent`.
+
+## Additional Information
+
+This resource creates and manages views on an Azure Artifacts feed. Feed views (such as `@Release` and `@Prerelease`) let consumers pull only packages that have been promoted to a given quality level.
+
+## Examples
+
+## Example 1: Sample Configuration using AzDoArtifactFeedView Resource
+
+``` PowerShell
+Configuration ExampleConfig {
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    Node localhost {
+        AzDoArtifactFeedView AddReleaseView {
+            Ensure         = 'Present'
+            ProjectName    = 'MyProject'
+            FeedName       = 'MyFeed'
+            ViewName       = 'Release'
+            ViewType       = 'release'
+            ViewVisibility = 'organization'
+        }
+    }
+}
+
+Start-DscConfiguration -Path ./ExampleConfig -Wait -Verbose
+```
+
+## Example 2: Sample Configuration using Invoke-DSCResource
+
+``` PowerShell
+# Return the current configuration for AzDoArtifactFeedView
+$properties = @{
+    ProjectName = 'MyProject'
+    FeedName    = 'MyFeed'
+    ViewName    = 'Release'
+}
+
+Invoke-DscResource -Name 'AzDoArtifactFeedView' -Method Get -Property $properties -ModuleName 'AzureDevOpsDsc'
+```
+
+## Example 3: Sample Configuration using AzDO-DSC-LCM
+
+``` YAML
+parameters: {}
+
+variables: {
+  ProjectName: MyProject,
+  FeedName: MyFeed
+}
+
+resources:
+- name: Release Feed View
+  type: AzureDevOpsDsc/AzDoArtifactFeedView
+  dependsOn:
+    - AzureDevOpsDsc/AzDoArtifactFeed/MyFeed
+  properties:
+    ProjectName: $ProjectName
+    FeedName: $FeedName
+    ViewName: Release
+    ViewType: release
+    ViewVisibility: organization
+    Ensure: Present
+```
+
+LCM Initialization:
+
+``` PowerShell
+
+$params = @{
+    AzureDevopsOrganizationName = "SampleAzDoOrgName"
+    ConfigurationDirectory      = "C:\Datum\DSCOutput\"
+    ConfigurationUrl            = 'https://configuration-path'
+    JITToken                    = 'SampleJITToken'
+    Mode                        = 'Set'
+    AuthenticationType          = 'ManagedIdentity'
+    ReportPath                  = 'C:\Datum\DSCOutput\Reports'
+}
+
+Invoke-AzDoLCM @params
+```

--- a/source/Examples/Resources/AzDoArtifactFeedView/1-AddAzDoArtifactFeedView.ps1
+++ b/source/Examples/Resources/AzDoArtifactFeedView/1-AddAzDoArtifactFeedView.ps1
@@ -1,0 +1,24 @@
+<#
+    .DESCRIPTION
+        This example shows how to create a view on an Azure Artifacts feed.
+#>
+
+New-AzDoAuthenticationProvider -OrganizationName 'test-organization' -PersonalAccessToken 'my-pat'
+
+Configuration Example
+{
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    node localhost
+    {
+        AzDoArtifactFeedView 'AddReleaseView'
+        {
+            Ensure         = 'Present'
+            ProjectName    = 'MyProject'
+            FeedName       = 'MyFeed'
+            ViewName       = 'Release'
+            ViewType       = 'release'
+            ViewVisibility = 'organization'
+        }
+    }
+}

--- a/source/Examples/Resources/AzDoProcess.md
+++ b/source/Examples/Resources/AzDoProcess.md
@@ -1,0 +1,95 @@
+# DSC AzDoProcess Resource
+
+## Syntax
+
+```PowerShell
+AzDoProcess [string] #ResourceName
+{
+    ProcessName         = [String]$ProcessName
+    ParentProcessName   = [String]$ParentProcessName
+    [ Description       = [String]$Description ]
+    [ Ensure           = [String] {'Present', 'Absent'} ]
+}
+```
+
+## Properties
+
+### Common Properties
+
+- **ProcessName**: The name of the inherited process. This property is mandatory and serves as the key property for the resource.
+- **ParentProcessName**: The name of the parent (system or custom) process to inherit from, for example `Agile`, `Scrum`, `CMMI` or `Basic`. This property is mandatory. It is immutable — the parent cannot be changed after creation.
+- **Description**: An optional description for the process.
+- **Ensure**: Specifies whether the process should exist. Valid values are `Present` and `Absent`.
+
+## Additional Information
+
+This resource creates and manages Azure DevOps **inherited processes** (process templates) via the Work Item Tracking Process REST API. Only the description is reconciled after creation; the parent process is fixed. A process that is in use by a project (or a system process) cannot be deleted.
+
+## Examples
+
+## Example 1: Sample Configuration using AzDoProcess Resource
+
+``` PowerShell
+Configuration ExampleConfig {
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    Node localhost {
+        AzDoProcess ContosoAgile {
+            Ensure            = 'Present'
+            ProcessName       = 'Contoso Agile'
+            ParentProcessName = 'Agile'
+            Description       = 'Agile process customised for Contoso'
+        }
+    }
+}
+
+Start-DscConfiguration -Path ./ExampleConfig -Wait -Verbose
+```
+
+## Example 2: Sample Configuration using Invoke-DSCResource
+
+``` PowerShell
+# Return the current configuration for AzDoProcess
+$properties = @{
+    ProcessName       = 'Contoso Agile'
+    ParentProcessName = 'Agile'
+}
+
+Invoke-DscResource -Name 'AzDoProcess' -Method Get -Property $properties -ModuleName 'AzureDevOpsDsc'
+```
+
+## Example 3: Sample Configuration using AzDO-DSC-LCM
+
+``` YAML
+parameters: {}
+
+variables: {
+  ProcessName: Contoso Agile
+}
+
+resources:
+- name: Contoso Agile Process
+  type: AzureDevOpsDsc/AzDoProcess
+  properties:
+    ProcessName: $ProcessName
+    ParentProcessName: Agile
+    Description: Agile process customised for Contoso
+    Ensure: Present
+```
+
+LCM Initialization:
+
+``` PowerShell
+
+$params = @{
+    AzureDevopsOrganizationName = "SampleAzDoOrgName"
+    ConfigurationDirectory      = "C:\Datum\DSCOutput\"
+    ConfigurationUrl            = 'https://configuration-path'
+    JITToken                    = 'SampleJITToken'
+    Mode                        = 'Set'
+    AuthenticationType          = 'ManagedIdentity'
+    ReportPath                  = 'C:\Datum\DSCOutput\Reports'
+}
+
+Invoke-AzDoLCM @params
+```

--- a/source/Examples/Resources/AzDoProcessPermission.md
+++ b/source/Examples/Resources/AzDoProcessPermission.md
@@ -1,0 +1,149 @@
+# DSC AzDoProcessPermission Resource
+
+## Syntax
+
+```PowerShell
+AzDoProcessPermission [string] #ResourceName
+{
+    ProcessName   = [String]$ProcessName
+    [ isInherited = [Boolean]$isInherited ]
+    [ Permissions = [HashTable[]]$Permissions ]
+    [ Ensure      = [String] {'Present', 'Absent'} ]
+}
+```
+
+## Permissions Syntax
+
+``` PowerShell
+AzDoProcessPermission/Permissions
+{
+    Identity   = [String]$Identity # Syntax
+    #   SYNTAX:     '[ProjectName | OrganizationName]\ServicePrincipalName, UserPrincipalName, UserDisplayName, GroupDisplayName'
+    #   EXAMPLE:    '[SampleOrganizationName]\Process Authors'
+    #   EXAMPLE:    '[]\Process Authors'   # organisation-level group
+    Permission = [Hashtable]$Permissions # See 'Permission List'
+}
+```
+
+## Permission Usage
+
+``` PowerShell
+AzDoProcessPermission/Permissions/Permission
+{
+    PermissionName|PermissionDisplayName = [String]$Name { 'Allow, Deny' }
+}
+```
+
+## Permission List
+
+> Either 'Name' or 'DisplayName' can be used, but we Strongly Recommend that you use 'Name' in your configuration.
+
+| Name | DisplayName | Values | Note |
+| ---- | ----------- | ------ | ---- |
+| Create | Create process | [ allow, deny ] | Allows creating inherited (child) processes from existing ones. |
+| Edit | Edit process | [ allow, deny ] | |
+| Delete | Delete process | [ allow, deny ] | |
+| AdministerProcessPermissions | Administer process permissions | [ allow, deny ] | |
+| ReadProcessPermissions | Read process permissions | [ allow, deny ] | |
+
+## Properties
+
+### Common Properties
+
+- **ProcessName**: The scope of the permissions. This is the key property. Use the sentinel value `AllProcesses` to target the organisation-wide root scope (`$PROCESS`), which governs who can create, edit, delete and administer processes — including creating inherited (child) processes. Use a specific inherited process name to scope permissions to that single process.
+- **isInherited**: Whether the ACL inherits permissions from parent scopes. Defaults to `$true`.
+- **Permissions**: A HashTable array that specifies the permissions to be set. Refer to: 'Permissions Syntax'.
+- **Ensure**: Specifies whether the permissions should exist. Valid values are `Present` and `Absent`.
+
+## Additional Information
+
+This resource manages access control entries in the Azure DevOps **Process** security namespace. The most common use is granting a group the `Create` permission at the `AllProcesses` scope so its members can create inherited processes based on existing ones. System processes (Agile, Scrum, CMMI, Basic) have no per-process token; their create/administer security lives at the `AllProcesses` (root) scope.
+
+## Examples
+
+## Example 1: Allow a group to create child processes (org-wide)
+
+``` PowerShell
+Configuration ExampleConfig {
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    Node localhost {
+        AzDoProcessPermission AllowCreateProcesses {
+            Ensure      = 'Present'
+            ProcessName = 'AllProcesses'
+            isInherited = $true
+            Permissions = @(
+                @{
+                    Identity   = '[MyOrg]\Process Authors'
+                    Permission = @{
+                        'Create' = 'Allow'
+                        'Edit'   = 'Allow'
+                    }
+                }
+            )
+        }
+    }
+}
+
+Start-DscConfiguration -Path ./ExampleConfig -Wait -Verbose
+```
+
+## Example 2: Sample Configuration using Invoke-DSCResource
+
+``` PowerShell
+# Return the current configuration for AzDoProcessPermission
+$properties = @{
+    ProcessName = 'AllProcesses'
+    isInherited = $true
+    Permissions = @(
+        @{
+            Identity   = '[MyOrg]\Process Authors'
+            Permission = @{
+                'Create' = 'Allow'
+            }
+        }
+    )
+}
+
+Invoke-DscResource -Name 'AzDoProcessPermission' -Method Get -Property $properties -ModuleName 'AzureDevOpsDsc'
+```
+
+## Example 3: Sample Configuration using AzDO-DSC-LCM
+
+``` YAML
+parameters: {}
+
+variables: {
+  OrganizationName: MyOrg
+}
+
+resources:
+- name: Allow Process Authors to create processes
+  type: AzureDevOpsDsc/AzDoProcessPermission
+  properties:
+    ProcessName: AllProcesses
+    isInherited: true
+    Permissions:
+      - Identity: '[$OrganizationName]\Process Authors'
+        Permission:
+          Create: Allow
+          Edit: Allow
+    Ensure: Present
+```
+
+LCM Initialization:
+
+``` PowerShell
+
+$params = @{
+    AzureDevopsOrganizationName = "SampleAzDoOrgName"
+    ConfigurationDirectory      = "C:\Datum\DSCOutput\"
+    ConfigurationUrl            = 'https://configuration-path'
+    JITToken                    = 'SampleJITToken'
+    Mode                        = 'Set'
+    AuthenticationType          = 'ManagedIdentity'
+    ReportPath                  = 'C:\Datum\DSCOutput\Reports'
+}
+
+Invoke-AzDoLCM @params
+```

--- a/source/Examples/Resources/AzDoTeamSettings.md
+++ b/source/Examples/Resources/AzDoTeamSettings.md
@@ -1,0 +1,130 @@
+# DSC AzDoTeamSettings Resource
+
+## Syntax
+
+```PowerShell
+AzDoTeamSettings [string] #ResourceName
+{
+    ProjectName              = [String]$ProjectName
+    TeamName                 = [String]$TeamName
+    [ BacklogIterationPath  = [String]$BacklogIterationPath ]
+    [ DefaultIterationPath  = [String]$DefaultIterationPath ]
+    [ IterationPaths        = [String[]]$IterationPaths ]
+    [ DefaultAreaPath       = [String]$DefaultAreaPath ]
+    [ AreaPaths             = [String[]]$AreaPaths ]
+    [ WorkingDays           = [String[]]$WorkingDays ]
+    [ BugsBehavior          = [String] {'asRequirements', 'asTasks', 'off'} ]
+    [ Ensure                = [String] {'Present', 'Absent'} ]
+}
+```
+
+## Properties
+
+### Common Properties
+
+- **ProjectName**: The name of the Azure DevOps project. This property is mandatory and serves as the key property for the resource.
+- **TeamName**: The name of the team whose settings are managed. This property is mandatory.
+- **BacklogIterationPath**: The backlog iteration path for the team.
+- **DefaultIterationPath**: The default iteration path for new work items.
+- **IterationPaths**: The iteration paths selected for the team.
+- **DefaultAreaPath**: The default area path for the team.
+- **AreaPaths**: The area paths assigned to the team.
+- **WorkingDays**: The team's working days, for example `@('monday','tuesday','wednesday','thursday','friday')`.
+- **BugsBehavior**: How bugs are shown on backlogs and boards. Valid values are `asRequirements`, `asTasks` and `off`.
+- **Ensure**: Specifies the desired state. This resource configures an existing team's settings and cannot be removed, so `Absent` is a no-op.
+
+## Additional Information
+
+This resource configures an existing Azure DevOps team's board/backlog settings: iteration and area paths, working days, and bug behaviour. The team itself is managed by the `AzDoTeam` resource. Because team settings cannot be deleted, `Ensure = 'Absent'` is treated as a no-op.
+
+## Examples
+
+## Example 1: Sample Configuration using AzDoTeamSettings Resource
+
+``` PowerShell
+Configuration ExampleConfig {
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    Node localhost {
+        AzDoTeamSettings ConfigureTeam {
+            Ensure               = 'Present'
+            ProjectName          = 'MyProject'
+            TeamName             = 'MyProject Team'
+            BacklogIterationPath = 'MyProject'
+            DefaultIterationPath = 'MyProject\Sprint 1'
+            IterationPaths       = @('MyProject\Sprint 1', 'MyProject\Sprint 2')
+            DefaultAreaPath      = 'MyProject'
+            AreaPaths            = @('MyProject')
+            WorkingDays          = @('monday', 'tuesday', 'wednesday', 'thursday', 'friday')
+            BugsBehavior         = 'asRequirements'
+        }
+    }
+}
+
+Start-DscConfiguration -Path ./ExampleConfig -Wait -Verbose
+```
+
+## Example 2: Sample Configuration using Invoke-DSCResource
+
+``` PowerShell
+# Return the current configuration for AzDoTeamSettings
+$properties = @{
+    ProjectName = 'MyProject'
+    TeamName    = 'MyProject Team'
+}
+
+Invoke-DscResource -Name 'AzDoTeamSettings' -Method Get -Property $properties -ModuleName 'AzureDevOpsDsc'
+```
+
+## Example 3: Sample Configuration using AzDO-DSC-LCM
+
+``` YAML
+parameters: {}
+
+variables: {
+  ProjectName: MyProject,
+  TeamName: MyProject Team
+}
+
+resources:
+- name: Configure Team Settings
+  type: AzureDevOpsDsc/AzDoTeamSettings
+  dependsOn:
+    - AzureDevOpsDsc/AzDoTeam/MyProject Team
+  properties:
+    ProjectName: $ProjectName
+    TeamName: $TeamName
+    BacklogIterationPath: $ProjectName
+    DefaultIterationPath: $ProjectName\Sprint 1
+    IterationPaths:
+      - $ProjectName\Sprint 1
+      - $ProjectName\Sprint 2
+    DefaultAreaPath: $ProjectName
+    AreaPaths:
+      - $ProjectName
+    WorkingDays:
+      - monday
+      - tuesday
+      - wednesday
+      - thursday
+      - friday
+    BugsBehavior: asRequirements
+    Ensure: Present
+```
+
+LCM Initialization:
+
+``` PowerShell
+
+$params = @{
+    AzureDevopsOrganizationName = "SampleAzDoOrgName"
+    ConfigurationDirectory      = "C:\Datum\DSCOutput\"
+    ConfigurationUrl            = 'https://configuration-path'
+    JITToken                    = 'SampleJITToken'
+    Mode                        = 'Set'
+    AuthenticationType          = 'ManagedIdentity'
+    ReportPath                  = 'C:\Datum\DSCOutput\Reports'
+}
+
+Invoke-AzDoLCM @params
+```

--- a/source/Examples/Resources/AzDoTeamSettings/1-ConfigureAzDoTeamSettings.ps1
+++ b/source/Examples/Resources/AzDoTeamSettings/1-ConfigureAzDoTeamSettings.ps1
@@ -1,0 +1,34 @@
+<#
+    .DESCRIPTION
+        This example shows how to configure the iteration and area paths for an Azure DevOps team.
+#>
+
+New-AzDoAuthenticationProvider -OrganizationName 'test-organization' -PersonalAccessToken 'my-pat'
+
+Configuration Example
+{
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    node localhost
+    {
+        AzDoTeamSettings 'ConfigureFrontendTeam'
+        {
+            Ensure               = 'Present'
+            ProjectName          = 'MyProject'
+            TeamName             = 'Frontend Team'
+
+            # Iteration configuration
+            BacklogIterationPath = 'MyProject'
+            DefaultIterationPath = 'MyProject\Sprint 1'
+            IterationPaths       = @('MyProject\Sprint 1', 'MyProject\Sprint 2')
+
+            # Area-path configuration
+            DefaultAreaPath      = 'MyProject\Frontend'
+            AreaPaths            = @('MyProject\Frontend', 'MyProject\Frontend\Web')
+
+            # General team settings
+            WorkingDays          = @('monday', 'tuesday', 'wednesday', 'thursday', 'friday')
+            BugsBehavior         = 'asRequirements'
+        }
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Get-DevOpsArtifactFeedRetentionPolicy.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Get-DevOpsArtifactFeedRetentionPolicy.ps1
@@ -1,0 +1,29 @@
+Function Get-DevOpsArtifactFeedRetentionPolicy
+{
+    <#
+        .SYNOPSIS
+            Retrieves the retention policy (artifact lifecycle) for an Azure Artifacts feed.
+        .DESCRIPTION
+            Returns the feed's retention policy object ('countLimit' and
+            'daysToKeepRecentlyDownloadedPackages'), or $null if no policy is configured.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ApiUri,
+        [Parameter()][string]$ProjectName,
+        [Parameter(Mandatory)][string]$FeedId,
+        [Parameter()][string]$ApiVersion = '7.1-preview.1'
+    )
+    $baseUri = if ($ProjectName) { '{0}/{1}' -f $ApiUri.TrimEnd('/'), $ProjectName } else { $ApiUri.TrimEnd('/') }
+    $params = @{
+        Uri    = '{0}/_apis/packaging/feeds/{1}/retentionpolicies?api-version={2}' -f $baseUri, $FeedId, $ApiVersion
+        Method = 'GET'
+    }
+    try   { return Invoke-AzDevOpsApiRestMethod @params }
+    catch
+    {
+        # A feed with no retention policy returns 404 — treat that as "no policy" rather than an error.
+        Write-Verbose "[Get-DevOpsArtifactFeedRetentionPolicy] No retention policy for feed '$FeedId': $_"
+        return $null
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/List-DevOpsArtifactFeedViews.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/List-DevOpsArtifactFeedViews.ps1
@@ -1,0 +1,17 @@
+Function List-DevOpsArtifactFeedViews
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ApiUri,
+        [Parameter()][string]$ProjectName,
+        [Parameter(Mandatory)][string]$FeedId,
+        [Parameter()][string]$ApiVersion = '7.1-preview.1'
+    )
+    $baseUri = if ($ProjectName) { '{0}/{1}' -f $ApiUri.TrimEnd('/'), $ProjectName } else { $ApiUri.TrimEnd('/') }
+    $params = @{
+        Uri    = '{0}/_apis/packaging/feeds/{1}/views?api-version={2}' -f $baseUri, $FeedId, $ApiVersion
+        Method = 'GET'
+    }
+    try   { return (Invoke-AzDevOpsApiRestMethod @params).value }
+    catch { Throw "[List-DevOpsArtifactFeedViews] Failed to list views for feed '$FeedId': $_" }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/New-DevOpsArtifactFeedView.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/New-DevOpsArtifactFeedView.ps1
@@ -1,0 +1,22 @@
+Function New-DevOpsArtifactFeedView
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ApiUri,
+        [Parameter()][string]$ProjectName,
+        [Parameter(Mandatory)][string]$FeedId,
+        [Parameter(Mandatory)][string]$ViewName,
+        [Parameter()][string]$ViewType = 'release',
+        [Parameter()][string]$ViewVisibility = 'collection',
+        [Parameter()][string]$ApiVersion = '7.1-preview.1'
+    )
+    $baseUri = if ($ProjectName) { '{0}/{1}' -f $ApiUri.TrimEnd('/'), $ProjectName } else { $ApiUri.TrimEnd('/') }
+    $params = @{
+        Uri         = '{0}/_apis/packaging/feeds/{1}/views?api-version={2}' -f $baseUri, $FeedId, $ApiVersion
+        Method      = 'POST'
+        ContentType = 'application/json'
+        Body        = @{ name = $ViewName; type = $ViewType; visibility = $ViewVisibility } | ConvertTo-Json
+    }
+    try   { return Invoke-AzDevOpsApiRestMethod @params }
+    catch { Throw "[New-DevOpsArtifactFeedView] Failed to create view '$ViewName' on feed '$FeedId': $_" }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Remove-DevOpsArtifactFeedView.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Remove-DevOpsArtifactFeedView.ps1
@@ -1,0 +1,18 @@
+Function Remove-DevOpsArtifactFeedView
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ApiUri,
+        [Parameter()][string]$ProjectName,
+        [Parameter(Mandatory)][string]$FeedId,
+        [Parameter(Mandatory)][string]$ViewId,
+        [Parameter()][string]$ApiVersion = '7.1-preview.1'
+    )
+    $baseUri = if ($ProjectName) { '{0}/{1}' -f $ApiUri.TrimEnd('/'), $ProjectName } else { $ApiUri.TrimEnd('/') }
+    $params = @{
+        Uri    = '{0}/_apis/packaging/feeds/{1}/views/{2}?api-version={3}' -f $baseUri, $FeedId, $ViewId, $ApiVersion
+        Method = 'DELETE'
+    }
+    try   { return Invoke-AzDevOpsApiRestMethod @params }
+    catch { Throw "[Remove-DevOpsArtifactFeedView] Failed to remove view '$ViewId' from feed '$FeedId': $_" }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Resolve-DevOpsArtifactFeed.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Resolve-DevOpsArtifactFeed.ps1
@@ -1,0 +1,42 @@
+Function Resolve-DevOpsArtifactFeed
+{
+    <#
+        .SYNOPSIS
+            Resolves an Azure Artifacts feed by name, checking the cache first and then the live API.
+        .DESCRIPTION
+            Returns the feed object for the given project/feed name combination, or $null if it cannot
+            be found. Checks the 'LiveArtifactFeeds' cache first, then falls back to a project-scope and
+            finally an organization-scope live lookup (mirroring Get-AzDoArtifactFeed).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectName,
+        [Parameter(Mandatory)][string]$FeedName
+    )
+
+    $cacheKey = '{0}\{1}' -f $ProjectName, $FeedName
+    $feed     = Get-CacheItem -Key $cacheKey -Type 'LiveArtifactFeeds'
+    if ($feed) { return $feed }
+
+    $apiUri = 'https://feeds.dev.azure.com/{0}/' -f (Get-AzDoOrganizationName)
+
+    try
+    {
+        $feed = List-DevOpsArtifactFeeds -ApiUri $apiUri -ProjectName $ProjectName |
+            Where-Object { $_.name -eq $FeedName } | Select-Object -First 1
+    }
+    catch { Write-Verbose "[Resolve-DevOpsArtifactFeed] Project-scope list failed: $_" }
+
+    if (-not $feed)
+    {
+        try
+        {
+            $feed = List-DevOpsArtifactFeeds -ApiUri $apiUri |
+                Where-Object { $_.name -eq $FeedName } | Select-Object -First 1
+        }
+        catch { Write-Verbose "[Resolve-DevOpsArtifactFeed] Org-scope list failed: $_" }
+    }
+
+    if ($feed) { Add-CacheItem -Key $cacheKey -Value $feed -Type 'LiveArtifactFeeds' }
+    return $feed
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Set-DevOpsArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Set-DevOpsArtifactFeedSettings.ps1
@@ -1,0 +1,56 @@
+Function Set-DevOpsArtifactFeedSettings
+{
+    <#
+        .SYNOPSIS
+            Applies the configurable settings of an Azure Artifacts feed.
+        .DESCRIPTION
+            Updates the upstream sources and hide-deleted-package-versions behaviour via a PATCH to the
+            feed, and the artifact lifecycle (retention policy) via a PUT to the feed's retention
+            policies endpoint. The retention policy is only applied when 'RetentionCountLimit' is
+            greater than zero.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ApiUri,
+        [Parameter()][string]$ProjectName,
+        [Parameter(Mandatory)][string]$FeedId,
+        [Parameter()][object[]]$UpstreamSources,
+        [Parameter()][bool]$HideDeletedPackageVersions = $true,
+        [Parameter()][int]$RetentionCountLimit = 0,
+        [Parameter()][int]$DaysToKeepRecentlyDownloadedPackages = 0,
+        [Parameter()][string]$ApiVersion = '7.1-preview.1'
+    )
+
+    $baseUri = if ($ProjectName) { '{0}/{1}' -f $ApiUri.TrimEnd('/'), $ProjectName } else { $ApiUri.TrimEnd('/') }
+
+    # --- Feed-level settings (PATCH) -----------------------------------------------------
+    $body = @{ hideDeletedPackageVersions = $HideDeletedPackageVersions }
+    if ($PSBoundParameters.ContainsKey('UpstreamSources')) { $body.upstreamSources = @($UpstreamSources) }
+
+    try
+    {
+        $feed = Invoke-AzDevOpsApiRestMethod `
+            -Uri ('{0}/_apis/packaging/feeds/{1}?api-version={2}' -f $baseUri, $FeedId, $ApiVersion) `
+            -Method Patch -ContentType 'application/json' -Body ($body | ConvertTo-Json -Depth 10)
+    }
+    catch { Throw "[Set-DevOpsArtifactFeedSettings] Failed to update settings for feed '$FeedId': $_" }
+
+    # --- Artifact lifecycle / retention policy (PUT) -------------------------------------
+    # A RetentionCountLimit of 0 means retention is not managed by this resource.
+    if ($RetentionCountLimit -gt 0)
+    {
+        $retentionBody = @{
+            countLimit                           = $RetentionCountLimit
+            daysToKeepRecentlyDownloadedPackages = $DaysToKeepRecentlyDownloadedPackages
+        }
+        try
+        {
+            Invoke-AzDevOpsApiRestMethod `
+                -Uri ('{0}/_apis/packaging/feeds/{1}/retentionpolicies?api-version={2}' -f $baseUri, $FeedId, $ApiVersion) `
+                -Method Put -ContentType 'application/json' -Body ($retentionBody | ConvertTo-Json) | Out-Null
+        }
+        catch { Throw "[Set-DevOpsArtifactFeedSettings] Failed to update retention policy for feed '$FeedId': $_" }
+    }
+
+    return $feed
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Set-DevOpsArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Set-DevOpsArtifactFeedSettings.ps1
@@ -25,7 +25,7 @@ Function Set-DevOpsArtifactFeedSettings
 
     # --- Feed-level settings (PATCH) -----------------------------------------------------
     $body = @{ hideDeletedPackageVersions = $HideDeletedPackageVersions }
-    if ($PSBoundParameters.ContainsKey('UpstreamSources')) { $body.upstreamSources = @($UpstreamSources) }
+    if ($UpstreamSources) { $body.upstreamSources = @($UpstreamSources) }
 
     try
     {

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Set-DevOpsArtifactFeedView.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Set-DevOpsArtifactFeedView.ps1
@@ -1,0 +1,29 @@
+Function Set-DevOpsArtifactFeedView
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ApiUri,
+        [Parameter()][string]$ProjectName,
+        [Parameter(Mandatory)][string]$FeedId,
+        [Parameter(Mandatory)][string]$ViewId,
+        [Parameter()][string]$ViewName,
+        [Parameter()][string]$ViewType,
+        [Parameter()][string]$ViewVisibility,
+        [Parameter()][string]$ApiVersion = '7.1-preview.1'
+    )
+    $baseUri = if ($ProjectName) { '{0}/{1}' -f $ApiUri.TrimEnd('/'), $ProjectName } else { $ApiUri.TrimEnd('/') }
+
+    $body = @{}
+    if ($ViewName)       { $body.name       = $ViewName }
+    if ($ViewType)       { $body.type       = $ViewType }
+    if ($ViewVisibility) { $body.visibility = $ViewVisibility }
+
+    $params = @{
+        Uri         = '{0}/_apis/packaging/feeds/{1}/views/{2}?api-version={3}' -f $baseUri, $FeedId, $ViewId, $ApiVersion
+        Method      = 'PATCH'
+        ContentType = 'application/json'
+        Body        = $body | ConvertTo-Json
+    }
+    try   { return Invoke-AzDevOpsApiRestMethod @params }
+    catch { Throw "[Set-DevOpsArtifactFeedView] Failed to update view '$ViewId' on feed '$FeedId': $_" }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Get-DevOpsProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Get-DevOpsProcess.ps1
@@ -1,0 +1,56 @@
+<#
+.SYNOPSIS
+Gets a single Azure DevOps process, including its parent process type id.
+
+.DESCRIPTION
+Retrieves a process by its type id using the Work Item Tracking Process REST API
+(GET _apis/work/processes/{processTypeId}). Unlike the older _apis/process/processes list (used to seed
+the cache), this endpoint returns parentProcessTypeId, which is required to build a process ACL token
+of the form $PROCESS:{parentProcessTypeId}:{processTypeId}.
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER ProcessTypeId
+The type id (GUID) of the process to retrieve.
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1-preview.2'.
+
+.OUTPUTS
+The process object (typeId, name, description, parentProcessTypeId, customizationType), or $null.
+
+.EXAMPLE
+Get-DevOpsProcess -Organization 'myorg' -ProcessTypeId '73295818-1008-4d75-87f8-2192975c71cf'
+#>
+function Get-DevOpsProcess
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ProcessTypeId,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1-preview.2'
+    )
+
+    $params = @{
+        Uri    = 'https://dev.azure.com/{0}/_apis/work/processes/{1}?api-version={2}' -f $Organization, $ProcessTypeId, $ApiVersion
+        Method = 'Get'
+    }
+
+    try
+    {
+        return Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        Write-Verbose "[Get-DevOpsProcess] Lookup of process '$ProcessTypeId' failed: $_"
+        return $null
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Get-DevOpsProcessAclToken.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Get-DevOpsProcessAclToken.ps1
@@ -1,0 +1,69 @@
+<#
+.SYNOPSIS
+Builds the Process security namespace ACL token for a given process scope.
+
+.DESCRIPTION
+Returns the ACL token used by the 'Process' security namespace:
+
+  - The sentinel 'AllProcesses' resolves to the org-wide root token '$PROCESS', which governs who can
+    create, edit, delete and administer processes across the organization (the scope that grants the
+    ability to create inherited/child processes).
+  - A specific inherited process name resolves to '$PROCESS:{parentProcessTypeId}:{processTypeId}'.
+
+System processes (Agile, Scrum, CMMI, Basic) have no per-process ACL token; their create/administer
+security lives at the root scope, so passing a system process name returns $null with a warning.
+
+.PARAMETER ProcessName
+The process name, or the sentinel 'AllProcesses' for the org-wide root scope.
+
+.PARAMETER OrganizationName
+The name of the Azure DevOps organization.
+
+.OUTPUTS
+The ACL token string, or $null when the scope cannot be resolved to a token.
+
+.EXAMPLE
+Get-DevOpsProcessAclToken -ProcessName 'AllProcesses' -OrganizationName 'myorg'   # -> '$PROCESS'
+
+.EXAMPLE
+Get-DevOpsProcessAclToken -ProcessName 'Contoso Agile' -OrganizationName 'myorg'  # -> '$PROCESS:{parent}:{id}'
+#>
+function Get-DevOpsProcessAclToken
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$ProcessName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OrganizationName
+    )
+
+    # Org-wide root scope.
+    if ($ProcessName -eq 'AllProcesses')
+    {
+        return '$PROCESS'
+    }
+
+    $process = Resolve-DevOpsProcess -ProcessName $ProcessName -OrganizationName $OrganizationName
+    if ($null -eq $process)
+    {
+        Write-Warning "[Get-DevOpsProcessAclToken] Process '$ProcessName' not found; cannot build a Process ACL token."
+        return $null
+    }
+
+    # The list/cache shape lacks parentProcessTypeId; fetch the full process to obtain it.
+    $detail = Get-DevOpsProcess -Organization $OrganizationName -ProcessTypeId $process.id
+    $parentProcessTypeId = $detail.parentProcessTypeId
+
+    $emptyGuid = '00000000-0000-0000-0000-000000000000'
+    if ([string]::IsNullOrEmpty($parentProcessTypeId) -or $parentProcessTypeId -eq $emptyGuid)
+    {
+        Write-Warning "[Get-DevOpsProcessAclToken] '$ProcessName' is a system process with no per-process ACL token. Use 'AllProcesses' to manage org-wide process permissions."
+        return $null
+    }
+
+    return '$PROCESS:{0}:{1}' -f $parentProcessTypeId, $process.id
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/New-DevOpsProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/New-DevOpsProcess.ps1
@@ -1,0 +1,80 @@
+<#
+.SYNOPSIS
+Creates a new inherited process in Azure DevOps.
+
+.DESCRIPTION
+Creates an inherited process derived from an existing (system or custom) parent process using the
+Azure DevOps Work Item Tracking Process REST API (POST _apis/work/processes).
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER Name
+The name of the new inherited process.
+
+.PARAMETER ParentProcessTypeId
+The type id (GUID) of the parent process to inherit from.
+
+.PARAMETER Description
+An optional description for the process.
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1-preview.2', which supports inherited process creation.
+
+.EXAMPLE
+New-DevOpsProcess -Organization 'myorg' -Name 'MyAgile' -ParentProcessTypeId 'adcc42ab-9882-485e-a3ed-7678f01f66bc' -Description 'Custom Agile'
+#>
+function New-DevOpsProcess
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParentProcessTypeId,
+
+        [Parameter()]
+        [string]$Description = '',
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1-preview.2'
+    )
+
+    $body = @{
+        name                = $Name
+        parentProcessTypeId = $ParentProcessTypeId
+        description         = $Description
+    }
+
+    $params = @{
+        Uri    = 'https://dev.azure.com/{0}/_apis/work/processes?api-version={1}' -f $Organization, $ApiVersion
+        Method = 'POST'
+        Body   = $body | ConvertTo-Json
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Name, 'Create inherited process'))
+    {
+        return
+    }
+
+    try
+    {
+        $response = Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        throw "[New-DevOpsProcess] Failed to create process '$Name' in '$Organization': $_"
+    }
+
+    if ($null -eq $response)
+    {
+        throw "[New-DevOpsProcess] Failed to create process '$Name'. No response returned."
+    }
+
+    return $response
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Remove-DevOpsProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Remove-DevOpsProcess.ps1
@@ -1,0 +1,55 @@
+<#
+.SYNOPSIS
+Removes an inherited process from Azure DevOps.
+
+.DESCRIPTION
+Deletes an inherited process using the Azure DevOps Work Item Tracking Process REST API
+(DELETE _apis/work/processes/{processTypeId}). A process that is in use by a project, or a system
+process, cannot be deleted and the API returns an error.
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER ProcessTypeId
+The type id (GUID) of the process to delete.
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1-preview.2'.
+
+.EXAMPLE
+Remove-DevOpsProcess -Organization 'myorg' -ProcessTypeId '...'
+#>
+function Remove-DevOpsProcess
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ProcessTypeId,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1-preview.2'
+    )
+
+    $params = @{
+        Uri    = 'https://dev.azure.com/{0}/_apis/work/processes/{1}?api-version={2}' -f $Organization, $ProcessTypeId, $ApiVersion
+        Method = 'DELETE'
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($ProcessTypeId, 'Delete inherited process'))
+    {
+        return
+    }
+
+    try
+    {
+        return Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        throw "[Remove-DevOpsProcess] Failed to delete process '$ProcessTypeId' in '$Organization': $_"
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Resolve-DevOpsProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Resolve-DevOpsProcess.ps1
@@ -1,0 +1,52 @@
+<#
+.SYNOPSIS
+Resolves an Azure DevOps process by name from cache, falling back to a live lookup.
+
+.DESCRIPTION
+Looks up a process in the 'LiveProcesses' cache by name. If it is not cached (e.g. created after the
+last cache initialization), it falls back to a live 'List-DevOpsProcess' query and matches by name. The
+returned object exposes an 'id' property (the process type id GUID) used to build REST routes and ACL
+tokens, matching the shape stored by the cache initializer.
+
+.PARAMETER ProcessName
+The name of the process to resolve.
+
+.PARAMETER OrganizationName
+The name of the Azure DevOps organization.
+
+.OUTPUTS
+The resolved process object, or $null when no process with that name exists.
+
+.EXAMPLE
+Resolve-DevOpsProcess -ProcessName 'Agile' -OrganizationName 'myorg'
+#>
+function Resolve-DevOpsProcess
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$ProcessName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OrganizationName
+    )
+
+    $process = Get-CacheItem -Key $ProcessName -Type 'LiveProcesses'
+    if ($null -ne $process)
+    {
+        return $process
+    }
+
+    Write-Verbose "[Resolve-DevOpsProcess] Process '$ProcessName' not in cache — falling back to live API lookup."
+    $process = List-DevOpsProcess -Organization $OrganizationName |
+        Where-Object { $_.name -eq $ProcessName } | Select-Object -First 1
+
+    if ($null -ne $process)
+    {
+        Add-CacheItem -Key $process.name -Value $process -Type 'LiveProcesses' -SuppressWarning
+    }
+
+    return $process
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Update-DevOpsProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Update-DevOpsProcess.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+Edits an existing inherited process in Azure DevOps.
+
+.DESCRIPTION
+Updates the name and/or description of an inherited process using the Azure DevOps Work Item Tracking
+Process REST API (PATCH _apis/work/processes/{processTypeId}). System processes cannot be edited.
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER ProcessTypeId
+The type id (GUID) of the process to edit.
+
+.PARAMETER Name
+The new name for the process.
+
+.PARAMETER Description
+The new description for the process.
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1-preview.2'.
+
+.EXAMPLE
+Update-DevOpsProcess -Organization 'myorg' -ProcessTypeId '...' -Name 'MyAgile' -Description 'Updated'
+#>
+function Update-DevOpsProcess
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ProcessTypeId,
+
+        [Parameter()]
+        [string]$Name,
+
+        [Parameter()]
+        [string]$Description,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1-preview.2'
+    )
+
+    # Only send the fields that were supplied so we never blank out a value we were not asked to change.
+    $body = @{}
+    if ($PSBoundParameters.ContainsKey('Name'))        { $body.name        = $Name }
+    if ($PSBoundParameters.ContainsKey('Description')) { $body.description = $Description }
+
+    if ($body.Keys.Count -eq 0)
+    {
+        Write-Verbose '[Update-DevOpsProcess] No updatable fields supplied; nothing to do.'
+        return
+    }
+
+    $params = @{
+        Uri    = 'https://dev.azure.com/{0}/_apis/work/processes/{1}?api-version={2}' -f $Organization, $ProcessTypeId, $ApiVersion
+        Method = 'PATCH'
+        Body   = $body | ConvertTo-Json
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($ProcessTypeId, 'Edit inherited process'))
+    {
+        return
+    }
+
+    try
+    {
+        return Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        throw "[Update-DevOpsProcess] Failed to edit process '$ProcessTypeId' in '$Organization': $_"
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Team/Get-DevOpsTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Team/Get-DevOpsTeamSettings.ps1
@@ -1,0 +1,41 @@
+Function Get-DevOpsTeamSettings
+{
+    <#
+        .SYNOPSIS
+            Retrieves the iteration and area-path configuration for an Azure DevOps team.
+        .DESCRIPTION
+            Combines the team's 'teamsettings' (default and backlog iteration) and
+            'teamfieldvalues' (default area path and assigned area paths) into a single object.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ApiUri,
+        [Parameter(Mandatory)][string]$ProjectId,
+        [Parameter(Mandatory)][string]$TeamId,
+        [Parameter()][string]$ApiVersion = '7.1'
+    )
+
+    $base = '{0}/{1}/{2}/_apis/work/teamsettings' -f $ApiUri.TrimEnd('/'), $ProjectId, $TeamId
+
+    try
+    {
+        $settings    = Invoke-AzDevOpsApiRestMethod -Uri ('{0}?api-version={1}' -f $base, $ApiVersion) -Method Get
+        $fieldValues = Invoke-AzDevOpsApiRestMethod -Uri ('{0}/teamfieldvalues?api-version={1}' -f $base, $ApiVersion) -Method Get
+        $iterations  = Invoke-AzDevOpsApiRestMethod -Uri ('{0}/iterations?api-version={1}' -f $base, $ApiVersion) -Method Get
+    }
+    catch
+    {
+        Throw "[Get-DevOpsTeamSettings] Failed to retrieve team settings for team '$TeamId': $_"
+    }
+
+    return [PSCustomObject]@{
+        BacklogIterationPath = $settings.backlogIteration.path
+        DefaultIterationPath = $settings.defaultIteration.path
+        IterationPaths       = @($iterations.value  | ForEach-Object { $_.path })
+        DefaultAreaPath      = $fieldValues.defaultValue
+        AreaPaths            = @($fieldValues.values | ForEach-Object { $_.value })
+        WorkingDays          = @($settings.workingDays)
+        BugsBehavior         = $settings.bugsBehavior
+        Raw                  = [PSCustomObject]@{ Settings = $settings; FieldValues = $fieldValues; Iterations = $iterations }
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Team/Set-DevOpsTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Team/Set-DevOpsTeamSettings.ps1
@@ -1,0 +1,108 @@
+Function Set-DevOpsTeamSettings
+{
+    <#
+        .SYNOPSIS
+            Applies the iteration and area-path configuration for an Azure DevOps team.
+        .DESCRIPTION
+            Resolves iteration and area paths to classification-node identifiers and applies them
+            to the team via the 'teamsettings', 'teamsettings/iterations' and
+            'teamsettings/teamfieldvalues' endpoints.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$ApiUri,
+        [Parameter(Mandatory)][string]$ProjectId,
+        [Parameter(Mandatory)][string]$TeamId,
+        [Parameter()][string]$BacklogIterationPath,
+        [Parameter()][string]$DefaultIterationPath,
+        [Parameter()][string[]]$IterationPaths,
+        [Parameter()][string]$DefaultAreaPath,
+        [Parameter()][string[]]$AreaPaths,
+        [Parameter()][string[]]$WorkingDays,
+        [Parameter()][ValidateSet('asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
+        [Parameter()][string]$ApiVersion = '7.1'
+    )
+
+    $org  = $ApiUri.TrimEnd('/')
+    $base = '{0}/{1}/{2}/_apis/work/teamsettings' -f $org, $ProjectId, $TeamId
+
+    # Resolve a classification node (iteration|area) path to its node identifier.
+    function Resolve-ClassificationNode
+    {
+        param([string]$Structure, [string]$Path)
+        if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
+        # Strip a leading '<Project>\' prefix so the path is relative to the node root.
+        $relative = ($Path -replace '^[^\\/]+[\\/]', '') -replace '\\', '/'
+        $uri = '{0}/{1}/_apis/wit/classificationnodes/{2}/{3}?api-version={4}' -f $org, $ProjectId, $Structure, $relative, $ApiVersion
+        try   { return Invoke-AzDevOpsApiRestMethod -Uri $uri -Method Get }
+        catch { Throw "[Set-DevOpsTeamSettings] Failed to resolve $Structure path '$Path': $_" }
+    }
+
+    try
+    {
+        # --- Iterations -----------------------------------------------------------------
+        $settingsBody = @{}
+        if ($PSBoundParameters.ContainsKey('BacklogIterationPath') -and $BacklogIterationPath)
+        {
+            $settingsBody.backlogIteration = (Resolve-ClassificationNode -Structure 'iterations' -Path $BacklogIterationPath).identifier
+        }
+        if ($PSBoundParameters.ContainsKey('DefaultIterationPath') -and $DefaultIterationPath)
+        {
+            $settingsBody.defaultIteration = (Resolve-ClassificationNode -Structure 'iterations' -Path $DefaultIterationPath).identifier
+        }
+        if ($PSBoundParameters.ContainsKey('WorkingDays'))
+        {
+            $settingsBody.workingDays = @($WorkingDays)
+        }
+        if ($PSBoundParameters.ContainsKey('BugsBehavior') -and $BugsBehavior)
+        {
+            $settingsBody.bugsBehavior = $BugsBehavior
+        }
+        if ($settingsBody.Count -gt 0 -and $PSCmdlet.ShouldProcess($TeamId, 'Update team iteration settings'))
+        {
+            Invoke-AzDevOpsApiRestMethod -Uri ('{0}?api-version={1}' -f $base, $ApiVersion) -Method Patch `
+                -ContentType 'application/json' -Body ($settingsBody | ConvertTo-Json -Depth 5) | Out-Null
+        }
+
+        # Assign the team's iteration backlog (the iterations the team participates in).
+        if ($PSBoundParameters.ContainsKey('IterationPaths') -and $IterationPaths)
+        {
+            foreach ($iterationPath in $IterationPaths)
+            {
+                $node = Resolve-ClassificationNode -Structure 'iterations' -Path $iterationPath
+                if ($node -and $PSCmdlet.ShouldProcess($iterationPath, 'Assign iteration to team'))
+                {
+                    Invoke-AzDevOpsApiRestMethod -Uri ('{0}/iterations?api-version={1}' -f $base, $ApiVersion) -Method Post `
+                        -ContentType 'application/json' -Body (@{ id = $node.identifier } | ConvertTo-Json) | Out-Null
+                }
+            }
+        }
+
+        # --- Area paths (team field values) --------------------------------------------
+        if ($PSBoundParameters.ContainsKey('DefaultAreaPath') -or $PSBoundParameters.ContainsKey('AreaPaths'))
+        {
+            $values = @()
+            foreach ($areaPath in @($AreaPaths)) { if ($areaPath) { $values += @{ value = $areaPath; includeChildren = $true } } }
+
+            $defaultValue = $DefaultAreaPath
+            if ([string]::IsNullOrWhiteSpace($defaultValue) -and $values.Count -gt 0) { $defaultValue = $values[0].value }
+            if ($defaultValue -and -not ($values | Where-Object { $_.value -eq $defaultValue }))
+            {
+                $values += @{ value = $defaultValue; includeChildren = $true }
+            }
+
+            $fieldBody = @{ defaultValue = $defaultValue; values = $values }
+            if ($PSCmdlet.ShouldProcess($TeamId, 'Update team area paths'))
+            {
+                Invoke-AzDevOpsApiRestMethod -Uri ('{0}/teamfieldvalues?api-version={1}' -f $base, $ApiVersion) -Method Patch `
+                    -ContentType 'application/json' -Body ($fieldBody | ConvertTo-Json -Depth 5) | Out-Null
+            }
+        }
+    }
+    catch
+    {
+        Throw "[Set-DevOpsTeamSettings] Failed to apply team settings for team '$TeamId': $_"
+    }
+
+    return Get-DevOpsTeamSettings -ApiUri $ApiUri -ProjectId $ProjectId -TeamId $TeamId -ApiVersion $ApiVersion
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Team/Set-DevOpsTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Team/Set-DevOpsTeamSettings.ps1
@@ -19,7 +19,7 @@ Function Set-DevOpsTeamSettings
         [Parameter()][string]$DefaultAreaPath,
         [Parameter()][string[]]$AreaPaths,
         [Parameter()][string[]]$WorkingDays,
-        [Parameter()][ValidateSet('asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
+        [Parameter()][ValidateSet('', 'asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
         [Parameter()][string]$ApiVersion = '7.1'
     )
 

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-ACLHashtable.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-ACLHashtable.ps1
@@ -152,7 +152,12 @@ Function ConvertTo-ACLHashtable
             Write-Verbose "[ConvertTo-ACLHashtable] ACEObject $($ACEObject | ConvertTo-Json)."
             Write-Verbose "[ConvertTo-ACLHashtable] Adding ACE to the ACEs Dictionary."
 
-            $ACLObject.acesDictionary.Add($ACE.Identity.value.ACLIdentity.descriptor, $ACEObject)
+            $descriptor = $ACE.Identity.value.ACLIdentity.descriptor
+            if ($null -eq $descriptor) {
+                Write-Warning "[ConvertTo-ACLHashtable] Skipping ACE with null descriptor."
+                continue
+            }
+            $ACLObject.acesDictionary.Add($descriptor, $ACEObject)
         }
 
         # Add the constructed ACL object (ACLObject) to the ACL List

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-FormattedToken.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-FormattedToken.ps1
@@ -68,6 +68,16 @@ Function ConvertTo-FormattedToken {
             $string = '$PROJECT:vstfs:///Classification/TeamProject/{0}' -f $Token.ProjectId
             break
         }
+        # Process permissions — org-wide root
+        {$_.type -eq 'ProcessRoot'} {
+            $string = '$PROCESS'
+            break
+        }
+        # Process permissions — specific process ($PROCESS:{parentId}:{processId})
+        {$_.type -eq 'Process'} {
+            $string = '$PROCESS:{0}:{1}' -f $Token.ParentProcessId, $Token.ProcessId
+            break
+        }
         # Build (Pipeline) permissions
         {$_.type -eq 'Build'} {
             $string = if ($Token.PipelineId) { '{0}/{1}' -f $Token.ProjectId, $Token.PipelineId }

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/New-ACLToken.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/New-ACLToken.ps1
@@ -177,6 +177,26 @@ Function New-ACLToken
             break
         }
 
+        # Process permissions — root ($PROCESS) or a specific process ($PROCESS:{parentId}:{processId}).
+        'Process' {
+            if ($TokenName -match $LocalizedDataAzACLTokenPatten.ProcessRootPermission)
+            {
+                $result.type = 'ProcessRoot'
+            }
+            elseif ($TokenName -match $LocalizedDataAzACLTokenPatten.ProcessPermission)
+            {
+                $result.type            = 'Process'
+                $result.ParentProcessId = $matches.ParentProcessId
+                $result.ProcessId       = $matches.ProcessId
+            }
+            else
+            {
+                $result.type = 'ProcessUnknown'
+                Write-Warning "[New-ACLToken] TokenName '$TokenName' does not match any known Process ACL Token Patterns."
+            }
+            break
+        }
+
         # Build / Pipeline permissions — resolve pipeline name to numeric ID for the API token.
         'Build' {
             if ($TokenName -match $LocalizedDataAzResourceTokenPatten.BuildPermission)

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Parse-ACLToken.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Parse-ACLToken.ps1
@@ -79,6 +79,15 @@ Function Parse-ACLToken
             }
         }
 
+        'Process' {
+            switch -regex ($Token.Trim())
+            {
+                $LocalizedDataAzACLTokenPatten.ProcessRootPermission { $result.type = 'ProcessRoot'; break }
+                $LocalizedDataAzACLTokenPatten.ProcessPermission     { $result.type = 'Process';     break }
+                default                                              { $result.type = 'ProcessUnknown'     }
+            }
+        }
+
         'Build' {
             switch -regex ($Token.Trim())
             {

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Test-AzDoArrayDrift.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Test-AzDoArrayDrift.ps1
@@ -1,0 +1,29 @@
+Function Test-AzDoArrayDrift
+{
+    <#
+        .SYNOPSIS
+            Returns $true when two string collections differ, tolerating null/empty inputs.
+        .DESCRIPTION
+            Compare-Object throws when a reference or difference collection is empty, because an
+            empty array unrolls to $null when bound to its (mandatory) parameters. This helper
+            normalises both sides to arrays, short-circuits on a count mismatch, and only calls
+            Compare-Object when both sides are non-empty — making array drift detection safe for
+            DSC resources where unmanaged properties arrive as $null.
+        .OUTPUTS
+            System.Boolean. $true if the collections differ; otherwise $false.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param(
+        [Parameter()][AllowNull()][object[]]$Reference,
+        [Parameter()][AllowNull()][object[]]$Difference
+    )
+
+    $ref  = @($Reference  | Where-Object { $null -ne $_ })
+    $diff = @($Difference | Where-Object { $null -ne $_ })
+
+    if ($ref.Count -ne $diff.Count) { return $true }
+    if ($diff.Count -eq 0)          { return $false }
+
+    return [bool](Compare-Object -ReferenceObject $ref -DifferenceObject $diff)
+}

--- a/source/Modules/AzureDevOpsDsc.Common/LocalizedData/000.LocalizedDataAzACLTokenPatten.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/LocalizedData/000.LocalizedDataAzACLTokenPatten.ps1
@@ -36,6 +36,9 @@ data LocalizedDataAzACLTokenPatten
         IterationPathPermission = '(vstfs:\/{3}Classification\/Node\/)(?<identifiers>[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})'
         # Project-level ACL Token Patterns
         ProjectPermission       = '^\$PROJECT:vstfs:\/{3}Classification\/TeamProject\/(?<ProjectId>[A-Za-z0-9-]+)$'
+        # Process ACL Token Patterns — org-wide root ($PROCESS), or $PROCESS:{parentProcessId}:{processId}
+        ProcessRootPermission   = '^\$PROCESS$'
+        ProcessPermission       = '^\$PROCESS:(?<ParentProcessId>[A-Za-z0-9-]+):(?<ProcessId>[A-Za-z0-9-]+)$'
         # Build (Pipeline) ACL Token Patterns  — ProjectId only, or ProjectId/PipelineId
         BuildPermission         = '^(?<ProjectId>[A-Za-z0-9-]+)(\/(?<PipelineId>[0-9]+))?$'
         # Library (VariableGroup) ACL Token Patterns

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Get-AzDoArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Get-AzDoArtifactFeedSettings.ps1
@@ -1,0 +1,75 @@
+Function Get-AzDoArtifactFeedSettings
+{
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSObject[]])]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$FeedName,
+        [Parameter()][object[]]$UpstreamSources,
+        [Parameter()][bool]$HideDeletedPackageVersions = $true,
+        [Parameter()][int]$RetentionCountLimit = 0,
+        [Parameter()][int]$DaysToKeepRecentlyDownloadedPackages = 0,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Get-AzDoArtifactFeedSettings] Started for feed '$FeedName' in project '$ProjectName'."
+
+    $result = @{ Ensure = [Ensure]::Absent; propertiesChanged = @(); status = $null }
+
+    $feed = Resolve-DevOpsArtifactFeed -ProjectName $ProjectName -FeedName $FeedName
+    if (-not $feed)
+    {
+        Write-Verbose "[Get-AzDoArtifactFeedSettings] Feed '$FeedName' not found."
+        $result.status = [DSCGetSummaryState]::NotFound
+        return $result
+    }
+
+    $result.liveCache = $feed
+    $result.Ensure    = [Ensure]::Present
+
+    # Compare desired settings against the live feed to detect drift.
+    $propertiesChanged = @()
+
+    if ($PSBoundParameters.ContainsKey('HideDeletedPackageVersions') -and
+        [bool]$feed.hideDeletedPackageVersions -ne $HideDeletedPackageVersions) { $propertiesChanged += 'HideDeletedPackageVersions' }
+
+    if ($PSBoundParameters.ContainsKey('UpstreamSources'))
+    {
+        $liveNames    = @($feed.upstreamSources | ForEach-Object { $_.name })
+        $desiredNames = @($UpstreamSources       | ForEach-Object { if ($_ -is [string]) { $_ } else { $_.name } })
+        if (Compare-Object -ReferenceObject @($liveNames) -DifferenceObject @($desiredNames)) { $propertiesChanged += 'UpstreamSources' }
+    }
+
+    # Retention policy is only managed when a positive count limit is requested.
+    if ($RetentionCountLimit -gt 0)
+    {
+        $apiUri    = 'https://feeds.dev.azure.com/{0}/' -f (Get-AzDoOrganizationName)
+        $retention = Get-DevOpsArtifactFeedRetentionPolicy -ApiUri $apiUri -ProjectName $ProjectName -FeedId $feed.id
+
+        if ((-not $retention) -or ([int]$retention.countLimit -ne $RetentionCountLimit))
+        {
+            $propertiesChanged += 'RetentionCountLimit'
+        }
+        if ((-not $retention) -or ([int]$retention.daysToKeepRecentlyDownloadedPackages -ne $DaysToKeepRecentlyDownloadedPackages))
+        {
+            $propertiesChanged += 'DaysToKeepRecentlyDownloadedPackages'
+        }
+    }
+
+    $result.propertiesChanged = $propertiesChanged
+
+    if ($propertiesChanged.Count -gt 0)
+    {
+        Write-Verbose "[Get-AzDoArtifactFeedSettings] Drift detected on: $($propertiesChanged -join ', ')."
+        $result.status = [DSCGetSummaryState]::Changed
+    }
+    else
+    {
+        Write-Verbose "[Get-AzDoArtifactFeedSettings] Feed settings match desired state."
+        $result.status = [DSCGetSummaryState]::Unchanged
+    }
+
+    return $result
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Get-AzDoArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Get-AzDoArtifactFeedSettings.ps1
@@ -18,6 +18,15 @@ Function Get-AzDoArtifactFeedSettings
 
     $result = @{ Ensure = [Ensure]::Absent; propertiesChanged = @(); status = $null }
 
+    # Feed settings cannot be removed independently of the feed. Treat 'Ensure = Absent' as a no-op
+    # that is already in its desired state so the engine does not loop trying to remove it.
+    if ($Ensure -eq [Ensure]::Absent)
+    {
+        Write-Verbose "[Get-AzDoArtifactFeedSettings] Ensure = Absent; feed settings cannot be removed (no-op)."
+        $result.status = [DSCGetSummaryState]::NotFound
+        return $result
+    }
+
     $feed = Resolve-DevOpsArtifactFeed -ProjectName $ProjectName -FeedName $FeedName
     if (-not $feed)
     {
@@ -35,11 +44,11 @@ Function Get-AzDoArtifactFeedSettings
     if ($PSBoundParameters.ContainsKey('HideDeletedPackageVersions') -and
         [bool]$feed.hideDeletedPackageVersions -ne $HideDeletedPackageVersions) { $propertiesChanged += 'HideDeletedPackageVersions' }
 
-    if ($PSBoundParameters.ContainsKey('UpstreamSources'))
+    if ($UpstreamSources)
     {
         $liveNames    = @($feed.upstreamSources | ForEach-Object { $_.name })
         $desiredNames = @($UpstreamSources       | ForEach-Object { if ($_ -is [string]) { $_ } else { $_.name } })
-        if (Compare-Object -ReferenceObject @($liveNames) -DifferenceObject @($desiredNames)) { $propertiesChanged += 'UpstreamSources' }
+        if (Test-AzDoArrayDrift -Reference $liveNames -Difference $desiredNames) { $propertiesChanged += 'UpstreamSources' }
     }
 
     # Retention policy is only managed when a positive count limit is requested.

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/New-AzDoArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/New-AzDoArtifactFeedSettings.ps1
@@ -1,0 +1,20 @@
+Function New-AzDoArtifactFeedSettings
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$FeedName,
+        [Parameter()][object[]]$UpstreamSources,
+        [Parameter()][bool]$HideDeletedPackageVersions = $true,
+        [Parameter()][int]$RetentionCountLimit = 0,
+        [Parameter()][int]$DaysToKeepRecentlyDownloadedPackages = 0,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[New-AzDoArtifactFeedSettings] Configuring settings for feed '$FeedName' in project '$ProjectName'."
+
+    # Settings always exist for an existing feed, so creation and update are the same operation.
+    Set-AzDoArtifactFeedSettings @PSBoundParameters
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Remove-AzDoArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Remove-AzDoArtifactFeedSettings.ps1
@@ -1,0 +1,19 @@
+Function Remove-AzDoArtifactFeedSettings
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$FeedName,
+        [Parameter()][object[]]$UpstreamSources,
+        [Parameter()][bool]$HideDeletedPackageVersions = $true,
+        [Parameter()][int]$RetentionCountLimit = 0,
+        [Parameter()][int]$DaysToKeepRecentlyDownloadedPackages = 0,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    # Feed settings are intrinsic to the feed and cannot be deleted independently of it.
+    # 'Ensure = Absent' is therefore a no-op for this resource; remove the feed itself with AzDoArtifactFeed.
+    Write-Verbose "[Remove-AzDoArtifactFeedSettings] Feed settings for '$FeedName' cannot be removed; manage the feed via AzDoArtifactFeed instead."
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Set-AzDoArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Set-AzDoArtifactFeedSettings.ps1
@@ -1,0 +1,47 @@
+Function Set-AzDoArtifactFeedSettings
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$FeedName,
+        [Parameter()][object[]]$UpstreamSources,
+        [Parameter()][bool]$HideDeletedPackageVersions = $true,
+        [Parameter()][int]$RetentionCountLimit = 0,
+        [Parameter()][int]$DaysToKeepRecentlyDownloadedPackages = 0,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Set-AzDoArtifactFeedSettings] Applying settings for feed '$FeedName' in project '$ProjectName'."
+
+    $feed = Resolve-DevOpsArtifactFeed -ProjectName $ProjectName -FeedName $FeedName
+    if (-not $feed)
+    {
+        Write-Error "[Set-AzDoArtifactFeedSettings] Feed '$FeedName' not found."
+        return
+    }
+
+    $params = @{
+        ApiUri                               = 'https://feeds.dev.azure.com/{0}/' -f (Get-AzDoOrganizationName)
+        ProjectName                          = $ProjectName
+        FeedId                               = $feed.id
+        HideDeletedPackageVersions           = $HideDeletedPackageVersions
+        RetentionCountLimit                  = $RetentionCountLimit
+        DaysToKeepRecentlyDownloadedPackages = $DaysToKeepRecentlyDownloadedPackages
+    }
+    if ($PSBoundParameters.ContainsKey('UpstreamSources')) { $params.UpstreamSources = $UpstreamSources }
+
+    $value = Set-DevOpsArtifactFeedSettings @params
+
+    if ($null -eq $value)
+    {
+        Write-Error "[Set-AzDoArtifactFeedSettings] Set-DevOpsArtifactFeedSettings returned null. Check authentication token and organization settings."
+        return
+    }
+
+    Add-CacheItem -Key ('{0}\{1}' -f $ProjectName, $FeedName) -Value $value -Type 'LiveArtifactFeeds'
+    Export-CacheObject -CacheType 'LiveArtifactFeeds' -Content $AzDoLiveArtifactFeeds
+    Refresh-CacheObject -CacheType 'LiveArtifactFeeds'
+    Write-Verbose "[Set-AzDoArtifactFeedSettings] Feed settings for '$FeedName' applied successfully."
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Set-AzDoArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Set-AzDoArtifactFeedSettings.ps1
@@ -30,7 +30,7 @@ Function Set-AzDoArtifactFeedSettings
         RetentionCountLimit                  = $RetentionCountLimit
         DaysToKeepRecentlyDownloadedPackages = $DaysToKeepRecentlyDownloadedPackages
     }
-    if ($PSBoundParameters.ContainsKey('UpstreamSources')) { $params.UpstreamSources = $UpstreamSources }
+    if ($UpstreamSources) { $params.UpstreamSources = $UpstreamSources }
 
     $value = Set-DevOpsArtifactFeedSettings @params
 

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Get-AzDoArtifactFeedView.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Get-AzDoArtifactFeedView.ps1
@@ -1,0 +1,61 @@
+Function Get-AzDoArtifactFeedView
+{
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSObject[]])]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$FeedName,
+        [Parameter(Mandatory = $true)][string]$ViewName,
+        [Parameter()][string]$ViewType,
+        [Parameter()][string]$ViewVisibility,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Get-AzDoArtifactFeedView] Started for view '$ViewName' on feed '$FeedName'."
+
+    $result = @{ Ensure = [Ensure]::Absent; propertiesChanged = @(); status = $null }
+
+    $feed = Resolve-DevOpsArtifactFeed -ProjectName $ProjectName -FeedName $FeedName
+    if (-not $feed)
+    {
+        Write-Verbose "[Get-AzDoArtifactFeedView] Feed '$FeedName' not found."
+        $result.status = [DSCGetSummaryState]::NotFound
+        return $result
+    }
+
+    $apiUri = 'https://feeds.dev.azure.com/{0}/' -f (Get-AzDoOrganizationName)
+    $view   = List-DevOpsArtifactFeedViews -ApiUri $apiUri -ProjectName $ProjectName -FeedId $feed.id |
+        Where-Object { $_.name -eq $ViewName } | Select-Object -First 1
+
+    if (-not $view)
+    {
+        Write-Verbose "[Get-AzDoArtifactFeedView] View '$ViewName' not found."
+        $result.status = [DSCGetSummaryState]::NotFound
+        return $result
+    }
+
+    $result.liveCache = $view
+    $result.Ensure    = [Ensure]::Present
+
+    $propertiesChanged = @()
+    if ($PSBoundParameters.ContainsKey('ViewType') -and $ViewType -and
+        $view.type -ne $ViewType) { $propertiesChanged += 'ViewType' }
+    if ($PSBoundParameters.ContainsKey('ViewVisibility') -and $ViewVisibility -and
+        $view.visibility -ne $ViewVisibility) { $propertiesChanged += 'ViewVisibility' }
+
+    $result.propertiesChanged = $propertiesChanged
+
+    if ($propertiesChanged.Count -gt 0)
+    {
+        Write-Verbose "[Get-AzDoArtifactFeedView] Drift detected on: $($propertiesChanged -join ', ')."
+        $result.status = [DSCGetSummaryState]::Changed
+    }
+    else
+    {
+        $result.status = [DSCGetSummaryState]::Unchanged
+    }
+
+    return $result
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/New-AzDoArtifactFeedView.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/New-AzDoArtifactFeedView.ps1
@@ -1,0 +1,42 @@
+Function New-AzDoArtifactFeedView
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$FeedName,
+        [Parameter(Mandatory = $true)][string]$ViewName,
+        [Parameter()][string]$ViewType = 'release',
+        [Parameter()][string]$ViewVisibility = 'collection',
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[New-AzDoArtifactFeedView] Creating view '$ViewName' on feed '$FeedName' in project '$ProjectName'."
+
+    $feed = Resolve-DevOpsArtifactFeed -ProjectName $ProjectName -FeedName $FeedName
+    if (-not $feed)
+    {
+        Write-Error "[New-AzDoArtifactFeedView] Feed '$FeedName' not found."
+        return
+    }
+
+    $params = @{
+        ApiUri         = 'https://feeds.dev.azure.com/{0}/' -f (Get-AzDoOrganizationName)
+        ProjectName    = $ProjectName
+        FeedId         = $feed.id
+        ViewName       = $ViewName
+        ViewType       = $ViewType
+        ViewVisibility = $ViewVisibility
+    }
+
+    $value = New-DevOpsArtifactFeedView @params
+
+    if ($null -eq $value)
+    {
+        Write-Error "[New-AzDoArtifactFeedView] New-DevOpsArtifactFeedView returned null. Check authentication token and organization settings."
+        return
+    }
+
+    Write-Verbose "[New-AzDoArtifactFeedView] View '$ViewName' created successfully."
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Remove-AzDoArtifactFeedView.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Remove-AzDoArtifactFeedView.ps1
@@ -1,0 +1,38 @@
+Function Remove-AzDoArtifactFeedView
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$FeedName,
+        [Parameter(Mandatory = $true)][string]$ViewName,
+        [Parameter()][string]$ViewType,
+        [Parameter()][string]$ViewVisibility,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Remove-AzDoArtifactFeedView] Removing view '$ViewName' from feed '$FeedName' in project '$ProjectName'."
+
+    $feed = Resolve-DevOpsArtifactFeed -ProjectName $ProjectName -FeedName $FeedName
+    if (-not $feed)
+    {
+        Write-Error "[Remove-AzDoArtifactFeedView] Feed '$FeedName' not found."
+        return
+    }
+
+    $apiUri = 'https://feeds.dev.azure.com/{0}/' -f (Get-AzDoOrganizationName)
+    $view   = List-DevOpsArtifactFeedViews -ApiUri $apiUri -ProjectName $ProjectName -FeedId $feed.id |
+        Where-Object { $_.name -eq $ViewName } | Select-Object -First 1
+
+    if (-not $view)
+    {
+        # Already absent — nothing to remove (desired state achieved).
+        Write-Verbose "[Remove-AzDoArtifactFeedView] View '$ViewName' not found; already absent."
+        return
+    }
+
+    Remove-DevOpsArtifactFeedView -ApiUri $apiUri -ProjectName $ProjectName -FeedId $feed.id -ViewId $view.id
+
+    Write-Verbose "[Remove-AzDoArtifactFeedView] View '$ViewName' removed successfully."
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Set-AzDoArtifactFeedView.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Set-AzDoArtifactFeedView.ps1
@@ -1,0 +1,55 @@
+Function Set-AzDoArtifactFeedView
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$FeedName,
+        [Parameter(Mandatory = $true)][string]$ViewName,
+        [Parameter()][string]$ViewType,
+        [Parameter()][string]$ViewVisibility,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Set-AzDoArtifactFeedView] Updating view '$ViewName' on feed '$FeedName' in project '$ProjectName'."
+
+    $feed = Resolve-DevOpsArtifactFeed -ProjectName $ProjectName -FeedName $FeedName
+    if (-not $feed)
+    {
+        Write-Error "[Set-AzDoArtifactFeedView] Feed '$FeedName' not found."
+        return
+    }
+
+    $apiUri = 'https://feeds.dev.azure.com/{0}/' -f (Get-AzDoOrganizationName)
+    $view   = List-DevOpsArtifactFeedViews -ApiUri $apiUri -ProjectName $ProjectName -FeedId $feed.id |
+        Where-Object { $_.name -eq $ViewName } | Select-Object -First 1
+
+    if (-not $view)
+    {
+        Write-Error "[Set-AzDoArtifactFeedView] View '$ViewName' not found on feed '$FeedName'."
+        return
+    }
+
+    $params = @{
+        ApiUri      = $apiUri
+        ProjectName = $ProjectName
+        FeedId      = $feed.id
+        ViewId      = $view.id
+        ViewName    = $ViewName
+    }
+    foreach ($name in 'ViewType', 'ViewVisibility')
+    {
+        if ($PSBoundParameters.ContainsKey($name)) { $params[$name] = $PSBoundParameters[$name] }
+    }
+
+    $value = Set-DevOpsArtifactFeedView @params
+
+    if ($null -eq $value)
+    {
+        Write-Error "[Set-AzDoArtifactFeedView] Set-DevOpsArtifactFeedView returned null. Check authentication token and organization settings."
+        return
+    }
+
+    Write-Verbose "[Set-AzDoArtifactFeedView] View '$ViewName' updated successfully."
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGroupPermission/Get-AzDoGroupPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGroupPermission/Get-AzDoGroupPermission.ps1
@@ -118,7 +118,43 @@ Function Get-AzDoGroupPermission
         $group = $allGroups | Where-Object { $_.principalName -eq $('[{0}]\{1}' -f $ProjectName, $GroupName) } | Select-Object -First 1
         if ($group)
         {
-            Add-CacheItem -Key $group.principalName -Value $group -Type 'LiveGroups'
+            # Enrich the group with its ACL identity before caching. The init-time cache guarantees every
+            # LiveGroups entry carries a .value.ACLIdentity (used downstream by Find-Identity ->
+            # ConvertTo-ACLHashtable to key ACEs by descriptor). Caching the raw group here would poison
+            # the cache: a later Find-Identity principalName hit would return an identity whose
+            # ACLIdentity.descriptor is null, crashing ConvertTo-ACLHashtable ("key cannot be null").
+            try
+            {
+                $aclIdentitySource = Get-DevOpsDescriptorIdentity -OrganizationName $OrganizationName -SubjectDescriptor $group.descriptor
+
+                $aclIdentity = [PSCustomObject]@{
+                    id                  = $aclIdentitySource.id
+                    descriptor          = $aclIdentitySource.descriptor
+                    subjectDescriptor   = $aclIdentitySource.subjectDescriptor
+                    providerDisplayName = $aclIdentitySource.providerDisplayName
+                    isActive            = $aclIdentitySource.isActive
+                    isContainer         = $aclIdentitySource.isContainer
+                }
+                $group | Add-Member -MemberType NoteProperty -Name 'ACLIdentity' -Force -Value $aclIdentity
+
+                Add-CacheItem -Key $group.principalName -Value $group -Type 'LiveGroups' -SuppressWarning
+
+                # Register in the descriptor index so a later descriptor search resolves from the index.
+                $descriptorIndexParams = @{
+                    AclDescriptor     = $aclIdentitySource.descriptor
+                    PrincipalName     = $group.principalName
+                    OriginId          = $group.originId
+                    GraphDescriptor   = $group.descriptor
+                    AclId             = $aclIdentitySource.id
+                    SubjectDescriptor = $aclIdentitySource.subjectDescriptor
+                    Persist           = $true
+                }
+                Add-IdentityDescriptorIndexItem @descriptorIndexParams
+            }
+            catch
+            {
+                Write-Warning "[Get-AzDoGroupPermission] Failed to enrich live group '$($group.principalName)' with its ACL identity: $_"
+            }
         }
     }
 

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Get-AzDoProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Get-AzDoProcess.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+Retrieves the current state of an Azure DevOps inherited process.
+
+.DESCRIPTION
+Looks up an inherited process by name and reports whether it exists and whether its mutable properties
+(currently the description) match the desired state. The parent process is immutable once created and is
+therefore not reconciled here.
+
+.PARAMETER ProcessName
+The name of the inherited process.
+
+.PARAMETER ParentProcessName
+The name of the parent (system or custom) process the inherited process derives from.
+
+.PARAMETER Description
+The desired description of the process.
+
+.PARAMETER LookupResult
+A hashtable to store the lookup result.
+
+.PARAMETER Ensure
+Specifies the desired state of the process.
+
+.OUTPUTS
+System.Collections.Hashtable
+#>
+function Get-AzDoProcess
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Alias('Name')]
+        [System.String]$ProcessName,
+
+        [Parameter()]
+        [System.String]$ParentProcessName,
+
+        [Parameter()]
+        [Alias('Description')]
+        [System.String]$Description = '',
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure
+    )
+
+    Write-Verbose "[Get-AzDoProcess] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    $result = @{
+        Ensure            = [Ensure]::Absent
+        ProcessName       = $ProcessName
+        ParentProcessName = $ParentProcessName
+        Description       = $Description
+        propertiesChanged = @()
+        status            = $null
+    }
+
+    $process = Resolve-DevOpsProcess -ProcessName $ProcessName -OrganizationName $OrganizationName
+
+    # Process does not exist — nothing to reconcile beyond creation.
+    if ($null -eq $process)
+    {
+        Write-Verbose "[Get-AzDoProcess] Process '$ProcessName' not found."
+        $result.status = [DSCGetSummaryState]::NotFound
+        return $result
+    }
+
+    # Normalize the live description (it may be absent/null on a freshly created process).
+    $currentDescription = if ($null -eq $process.description) { '' } else { [string]$process.description }
+
+    if ($Description.Trim() -ne $currentDescription.Trim())
+    {
+        Write-Verbose "[Get-AzDoProcess] Description has changed. Current: '$currentDescription', Desired: '$Description'."
+        $result.status = [DSCGetSummaryState]::Changed
+        $result.propertiesChanged += 'Description'
+    }
+
+    if ($result.propertiesChanged.Count -eq 0)
+    {
+        $result.status = [DSCGetSummaryState]::Unchanged
+        Write-Verbose "[Get-AzDoProcess] Process properties have not changed."
+    }
+
+    return $result
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Get-AzDoProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Get-AzDoProcess.ps1
@@ -39,7 +39,6 @@ function Get-AzDoProcess
         [System.String]$ParentProcessName,
 
         [Parameter()]
-        [Alias('Description')]
         [System.String]$Description = '',
 
         [Parameter()]

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/New-AzDoProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/New-AzDoProcess.ps1
@@ -1,0 +1,91 @@
+<#
+.SYNOPSIS
+Creates a new Azure DevOps inherited process.
+
+.DESCRIPTION
+Creates an inherited process derived from the specified parent process. The parent is resolved to its
+process type id from the 'LiveProcesses' cache (falling back to a live lookup), and the newly created
+process is added to the cache so subsequent Test runs in the same configuration resolve it.
+
+.PARAMETER ProcessName
+The name of the inherited process to create.
+
+.PARAMETER ParentProcessName
+The name of the parent (system or custom) process to inherit from.
+
+.PARAMETER Description
+An optional description for the process.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result.
+
+.PARAMETER Ensure
+Specifies the desired state of the process.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function New-AzDoProcess
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Alias('Name')]
+        [System.String]$ProcessName,
+
+        [Parameter()]
+        [System.String]$ParentProcessName,
+
+        [Parameter()]
+        [Alias('Description')]
+        [System.String]$Description = '',
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[New-AzDoProcess] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    if ([string]::IsNullOrWhiteSpace($ParentProcessName))
+    {
+        throw "[New-AzDoProcess] ParentProcessName is required to create process '$ProcessName'."
+    }
+
+    $parentProcess = Resolve-DevOpsProcess -ProcessName $ParentProcessName -OrganizationName $OrganizationName
+    if ($null -eq $parentProcess)
+    {
+        throw "[New-AzDoProcess] Parent process '$ParentProcessName' not found; cannot create '$ProcessName'."
+    }
+
+    $params = @{
+        Organization        = $OrganizationName
+        Name                = $ProcessName
+        ParentProcessTypeId = $parentProcess.id
+        Description         = $Description
+    }
+
+    $response = New-DevOpsProcess @params
+
+    # The work/processes response exposes 'typeId'; normalize to the 'id'-keyed shape the LiveProcesses
+    # cache uses so Get-AzDoProcess (and ACL token building) can resolve it immediately.
+    if ($null -ne $response)
+    {
+        $cacheValue = [PSCustomObject]@{
+            id          = $response.typeId
+            name        = $response.name
+            description = $response.description
+            type        = 'custom'
+            isDefault   = $false
+        }
+        Add-CacheItem -Key $ProcessName -Value $cacheValue -Type 'LiveProcesses' -SuppressWarning
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/New-AzDoProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/New-AzDoProcess.ps1
@@ -38,7 +38,6 @@ function New-AzDoProcess
         [System.String]$ParentProcessName,
 
         [Parameter()]
-        [Alias('Description')]
         [System.String]$Description = '',
 
         [Parameter()]

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Remove-AzDoProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Remove-AzDoProcess.ps1
@@ -1,0 +1,73 @@
+<#
+.SYNOPSIS
+Removes an Azure DevOps inherited process.
+
+.DESCRIPTION
+Deletes an inherited process by resolving it to its type id and issuing a delete request. Processes that
+are in use by a project (or system processes) cannot be deleted; the API surfaces an error in that case.
+The process is removed from the 'LiveProcesses' cache on success.
+
+.PARAMETER ProcessName
+The name of the inherited process to remove.
+
+.PARAMETER ParentProcessName
+The name of the parent process (informational only).
+
+.PARAMETER Description
+The description (informational only).
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result.
+
+.PARAMETER Ensure
+Specifies the desired state of the process.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function Remove-AzDoProcess
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Alias('Name')]
+        [System.String]$ProcessName,
+
+        [Parameter()]
+        [System.String]$ParentProcessName,
+
+        [Parameter()]
+        [Alias('Description')]
+        [System.String]$Description = '',
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Remove-AzDoProcess] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    $process = Resolve-DevOpsProcess -ProcessName $ProcessName -OrganizationName $OrganizationName
+    if ($null -eq $process)
+    {
+        Write-Verbose "[Remove-AzDoProcess] Process '$ProcessName' not found; nothing to remove."
+        return
+    }
+
+    $params = @{
+        Organization  = $OrganizationName
+        ProcessTypeId = $process.id
+    }
+
+    $null = Remove-DevOpsProcess @params
+
+    Remove-CacheItem -Key $ProcessName -Type 'LiveProcesses'
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Remove-AzDoProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Remove-AzDoProcess.ps1
@@ -38,7 +38,6 @@ function Remove-AzDoProcess
         [System.String]$ParentProcessName,
 
         [Parameter()]
-        [Alias('Description')]
         [System.String]$Description = '',
 
         [Parameter()]

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Set-AzDoProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Set-AzDoProcess.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+Updates an Azure DevOps inherited process.
+
+.DESCRIPTION
+Reconciles the mutable properties of an existing inherited process (currently the description) by
+resolving the process to its type id and issuing an edit request. The parent process is immutable and
+is not changed here.
+
+.PARAMETER ProcessName
+The name of the inherited process to update.
+
+.PARAMETER ParentProcessName
+The name of the parent process (informational only; not changed).
+
+.PARAMETER Description
+The desired description of the process.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result.
+
+.PARAMETER Ensure
+Specifies the desired state of the process.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function Set-AzDoProcess
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Alias('Name')]
+        [System.String]$ProcessName,
+
+        [Parameter()]
+        [System.String]$ParentProcessName,
+
+        [Parameter()]
+        [Alias('Description')]
+        [System.String]$Description = '',
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Set-AzDoProcess] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    $process = Resolve-DevOpsProcess -ProcessName $ProcessName -OrganizationName $OrganizationName
+    if ($null -eq $process)
+    {
+        throw "[Set-AzDoProcess] Process '$ProcessName' not found; cannot update."
+    }
+
+    $params = @{
+        Organization  = $OrganizationName
+        ProcessTypeId = $process.id
+        Name          = $ProcessName
+        Description   = $Description
+    }
+
+    $null = Update-DevOpsProcess @params
+
+    # Keep the cache description in sync for any subsequent Test in the same run.
+    if ($process.PSObject.Properties.Name -contains 'description')
+    {
+        $process.description = $Description
+    }
+    else
+    {
+        $process | Add-Member -MemberType NoteProperty -Name description -Value $Description -Force
+    }
+    Add-CacheItem -Key $ProcessName -Value $process -Type 'LiveProcesses' -SuppressWarning
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Set-AzDoProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Set-AzDoProcess.ps1
@@ -38,7 +38,6 @@ function Set-AzDoProcess
         [System.String]$ParentProcessName,
 
         [Parameter()]
-        [Alias('Description')]
         [System.String]$Description = '',
 
         [Parameter()]

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Test-AzDoProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Test-AzDoProcess.ps1
@@ -1,0 +1,55 @@
+<#
+.SYNOPSIS
+Placeholder test function for the AzDoProcess resource.
+
+.DESCRIPTION
+Test() is implemented by the AzDevOpsDscResourceBase base class, which compares the desired state against
+the result of Get-AzDoProcess. This function exists only to satisfy the resource function naming
+convention and should not be invoked directly.
+
+.PARAMETER ProcessName
+The name of the inherited process.
+
+.PARAMETER ParentProcessName
+The name of the parent process.
+
+.PARAMETER Description
+The description of the process.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result.
+
+.PARAMETER Ensure
+Specifies the desired state of the process.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function Test-AzDoProcess
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Alias('Name')]
+        [System.String]$ProcessName,
+
+        [Parameter()]
+        [System.String]$ParentProcessName,
+
+        [Parameter()]
+        [Alias('Description')]
+        [System.String]$Description = '',
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    # Should not be triggered. This is a placeholder for the test function.
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Test-AzDoProcess.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Test-AzDoProcess.ps1
@@ -38,7 +38,6 @@ function Test-AzDoProcess
         [System.String]$ParentProcessName,
 
         [Parameter()]
-        [Alias('Description')]
         [System.String]$Description = '',
 
         [Parameter()]

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Get-AzDoProcessPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Get-AzDoProcessPermission.ps1
@@ -29,7 +29,7 @@ Forces the operation.
 .OUTPUTS
 System.Collections.Hashtable
 #>
-function Get-AzDoProcessPermissions
+function Get-AzDoProcessPermission
 {
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
@@ -54,7 +54,7 @@ function Get-AzDoProcessPermissions
         [System.Management.Automation.SwitchParameter]$Force
     )
 
-    Write-Verbose "[Get-AzDoProcessPermissions] Started."
+    Write-Verbose "[Get-AzDoProcessPermission] Started."
 
     $SecurityNamespace = 'Process'
     $OrganizationName  = (Get-AzDoOrganizationName)
@@ -79,7 +79,7 @@ function Get-AzDoProcessPermissions
     $namespace = Get-CacheItem -Key $SecurityNamespace -Type 'SecurityNamespaces'
     if (-not $namespace)
     {
-        Write-Error "[Get-AzDoProcessPermissions] Security namespace '$SecurityNamespace' not found."
+        Write-Error "[Get-AzDoProcessPermission] Security namespace '$SecurityNamespace' not found."
         $getResult.status = [DSCGetSummaryState]::Error
         $getResult.reason = "Security namespace '$SecurityNamespace' not found."
         return $getResult

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/New-AzDoProcessPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/New-AzDoProcessPermission.ps1
@@ -1,16 +1,16 @@
 <#
 .SYNOPSIS
-Removes Azure DevOps Process permissions from a process scope token.
+Applies Azure DevOps Process permissions (new ACL).
 
 .DESCRIPTION
-Removes the managed ACL for the resolved process scope token via Remove-AzDoPermission. Protected
-system ACEs cannot be removed by the API and remain.
+Serializes the desired Process namespace ACEs and applies them to the resolved process scope token via
+Set-AzDoPermission. Other identities' ACEs on the same token are preserved.
 
 .PARAMETER ProcessName
 The process name, or the sentinel 'AllProcesses' for the org-wide root scope.
 
 .PARAMETER Permissions
-An array of hashtables describing the ACEs (unused on removal; present for signature parity).
+An array of hashtables describing the desired ACEs.
 
 .PARAMETER isInherited
 Whether the ACL inherits permissions.
@@ -24,7 +24,7 @@ Specifies the desired state.
 .PARAMETER Force
 Forces the operation.
 #>
-function Remove-AzDoProcessPermissions
+function New-AzDoProcessPermission
 {
     [CmdletBinding()]
     param
@@ -48,29 +48,38 @@ function Remove-AzDoProcessPermissions
         [System.Management.Automation.SwitchParameter]$Force
     )
 
-    Write-Verbose "[Remove-AzDoProcessPermissions] Started."
+    Write-Verbose "[New-AzDoProcessPermission] Started."
 
     $OrganizationName  = (Get-AzDoOrganizationName)
     $SecurityNamespace = Get-CacheItem -Key 'Process' -Type 'SecurityNamespaces'
 
     if (-not $SecurityNamespace)
     {
-        Write-Error "[Remove-AzDoProcessPermissions] Security namespace 'Process' not found."
+        Write-Error "[New-AzDoProcessPermission] Security namespace 'Process' not found."
         return
     }
 
     $processToken = Get-DevOpsProcessAclToken -ProcessName $ProcessName -OrganizationName $OrganizationName
     if (-not $processToken)
     {
-        Write-Error "[Remove-AzDoProcessPermissions] Could not resolve a Process ACL token for '$ProcessName'."
+        Write-Error "[New-AzDoProcessPermission] Could not resolve a Process ACL token for '$ProcessName'."
         return
+    }
+
+    # Preserve every other token's ACL; replace only the one we manage (exact, escaped match).
+    $descriptorMatchToken = '^{0}$' -f [regex]::Escape($processToken)
+
+    $serializeACLParams = @{
+        ReferenceACLs        = $LookupResult.propertiesChanged
+        DescriptorACLList    = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'
+        DescriptorMatchToken = $descriptorMatchToken
     }
 
     $params = @{
         OrganizationName    = $OrganizationName
         SecurityNamespaceID = $SecurityNamespace.namespaceId
-        TokenName           = $processToken
+        SerializedACLs      = ConvertTo-ACLHashtable @serializeACLParams
     }
 
-    Remove-AzDoPermission @params
+    Set-AzDoPermission @params
 }

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Remove-AzDoProcessPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Remove-AzDoProcessPermission.ps1
@@ -1,16 +1,16 @@
 <#
 .SYNOPSIS
-Updates Azure DevOps Process permissions (existing ACL).
+Removes Azure DevOps Process permissions from a process scope token.
 
 .DESCRIPTION
-Serializes the desired Process namespace ACEs and applies them to the resolved process scope token via
-Set-AzDoPermission, reconciling drift detected by Get-AzDoProcessPermissions.
+Removes the managed ACL for the resolved process scope token via Remove-AzDoPermission. Protected
+system ACEs cannot be removed by the API and remain.
 
 .PARAMETER ProcessName
 The process name, or the sentinel 'AllProcesses' for the org-wide root scope.
 
 .PARAMETER Permissions
-An array of hashtables describing the desired ACEs.
+An array of hashtables describing the ACEs (unused on removal; present for signature parity).
 
 .PARAMETER isInherited
 Whether the ACL inherits permissions.
@@ -24,7 +24,7 @@ Specifies the desired state.
 .PARAMETER Force
 Forces the operation.
 #>
-function Set-AzDoProcessPermissions
+function Remove-AzDoProcessPermission
 {
     [CmdletBinding()]
     param
@@ -48,37 +48,29 @@ function Set-AzDoProcessPermissions
         [System.Management.Automation.SwitchParameter]$Force
     )
 
-    Write-Verbose "[Set-AzDoProcessPermissions] Started."
+    Write-Verbose "[Remove-AzDoProcessPermission] Started."
 
     $OrganizationName  = (Get-AzDoOrganizationName)
     $SecurityNamespace = Get-CacheItem -Key 'Process' -Type 'SecurityNamespaces'
 
     if (-not $SecurityNamespace)
     {
-        Write-Error "[Set-AzDoProcessPermissions] Security namespace 'Process' not found."
+        Write-Error "[Remove-AzDoProcessPermission] Security namespace 'Process' not found."
         return
     }
 
     $processToken = Get-DevOpsProcessAclToken -ProcessName $ProcessName -OrganizationName $OrganizationName
     if (-not $processToken)
     {
-        Write-Error "[Set-AzDoProcessPermissions] Could not resolve a Process ACL token for '$ProcessName'."
+        Write-Error "[Remove-AzDoProcessPermission] Could not resolve a Process ACL token for '$ProcessName'."
         return
-    }
-
-    $descriptorMatchToken = '^{0}$' -f [regex]::Escape($processToken)
-
-    $serializeACLParams = @{
-        ReferenceACLs        = $LookupResult.propertiesChanged
-        DescriptorACLList    = @()
-        DescriptorMatchToken = $descriptorMatchToken
     }
 
     $params = @{
         OrganizationName    = $OrganizationName
         SecurityNamespaceID = $SecurityNamespace.namespaceId
-        SerializedACLs      = ConvertTo-ACLHashtable @serializeACLParams
+        TokenName           = $processToken
     }
 
-    Set-AzDoPermission @params
+    Remove-AzDoPermission @params
 }

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Set-AzDoProcessPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Set-AzDoProcessPermission.ps1
@@ -1,10 +1,10 @@
 <#
 .SYNOPSIS
-Applies Azure DevOps Process permissions (new ACL).
+Updates Azure DevOps Process permissions (existing ACL).
 
 .DESCRIPTION
 Serializes the desired Process namespace ACEs and applies them to the resolved process scope token via
-Set-AzDoPermission. Other identities' ACEs on the same token are preserved.
+Set-AzDoPermission, reconciling drift detected by Get-AzDoProcessPermission.
 
 .PARAMETER ProcessName
 The process name, or the sentinel 'AllProcesses' for the org-wide root scope.
@@ -24,7 +24,7 @@ Specifies the desired state.
 .PARAMETER Force
 Forces the operation.
 #>
-function New-AzDoProcessPermissions
+function Set-AzDoProcessPermission
 {
     [CmdletBinding()]
     param
@@ -48,30 +48,29 @@ function New-AzDoProcessPermissions
         [System.Management.Automation.SwitchParameter]$Force
     )
 
-    Write-Verbose "[New-AzDoProcessPermissions] Started."
+    Write-Verbose "[Set-AzDoProcessPermission] Started."
 
     $OrganizationName  = (Get-AzDoOrganizationName)
     $SecurityNamespace = Get-CacheItem -Key 'Process' -Type 'SecurityNamespaces'
 
     if (-not $SecurityNamespace)
     {
-        Write-Error "[New-AzDoProcessPermissions] Security namespace 'Process' not found."
+        Write-Error "[Set-AzDoProcessPermission] Security namespace 'Process' not found."
         return
     }
 
     $processToken = Get-DevOpsProcessAclToken -ProcessName $ProcessName -OrganizationName $OrganizationName
     if (-not $processToken)
     {
-        Write-Error "[New-AzDoProcessPermissions] Could not resolve a Process ACL token for '$ProcessName'."
+        Write-Error "[Set-AzDoProcessPermission] Could not resolve a Process ACL token for '$ProcessName'."
         return
     }
 
-    # Preserve every other token's ACL; replace only the one we manage (exact, escaped match).
     $descriptorMatchToken = '^{0}$' -f [regex]::Escape($processToken)
 
     $serializeACLParams = @{
         ReferenceACLs        = $LookupResult.propertiesChanged
-        DescriptorACLList    = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'
+        DescriptorACLList    = @()
         DescriptorMatchToken = $descriptorMatchToken
     }
 

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermissions/Get-AzDoProcessPermissions.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermissions/Get-AzDoProcessPermissions.ps1
@@ -1,0 +1,138 @@
+<#
+.SYNOPSIS
+Retrieves the current state of Azure DevOps Process permissions.
+
+.DESCRIPTION
+Compares the desired Process namespace ACEs against the live ACL for a process scope. The scope is the
+org-wide root ('$PROCESS', via ProcessName 'AllProcesses') which governs who can create/edit/delete and
+administer processes — including creating inherited (child) processes — or a specific inherited process
+('$PROCESS:{parentProcessTypeId}:{processTypeId}').
+
+.PARAMETER ProcessName
+The process name, or the sentinel 'AllProcesses' for the org-wide root scope.
+
+.PARAMETER Permissions
+An array of hashtables describing the desired ACEs (Identity + Permission map, e.g. @{ Create = 'Allow' }).
+
+.PARAMETER isInherited
+Whether the ACL inherits permissions.
+
+.PARAMETER LookupResult
+A hashtable to store the lookup result.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation.
+
+.OUTPUTS
+System.Collections.Hashtable
+#>
+function Get-AzDoProcessPermissions
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$ProcessName,
+
+        [Parameter()]
+        [HashTable[]]$Permissions,
+
+        [Parameter()]
+        [bool]$isInherited = $true,
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Get-AzDoProcessPermissions] Started."
+
+    $SecurityNamespace = 'Process'
+    $OrganizationName  = (Get-AzDoOrganizationName)
+
+    $getResult = @{
+        Ensure            = [Ensure]::Absent
+        propertiesChanged = @()
+        processName       = $ProcessName
+        status            = $null
+        reason            = $null
+    }
+
+    # Resolve the ACL token for this scope ($PROCESS root, or $PROCESS:{parent}:{id}).
+    $processToken = Get-DevOpsProcessAclToken -ProcessName $ProcessName -OrganizationName $OrganizationName
+    if (-not $processToken)
+    {
+        $getResult.status = [DSCGetSummaryState]::Error
+        $getResult.reason = "Could not resolve a Process ACL token for '$ProcessName'."
+        return $getResult
+    }
+
+    $namespace = Get-CacheItem -Key $SecurityNamespace -Type 'SecurityNamespaces'
+    if (-not $namespace)
+    {
+        Write-Error "[Get-AzDoProcessPermissions] Security namespace '$SecurityNamespace' not found."
+        $getResult.status = [DSCGetSummaryState]::Error
+        $getResult.reason = "Security namespace '$SecurityNamespace' not found."
+        return $getResult
+    }
+
+    $getResult.namespace = $namespace
+
+    $DevOpsACLs = Get-DevOpsACL -OrganizationName $OrganizationName -SecurityDescriptorId $namespace.namespaceId
+    if (-not $DevOpsACLs)
+    {
+        $getResult.status = [DSCGetSummaryState]::Error
+        $getResult.reason = 'No ACLs found.'
+        return $getResult
+    }
+
+    # Filter the raw ACLs to just this scope's token BEFORE the expensive identity formatting.
+    $DevOpsACLs = $DevOpsACLs | Where-Object { $_.token -eq $processToken }
+
+    # Wrap in @() so single results are not unrolled to a bare hashtable (breaks [0] indexing downstream).
+    $DifferenceACLs = @($DevOpsACLs | ConvertTo-FormattedACL -SecurityNamespace $SecurityNamespace -OrganizationName $OrganizationName)
+
+    $params = @{
+        Permissions       = $Permissions
+        SecurityNamespace = $SecurityNamespace
+        isInherited       = $isInherited
+        OrganizationName  = $OrganizationName
+        TokenName         = $processToken
+    }
+
+    $ReferenceACLs = @(ConvertTo-ACL @params | Where-Object { $_.token.Type -ne 'ProcessUnknown' })
+
+    # The Process namespace has protected system-group ACEs that cannot be removed. Filter the live ACEs
+    # down to just the identities we manage so the comparison only considers the relevant ACE(s).
+    if ($ReferenceACLs.Count -gt 0 -and $DifferenceACLs.Count -gt 0)
+    {
+        $desiredOriginIds = @($ReferenceACLs[0].aces | ForEach-Object { $_.Identity.value.originId } | Where-Object { $_ })
+        if ($desiredOriginIds.Count -gt 0)
+        {
+            $DifferenceACLs[0]['aces'] = @($DifferenceACLs[0].aces | Where-Object { $_.Identity.value.originId -in $desiredOriginIds })
+        }
+        else
+        {
+            $DifferenceACLs[0]['aces'] = @()
+        }
+    }
+
+    $compareResult = Test-ACLListforChanges -ReferenceACLs $ReferenceACLs -DifferenceACLs $DifferenceACLs
+
+    $getResult.propertiesChanged = $compareResult.propertiesChanged
+    $getResult.status            = [DSCGetSummaryState]::"$($compareResult.status)"
+    $getResult.reason            = $compareResult.reason
+    $getResult.ReferenceACLs     = $ReferenceACLs
+    $getResult.DifferenceACLs    = $DifferenceACLs
+
+    return $getResult
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermissions/New-AzDoProcessPermissions.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermissions/New-AzDoProcessPermissions.ps1
@@ -1,0 +1,85 @@
+<#
+.SYNOPSIS
+Applies Azure DevOps Process permissions (new ACL).
+
+.DESCRIPTION
+Serializes the desired Process namespace ACEs and applies them to the resolved process scope token via
+Set-AzDoPermission. Other identities' ACEs on the same token are preserved.
+
+.PARAMETER ProcessName
+The process name, or the sentinel 'AllProcesses' for the org-wide root scope.
+
+.PARAMETER Permissions
+An array of hashtables describing the desired ACEs.
+
+.PARAMETER isInherited
+Whether the ACL inherits permissions.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation.
+#>
+function New-AzDoProcessPermissions
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$ProcessName,
+
+        [Parameter()]
+        [HashTable[]]$Permissions,
+
+        [Parameter()]
+        [bool]$isInherited = $true,
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[New-AzDoProcessPermissions] Started."
+
+    $OrganizationName  = (Get-AzDoOrganizationName)
+    $SecurityNamespace = Get-CacheItem -Key 'Process' -Type 'SecurityNamespaces'
+
+    if (-not $SecurityNamespace)
+    {
+        Write-Error "[New-AzDoProcessPermissions] Security namespace 'Process' not found."
+        return
+    }
+
+    $processToken = Get-DevOpsProcessAclToken -ProcessName $ProcessName -OrganizationName $OrganizationName
+    if (-not $processToken)
+    {
+        Write-Error "[New-AzDoProcessPermissions] Could not resolve a Process ACL token for '$ProcessName'."
+        return
+    }
+
+    # Preserve every other token's ACL; replace only the one we manage (exact, escaped match).
+    $descriptorMatchToken = '^{0}$' -f [regex]::Escape($processToken)
+
+    $serializeACLParams = @{
+        ReferenceACLs        = $LookupResult.propertiesChanged
+        DescriptorACLList    = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'
+        DescriptorMatchToken = $descriptorMatchToken
+    }
+
+    $params = @{
+        OrganizationName    = $OrganizationName
+        SecurityNamespaceID = $SecurityNamespace.namespaceId
+        SerializedACLs      = ConvertTo-ACLHashtable @serializeACLParams
+    }
+
+    Set-AzDoPermission @params
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermissions/Remove-AzDoProcessPermissions.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermissions/Remove-AzDoProcessPermissions.ps1
@@ -1,0 +1,76 @@
+<#
+.SYNOPSIS
+Removes Azure DevOps Process permissions from a process scope token.
+
+.DESCRIPTION
+Removes the managed ACL for the resolved process scope token via Remove-AzDoPermission. Protected
+system ACEs cannot be removed by the API and remain.
+
+.PARAMETER ProcessName
+The process name, or the sentinel 'AllProcesses' for the org-wide root scope.
+
+.PARAMETER Permissions
+An array of hashtables describing the ACEs (unused on removal; present for signature parity).
+
+.PARAMETER isInherited
+Whether the ACL inherits permissions.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation.
+#>
+function Remove-AzDoProcessPermissions
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$ProcessName,
+
+        [Parameter()]
+        [HashTable[]]$Permissions,
+
+        [Parameter()]
+        [bool]$isInherited = $true,
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Remove-AzDoProcessPermissions] Started."
+
+    $OrganizationName  = (Get-AzDoOrganizationName)
+    $SecurityNamespace = Get-CacheItem -Key 'Process' -Type 'SecurityNamespaces'
+
+    if (-not $SecurityNamespace)
+    {
+        Write-Error "[Remove-AzDoProcessPermissions] Security namespace 'Process' not found."
+        return
+    }
+
+    $processToken = Get-DevOpsProcessAclToken -ProcessName $ProcessName -OrganizationName $OrganizationName
+    if (-not $processToken)
+    {
+        Write-Error "[Remove-AzDoProcessPermissions] Could not resolve a Process ACL token for '$ProcessName'."
+        return
+    }
+
+    $params = @{
+        OrganizationName    = $OrganizationName
+        SecurityNamespaceID = $SecurityNamespace.namespaceId
+        TokenName           = $processToken
+    }
+
+    Remove-AzDoPermission @params
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermissions/Set-AzDoProcessPermissions.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermissions/Set-AzDoProcessPermissions.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+Updates Azure DevOps Process permissions (existing ACL).
+
+.DESCRIPTION
+Serializes the desired Process namespace ACEs and applies them to the resolved process scope token via
+Set-AzDoPermission, reconciling drift detected by Get-AzDoProcessPermissions.
+
+.PARAMETER ProcessName
+The process name, or the sentinel 'AllProcesses' for the org-wide root scope.
+
+.PARAMETER Permissions
+An array of hashtables describing the desired ACEs.
+
+.PARAMETER isInherited
+Whether the ACL inherits permissions.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation.
+#>
+function Set-AzDoProcessPermissions
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$ProcessName,
+
+        [Parameter()]
+        [HashTable[]]$Permissions,
+
+        [Parameter()]
+        [bool]$isInherited = $true,
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Set-AzDoProcessPermissions] Started."
+
+    $OrganizationName  = (Get-AzDoOrganizationName)
+    $SecurityNamespace = Get-CacheItem -Key 'Process' -Type 'SecurityNamespaces'
+
+    if (-not $SecurityNamespace)
+    {
+        Write-Error "[Set-AzDoProcessPermissions] Security namespace 'Process' not found."
+        return
+    }
+
+    $processToken = Get-DevOpsProcessAclToken -ProcessName $ProcessName -OrganizationName $OrganizationName
+    if (-not $processToken)
+    {
+        Write-Error "[Set-AzDoProcessPermissions] Could not resolve a Process ACL token for '$ProcessName'."
+        return
+    }
+
+    $descriptorMatchToken = '^{0}$' -f [regex]::Escape($processToken)
+
+    $serializeACLParams = @{
+        ReferenceACLs        = $LookupResult.propertiesChanged
+        DescriptorACLList    = @()
+        DescriptorMatchToken = $descriptorMatchToken
+    }
+
+    $params = @{
+        OrganizationName    = $OrganizationName
+        SecurityNamespaceID = $SecurityNamespace.namespaceId
+        SerializedACLs      = ConvertTo-ACLHashtable @serializeACLParams
+    }
+
+    Set-AzDoPermission @params
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Get-AzDoTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Get-AzDoTeamSettings.ps1
@@ -11,7 +11,7 @@ Function Get-AzDoTeamSettings
         [Parameter()][string]$DefaultAreaPath,
         [Parameter()][string[]]$AreaPaths,
         [Parameter()][string[]]$WorkingDays,
-        [Parameter()][ValidateSet('asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
+        [Parameter()][ValidateSet('', 'asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
         [Parameter()][HashTable]$LookupResult,
         [Parameter()][Ensure]$Ensure,
         [Parameter()][System.Management.Automation.SwitchParameter]$Force
@@ -23,6 +23,15 @@ Function Get-AzDoTeamSettings
         Ensure            = [Ensure]::Absent
         propertiesChanged = @()
         status            = $null
+    }
+
+    # Team settings cannot be removed (they always exist for a team). Treat 'Ensure = Absent' as a
+    # no-op that is already in its desired state so the engine does not loop trying to remove it.
+    if ($Ensure -eq [Ensure]::Absent)
+    {
+        Write-Verbose "[Get-AzDoTeamSettings] Ensure = Absent; team settings cannot be removed (no-op)."
+        $result.status = [DSCGetSummaryState]::NotFound
+        return $result
     }
 
     $OrgName = Get-AzDoOrganizationName
@@ -68,14 +77,11 @@ Function Get-AzDoTeamSettings
     if ($PSBoundParameters.ContainsKey('DefaultAreaPath') -and $DefaultAreaPath -and
         $live.DefaultAreaPath -ne $DefaultAreaPath) { $propertiesChanged += 'DefaultAreaPath' }
 
-    if ($PSBoundParameters.ContainsKey('IterationPaths') -and $IterationPaths -and
-        (Compare-Object -ReferenceObject @($live.IterationPaths) -DifferenceObject @($IterationPaths))) { $propertiesChanged += 'IterationPaths' }
+    if ($IterationPaths -and (Test-AzDoArrayDrift -Reference $live.IterationPaths -Difference $IterationPaths)) { $propertiesChanged += 'IterationPaths' }
 
-    if ($PSBoundParameters.ContainsKey('AreaPaths') -and $AreaPaths -and
-        (Compare-Object -ReferenceObject @($live.AreaPaths) -DifferenceObject @($AreaPaths))) { $propertiesChanged += 'AreaPaths' }
+    if ($AreaPaths -and (Test-AzDoArrayDrift -Reference $live.AreaPaths -Difference $AreaPaths)) { $propertiesChanged += 'AreaPaths' }
 
-    if ($PSBoundParameters.ContainsKey('WorkingDays') -and
-        (Compare-Object -ReferenceObject @($live.WorkingDays) -DifferenceObject @($WorkingDays))) { $propertiesChanged += 'WorkingDays' }
+    if ($WorkingDays -and (Test-AzDoArrayDrift -Reference $live.WorkingDays -Difference $WorkingDays)) { $propertiesChanged += 'WorkingDays' }
 
     if ($PSBoundParameters.ContainsKey('BugsBehavior') -and $BugsBehavior -and
         $live.BugsBehavior -ne $BugsBehavior) { $propertiesChanged += 'BugsBehavior' }

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Get-AzDoTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Get-AzDoTeamSettings.ps1
@@ -1,0 +1,98 @@
+Function Get-AzDoTeamSettings
+{
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.PSObject[]])]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$TeamName,
+        [Parameter()][string]$BacklogIterationPath,
+        [Parameter()][string]$DefaultIterationPath,
+        [Parameter()][string[]]$IterationPaths,
+        [Parameter()][string]$DefaultAreaPath,
+        [Parameter()][string[]]$AreaPaths,
+        [Parameter()][string[]]$WorkingDays,
+        [Parameter()][ValidateSet('asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Get-AzDoTeamSettings] Started for team '$TeamName' in project '$ProjectName'."
+
+    $result = @{
+        Ensure            = [Ensure]::Absent
+        propertiesChanged = @()
+        status            = $null
+    }
+
+    $OrgName = Get-AzDoOrganizationName
+    $ApiUri  = 'https://dev.azure.com/{0}' -f $OrgName
+
+    # Resolve the project (cache first, then live lookup).
+    $project = Get-CacheItem -Key $ProjectName -Type 'LiveProjects'
+    if (-not $project)
+    {
+        $project = Invoke-AzDevOpsApiRestMethod -Uri "$ApiUri/_apis/projects/${ProjectName}?api-version=7.1-preview.4" -Method Get
+        if ($project) { Add-CacheItem -Key $ProjectName -Value $project -Type 'LiveProjects' }
+    }
+
+    # Resolve the team (cache first, then live lookup).
+    $cacheKey = '{0}\{1}' -f $ProjectName, $TeamName
+    $team     = Get-CacheItem -Key $cacheKey -Type 'LiveTeams'
+    if ((-not $team) -and $project)
+    {
+        $allTeams = List-DevOpsTeams -ApiUri $ApiUri -ProjectId $project.id
+        $team     = $allTeams | Where-Object { $_.name -eq $TeamName } | Select-Object -First 1
+        if ($team) { Add-CacheItem -Key $cacheKey -Value $team -Type 'LiveTeams' }
+    }
+
+    if ((-not $project) -or (-not $team))
+    {
+        Write-Verbose "[Get-AzDoTeamSettings] Project or Team not found."
+        $result.status = [DSCGetSummaryState]::NotFound
+        return $result
+    }
+
+    $live = Get-DevOpsTeamSettings -ApiUri $ApiUri -ProjectId $project.id -TeamId $team.id
+    $result.liveCache = $live
+
+    # Compare desired properties against the live configuration to detect drift.
+    $propertiesChanged = @()
+
+    if ($PSBoundParameters.ContainsKey('BacklogIterationPath') -and $BacklogIterationPath -and
+        $live.BacklogIterationPath -ne $BacklogIterationPath) { $propertiesChanged += 'BacklogIterationPath' }
+
+    if ($PSBoundParameters.ContainsKey('DefaultIterationPath') -and $DefaultIterationPath -and
+        $live.DefaultIterationPath -ne $DefaultIterationPath) { $propertiesChanged += 'DefaultIterationPath' }
+
+    if ($PSBoundParameters.ContainsKey('DefaultAreaPath') -and $DefaultAreaPath -and
+        $live.DefaultAreaPath -ne $DefaultAreaPath) { $propertiesChanged += 'DefaultAreaPath' }
+
+    if ($PSBoundParameters.ContainsKey('IterationPaths') -and $IterationPaths -and
+        (Compare-Object -ReferenceObject @($live.IterationPaths) -DifferenceObject @($IterationPaths))) { $propertiesChanged += 'IterationPaths' }
+
+    if ($PSBoundParameters.ContainsKey('AreaPaths') -and $AreaPaths -and
+        (Compare-Object -ReferenceObject @($live.AreaPaths) -DifferenceObject @($AreaPaths))) { $propertiesChanged += 'AreaPaths' }
+
+    if ($PSBoundParameters.ContainsKey('WorkingDays') -and
+        (Compare-Object -ReferenceObject @($live.WorkingDays) -DifferenceObject @($WorkingDays))) { $propertiesChanged += 'WorkingDays' }
+
+    if ($PSBoundParameters.ContainsKey('BugsBehavior') -and $BugsBehavior -and
+        $live.BugsBehavior -ne $BugsBehavior) { $propertiesChanged += 'BugsBehavior' }
+
+    $result.propertiesChanged = $propertiesChanged
+    $result.Ensure            = [Ensure]::Present
+
+    if ($propertiesChanged.Count -gt 0)
+    {
+        Write-Verbose "[Get-AzDoTeamSettings] Drift detected on: $($propertiesChanged -join ', ')."
+        $result.status = [DSCGetSummaryState]::Changed
+    }
+    else
+    {
+        Write-Verbose "[Get-AzDoTeamSettings] Team settings match desired state."
+        $result.status = [DSCGetSummaryState]::Unchanged
+    }
+
+    return $result
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/New-AzDoTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/New-AzDoTeamSettings.ps1
@@ -10,7 +10,7 @@ Function New-AzDoTeamSettings
         [Parameter()][string]$DefaultAreaPath,
         [Parameter()][string[]]$AreaPaths,
         [Parameter()][string[]]$WorkingDays,
-        [Parameter()][ValidateSet('asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
+        [Parameter()][ValidateSet('', 'asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
         [Parameter()][HashTable]$LookupResult,
         [Parameter()][Ensure]$Ensure,
         [Parameter()][System.Management.Automation.SwitchParameter]$Force

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/New-AzDoTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/New-AzDoTeamSettings.ps1
@@ -1,0 +1,23 @@
+Function New-AzDoTeamSettings
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$TeamName,
+        [Parameter()][string]$BacklogIterationPath,
+        [Parameter()][string]$DefaultIterationPath,
+        [Parameter()][string[]]$IterationPaths,
+        [Parameter()][string]$DefaultAreaPath,
+        [Parameter()][string[]]$AreaPaths,
+        [Parameter()][string[]]$WorkingDays,
+        [Parameter()][ValidateSet('asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[New-AzDoTeamSettings] Configuring settings for team '$TeamName' in project '$ProjectName'."
+
+    # Team settings always exist for an existing team, so creation and update are the same operation.
+    Set-AzDoTeamSettings @PSBoundParameters
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Remove-AzDoTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Remove-AzDoTeamSettings.ps1
@@ -1,0 +1,22 @@
+Function Remove-AzDoTeamSettings
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$TeamName,
+        [Parameter()][string]$BacklogIterationPath,
+        [Parameter()][string]$DefaultIterationPath,
+        [Parameter()][string[]]$IterationPaths,
+        [Parameter()][string]$DefaultAreaPath,
+        [Parameter()][string[]]$AreaPaths,
+        [Parameter()][string[]]$WorkingDays,
+        [Parameter()][ValidateSet('asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    # Team iteration and area-path configuration cannot be deleted — it always exists for a team
+    # and falls back to the project defaults. 'Ensure = Absent' is therefore a no-op for this resource.
+    Write-Verbose "[Remove-AzDoTeamSettings] Team settings for '$TeamName' cannot be removed; leaving project defaults in place."
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Remove-AzDoTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Remove-AzDoTeamSettings.ps1
@@ -10,7 +10,7 @@ Function Remove-AzDoTeamSettings
         [Parameter()][string]$DefaultAreaPath,
         [Parameter()][string[]]$AreaPaths,
         [Parameter()][string[]]$WorkingDays,
-        [Parameter()][ValidateSet('asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
+        [Parameter()][ValidateSet('', 'asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
         [Parameter()][HashTable]$LookupResult,
         [Parameter()][Ensure]$Ensure,
         [Parameter()][System.Management.Automation.SwitchParameter]$Force

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Set-AzDoTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Set-AzDoTeamSettings.ps1
@@ -1,0 +1,58 @@
+Function Set-AzDoTeamSettings
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter(Mandatory = $true)][string]$TeamName,
+        [Parameter()][string]$BacklogIterationPath,
+        [Parameter()][string]$DefaultIterationPath,
+        [Parameter()][string[]]$IterationPaths,
+        [Parameter()][string]$DefaultAreaPath,
+        [Parameter()][string[]]$AreaPaths,
+        [Parameter()][string[]]$WorkingDays,
+        [Parameter()][ValidateSet('asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Set-AzDoTeamSettings] Applying settings for team '$TeamName' in project '$ProjectName'."
+
+    $OrgName = Get-AzDoOrganizationName
+    $ApiUri  = 'https://dev.azure.com/{0}' -f $OrgName
+
+    $project = Resolve-AzDoProject -ProjectName $ProjectName
+    if (-not $project)
+    {
+        Write-Error "[Set-AzDoTeamSettings] Project '$ProjectName' not found."
+        return
+    }
+
+    $team = Get-CacheItem -Key ('{0}\{1}' -f $ProjectName, $TeamName) -Type 'LiveTeams'
+    if (-not $team)
+    {
+        $allTeams = List-DevOpsTeams -ApiUri $ApiUri -ProjectId $project.id
+        $team     = $allTeams | Where-Object { $_.name -eq $TeamName } | Select-Object -First 1
+    }
+    if (-not $team)
+    {
+        Write-Error "[Set-AzDoTeamSettings] Team '$TeamName' not found in project '$ProjectName'."
+        return
+    }
+
+    $params = @{ ApiUri = $ApiUri; ProjectId = $project.id; TeamId = $team.id }
+    foreach ($name in 'BacklogIterationPath', 'DefaultIterationPath', 'IterationPaths', 'DefaultAreaPath', 'AreaPaths', 'WorkingDays', 'BugsBehavior')
+    {
+        if ($PSBoundParameters.ContainsKey($name)) { $params[$name] = $PSBoundParameters[$name] }
+    }
+
+    $value = Set-DevOpsTeamSettings @params
+
+    if ($null -eq $value)
+    {
+        Write-Error "[Set-AzDoTeamSettings] Set-DevOpsTeamSettings returned null. Check authentication token and organization settings."
+        return
+    }
+
+    Write-Verbose "[Set-AzDoTeamSettings] Team settings for '$TeamName' applied successfully."
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Set-AzDoTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Set-AzDoTeamSettings.ps1
@@ -10,7 +10,7 @@ Function Set-AzDoTeamSettings
         [Parameter()][string]$DefaultAreaPath,
         [Parameter()][string[]]$AreaPaths,
         [Parameter()][string[]]$WorkingDays,
-        [Parameter()][ValidateSet('asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
+        [Parameter()][ValidateSet('', 'asRequirements', 'asTasks', 'off')][string]$BugsBehavior,
         [Parameter()][HashTable]$LookupResult,
         [Parameter()][Ensure]$Ensure,
         [Parameter()][System.Management.Automation.SwitchParameter]$Force

--- a/tests/Integration/Invoke-Tests.ps1
+++ b/tests/Integration/Invoke-Tests.ps1
@@ -34,6 +34,39 @@ Write-Host "[Invoke-Tests] Running pre-run teardown to ensure a clean environmen
 Write-Host "[Invoke-Tests] Pre-run teardown complete."
 
 #
+# Clear project-scoped module cache files so DSC Get() calls re-fetch live state after teardown.
+# The DSC resources (especially the cache-first *Permission resources) resolve resource IDs and ACL
+# descriptors from these caches; leaving them stale after teardown makes Set succeed but the following
+# Test() compare against dead object IDs and return $false. Org-wide caches (LiveProcesses, LiveUsers,
+# LiveServicePrinciples, SecurityNamespaces, LivePolicyTypes) are static and must NOT be cleared.
+
+$cacheDir = Join-Path $env:AZDODSC_CACHE_DIRECTORY 'Cache'
+if (Test-Path $cacheDir)
+{
+    Write-Host "[Invoke-Tests] Clearing project-scoped cache files after teardown..."
+    $cacheFilesToClear = @(
+        'LiveProjects', 'LiveGroups', 'LiveGroupMembers', 'LiveRepositories',
+        'LiveTeams', 'LiveTeamMembers', 'LiveArtifactFeeds', 'LiveAgentPools',
+        'LiveAgentQueues', 'LiveAreaNodes', 'LiveIterations', 'LiveACLList',
+        'Group', 'SecurityDescriptor', 'IdentityDescriptorIndex'
+    )
+    foreach ($cacheFile in $cacheFilesToClear)
+    {
+        $filePath = Join-Path $cacheDir "$cacheFile.clixml"
+        if (Test-Path $filePath)
+        {
+            Write-Host "[Invoke-Tests] Removing stale cache: $cacheFile"
+            Remove-Item -Path $filePath -Force
+        }
+    }
+}
+
+# Azure DevOps project deletions are asynchronous. Wait for them to settle before the tests try to
+# re-create the same projects; otherwise BeforeAll can hit 400 "project name in use" / TF200016.
+Write-Host "[Invoke-Tests] Waiting 90 seconds for Azure DevOps to complete async project deletions..."
+Start-Sleep -Seconds 90
+
+#
 # Trigger the Tests
 
 $pesterConfig = New-PesterConfiguration

--- a/tests/Integration/Resources/AzDoArtifactFeedSettings.tests.ps1
+++ b/tests/Integration/Resources/AzDoArtifactFeedSettings.tests.ps1
@@ -1,0 +1,94 @@
+Describe "AzDoArtifactFeedSettings Integration Tests" -Tag "Integration", "ArtifactFeedSettings" {
+
+    BeforeAll {
+
+        $PROJECTNAME = 'TEST_ARTIFACT_FEED_SETTINGS'
+        # Azure DevOps reserves a feed name for a cooldown period after deletion — use a unique name.
+        $FEEDNAME = "testfeedsettings$(Get-Random -Maximum 99999)"
+
+        New-TestProject -ProjectName $PROJECTNAME
+
+        # Settings require an existing feed — create one via the AzDoArtifactFeed resource first.
+        Invoke-DscResource -Name 'AzDoArtifactFeed' -ModuleName 'AzureDevOpsDsc' -Method 'Set' -Property @{
+            ProjectName = $PROJECTNAME
+            FeedName    = $FEEDNAME
+            Description = 'Feed used for feed-settings integration tests'
+        }
+
+        $parameters = @{
+            Name       = 'AzDoArtifactFeedSettings'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                ProjectName                          = $PROJECTNAME
+                FeedName                             = $FEEDNAME
+                HideDeletedPackageVersions           = $true
+                RetentionCountLimit                  = 100
+                DaysToKeepRecentlyDownloadedPackages = 30
+            }
+        }
+    }
+
+    Context "Testing if the feed settings are in desired state" {
+
+        BeforeAll { $parameters.Method = 'Test' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+    }
+
+    Context "Applying the feed settings" {
+
+        BeforeAll { $parameters.Method = 'Set' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after applying the settings" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Updating the hide-deleted-package-versions setting" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property.HideDeletedPackageVersions = $false
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after update" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Removing the feed settings (no-op — settings cannot be removed)" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property = @{
+                ProjectName = $PROJECTNAME
+                FeedName    = $FEEDNAME
+                Ensure      = 'Absent'
+            }
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True (Absent is a no-op for this resource)" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+}

--- a/tests/Integration/Resources/AzDoArtifactFeedView.tests.ps1
+++ b/tests/Integration/Resources/AzDoArtifactFeedView.tests.ps1
@@ -1,0 +1,101 @@
+Describe "AzDoArtifactFeedView Integration Tests" -Tag "Integration", "ArtifactFeedView" {
+
+    BeforeAll {
+
+        $PROJECTNAME = 'TEST_ARTIFACT_FEED_VIEW'
+        # Azure DevOps reserves a feed name for a cooldown period after deletion — use a unique name.
+        $FEEDNAME = "testfeedview$(Get-Random -Maximum 99999)"
+        $VIEWNAME = 'IntegrationView'
+
+        New-TestProject -ProjectName $PROJECTNAME
+
+        # Views require an existing feed — create one via the AzDoArtifactFeed resource first.
+        Invoke-DscResource -Name 'AzDoArtifactFeed' -ModuleName 'AzureDevOpsDsc' -Method 'Set' -Property @{
+            ProjectName = $PROJECTNAME
+            FeedName    = $FEEDNAME
+            Description = 'Feed used for feed-view integration tests'
+        }
+
+        $parameters = @{
+            Name       = 'AzDoArtifactFeedView'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                ProjectName    = $PROJECTNAME
+                FeedName       = $FEEDNAME
+                ViewName       = $VIEWNAME
+                ViewType       = 'release'
+                ViewVisibility = 'collection'
+            }
+        }
+    }
+
+    Context "Testing if the view exists" {
+
+        BeforeAll { $parameters.Method = 'Test' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return False (view does not exist yet)" {
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeFalse
+        }
+    }
+
+    Context "Creating the view" {
+
+        BeforeAll { $parameters.Method = 'Set' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after creation" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Updating the view visibility" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property.ViewVisibility = 'organization'
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after update" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Removing the view" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property = @{
+                ProjectName = $PROJECTNAME
+                FeedName    = $FEEDNAME
+                ViewName    = $VIEWNAME
+                Ensure      = 'Absent'
+            }
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True (Absent is desired state)" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+}

--- a/tests/Integration/Resources/AzDoProcess.tests.ps1
+++ b/tests/Integration/Resources/AzDoProcess.tests.ps1
@@ -1,0 +1,85 @@
+Describe "AzDoProcess Integration Tests" -Tag "Integration", "Process" {
+
+    BeforeAll {
+
+        # Inherited processes cannot be created twice with the same name, and a name may be briefly
+        # reserved after deletion — use a unique name per run.
+        $PROCESSNAME = "ITProcess$(Get-Random -Maximum 99999)"
+
+        $parameters = @{
+            Name       = 'AzDoProcess'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                ProcessName       = $PROCESSNAME
+                ParentProcessName = 'Agile'
+                Description       = 'Inherited process for integration testing'
+            }
+        }
+    }
+
+    Context "Testing if the process exists" {
+
+        BeforeAll { $parameters.Method = 'Test' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return False (process not yet created)" {
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeFalse
+        }
+    }
+
+    Context "Creating the process" {
+
+        BeforeAll { $parameters.Method = 'Set' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after creation" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Updating the description" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property.Description = 'Updated inherited process description'
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after the description update" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Removing the process" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property.Ensure = 'Absent'
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after removal" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+}

--- a/tests/Integration/Resources/AzDoProcessPermission.tests.ps1
+++ b/tests/Integration/Resources/AzDoProcessPermission.tests.ps1
@@ -1,0 +1,114 @@
+Describe "AzDoProcessPermission Integration Tests" -Tag "Integration", "ProcessPermission" {
+
+    BeforeAll {
+
+        $GROUPNAME = 'ProcessPermGroup'
+
+        # Process permissions apply at the organisation level ($PROCESS root). Create an org-level group
+        # to grant the 'Create' permission to (i.e. the ability to create inherited/child processes).
+        $body = @{ displayName = $GROUPNAME; description = 'Group for process permission testing' } | ConvertTo-Json
+        try
+        {
+            $null = Invoke-RestMethod -Uri "https://vssps.dev.azure.com/$(Resolve-TestOrg)/_apis/graph/groups?api-version=7.1-preview.1" `
+                -Method Post -Headers (Resolve-TestAuthHeader) -Body $body -ContentType 'application/json'
+        }
+        catch { if ("$_" -notmatch '409|already exist') { throw } }
+
+        # 'AllProcesses' targets the org-wide root token ($PROCESS). The GroupName/Identity references an
+        # organisation-level group descriptor ("[]\GroupName").
+        $parameters = @{
+            Name       = 'AzDoProcessPermission'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                ProcessName = 'AllProcesses'
+                isInherited = $false
+                Permissions = @(
+                    @{
+                        Identity   = "[]\$GROUPNAME"
+                        Permission = @{
+                            Create = 'Allow'
+                            Edit   = 'Allow'
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    Context "Testing if process permissions exist" {
+
+        BeforeAll { $parameters.Method = 'Test' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return False (permissions not yet set)" {
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeFalse
+        }
+    }
+
+    Context "Setting process permissions" {
+
+        BeforeAll { $parameters.Method = 'Set' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after setting permissions" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Changing process permissions" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property.Permissions = @(
+                @{
+                    Identity   = "[]\$GROUPNAME"
+                    Permission = @{
+                        Create = 'Allow'
+                        Edit   = 'Deny'
+                    }
+                }
+            )
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after changing permissions" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Reverting to inherited permissions" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property.Permissions = @()
+            $parameters.property.isInherited  = $true
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after reverting to inherited" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+}

--- a/tests/Integration/Resources/AzDoTeamSettings.tests.ps1
+++ b/tests/Integration/Resources/AzDoTeamSettings.tests.ps1
@@ -1,0 +1,97 @@
+Describe "AzDoTeamSettings Integration Tests" -Tag "Integration", "TeamSettings" {
+
+    BeforeAll {
+
+        $PROJECTNAME = 'TEST_TEAMSETTINGS'
+        $TEAMNAME    = 'TESTTEAMSETTINGS'
+
+        New-TestProject -ProjectName $PROJECTNAME
+
+        # Team settings require an existing team — create one via the AzDoTeam resource first.
+        Invoke-DscResource -Name 'AzDoTeam' -ModuleName 'AzureDevOpsDsc' -Method 'Set' -Property @{
+            ProjectName = $PROJECTNAME
+            TeamName    = $TEAMNAME
+            Description = 'Team used for team-settings integration tests'
+        }
+
+        $parameters = @{
+            Name       = 'AzDoTeamSettings'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                ProjectName  = $PROJECTNAME
+                TeamName     = $TEAMNAME
+                DefaultAreaPath = $PROJECTNAME
+                WorkingDays  = @('monday', 'tuesday', 'wednesday', 'thursday', 'friday')
+                BugsBehavior = 'asRequirements'
+            }
+        }
+    }
+
+    Context "Testing if the team settings are in desired state" {
+
+        BeforeAll {
+            $parameters.Method = 'Test'
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+    }
+
+    Context "Applying the team settings" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after applying the settings" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Updating the bugs behavior" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property.BugsBehavior = 'asTasks'
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after update" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Removing the team settings (no-op — settings cannot be removed)" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property = @{
+                ProjectName = $PROJECTNAME
+                TeamName    = $TEAMNAME
+                Ensure      = 'Absent'
+            }
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True (Absent is a no-op for this resource)" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Get-DevOpsProcess.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Get-DevOpsProcess.tests.ps1
@@ -1,0 +1,43 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Get-DevOpsProcess' -Tag "Unit", "Process", "API" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-DevOpsProcess.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+    }
+
+    Context 'when the process exists' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith {
+                return @{ typeId = 'pid'; name = 'MyProcess'; parentProcessTypeId = 'parent-id' }
+            }
+        }
+
+        It 'GETs the work/processes/{id} endpoint and returns the process' {
+            $result = Get-DevOpsProcess -Organization 'myorg' -ProcessTypeId 'pid'
+            $result.parentProcessTypeId | Should -Be 'parent-id'
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+                $ApiUri -like '*/_apis/work/processes/pid*' -and $Method -eq 'Get'
+            }
+        }
+    }
+
+    Context 'when the API call fails' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'not found' }
+        }
+
+        It 'returns null instead of throwing' {
+            $result = Get-DevOpsProcess -Organization 'myorg' -ProcessTypeId 'pid'
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Get-DevOpsProcessAclToken.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Get-DevOpsProcessAclToken.tests.ps1
@@ -1,0 +1,63 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Get-DevOpsProcessAclToken' -Tag "Unit", "Process", "API" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-DevOpsProcessAclToken.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Write-Warning
+    }
+
+    Context 'when scope is the AllProcesses sentinel' {
+
+        It 'returns the org-wide root token' {
+            $result = Get-DevOpsProcessAclToken -ProcessName 'AllProcesses' -OrganizationName 'myorg'
+            $result | Should -Be '$PROCESS'
+        }
+    }
+
+    Context 'when scope is a specific inherited process' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsProcess -MockWith { return @{ id = 'process-id'; name = 'MyProcess' } }
+            Mock -CommandName Get-DevOpsProcess -MockWith { return @{ typeId = 'process-id'; parentProcessTypeId = 'parent-id' } }
+        }
+
+        It 'returns the per-process token $PROCESS:{parent}:{id}' {
+            $result = Get-DevOpsProcessAclToken -ProcessName 'MyProcess' -OrganizationName 'myorg'
+            $result | Should -Be '$PROCESS:parent-id:process-id'
+        }
+    }
+
+    Context 'when scope is a system process (no parent)' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsProcess -MockWith { return @{ id = 'system-id'; name = 'Agile' } }
+            Mock -CommandName Get-DevOpsProcess -MockWith { return @{ typeId = 'system-id'; parentProcessTypeId = '00000000-0000-0000-0000-000000000000' } }
+        }
+
+        It 'returns null and warns' {
+            $result = Get-DevOpsProcessAclToken -ProcessName 'Agile' -OrganizationName 'myorg'
+            $result | Should -BeNullOrEmpty
+            Assert-MockCalled -CommandName Write-Warning -Times 1
+        }
+    }
+
+    Context 'when the process does not exist' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsProcess -MockWith { return $null }
+        }
+
+        It 'returns null' {
+            $result = Get-DevOpsProcessAclToken -ProcessName 'Missing' -OrganizationName 'myorg'
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/New-DevOpsProcess.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/New-DevOpsProcess.tests.ps1
@@ -1,0 +1,51 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'New-DevOpsProcess' -Tag "Unit", "Process", "API" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'New-DevOpsProcess.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith {
+            return @{ typeId = 'new-id'; name = 'MyProcess'; description = 'desc' }
+        }
+    }
+
+    Context 'when called with valid parameters' {
+
+        It 'POSTs to the work/processes endpoint and returns the created process' {
+            $result = New-DevOpsProcess -Organization 'myorg' -Name 'MyProcess' -ParentProcessTypeId 'parent-id' -Description 'desc'
+            $result.name | Should -Be 'MyProcess'
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+                $ApiUri -like '*/_apis/work/processes*' -and $Method -eq 'POST' -and $Body -ne $null
+            }
+        }
+    }
+
+    Context 'when the API returns null' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return $null }
+        }
+
+        It 'throws' {
+            { New-DevOpsProcess -Organization 'myorg' -Name 'MyProcess' -ParentProcessTypeId 'parent-id' } | Should -Throw
+        }
+    }
+
+    Context 'when the API call fails' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'API call failed' }
+        }
+
+        It 'throws a wrapped error' {
+            { New-DevOpsProcess -Organization 'myorg' -Name 'MyProcess' -ParentProcessTypeId 'parent-id' } | Should -Throw '*Failed to create process*'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Remove-DevOpsProcess.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Remove-DevOpsProcess.tests.ps1
@@ -1,0 +1,37 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Remove-DevOpsProcess' -Tag "Unit", "Process", "API" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Remove-DevOpsProcess.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return $null }
+    }
+
+    Context 'when called' {
+
+        It 'DELETEs the work/processes/{id} endpoint' {
+            Remove-DevOpsProcess -Organization 'myorg' -ProcessTypeId 'pid'
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+                $ApiUri -like '*/_apis/work/processes/pid*' -and $Method -eq 'DELETE'
+            }
+        }
+    }
+
+    Context 'when the API call fails' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'API call failed' }
+        }
+
+        It 'throws a wrapped error' {
+            { Remove-DevOpsProcess -Organization 'myorg' -ProcessTypeId 'pid' } | Should -Throw '*Failed to delete process*'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Resolve-DevOpsProcess.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Resolve-DevOpsProcess.tests.ps1
@@ -1,0 +1,62 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Resolve-DevOpsProcess' -Tag "Unit", "Process", "API" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Resolve-DevOpsProcess.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Add-CacheItem
+    }
+
+    Context 'when the process is in the cache' {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -MockWith { return @{ id = 'cached-id'; name = 'Agile' } }
+            Mock -CommandName List-DevOpsProcess
+        }
+
+        It 'returns the cached process without a live lookup' {
+            $result = Resolve-DevOpsProcess -ProcessName 'Agile' -OrganizationName 'myorg'
+            $result.id | Should -Be 'cached-id'
+            Assert-MockCalled -CommandName List-DevOpsProcess -Times 0
+        }
+    }
+
+    Context 'when the process is not cached but exists live' {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -MockWith { return $null }
+            Mock -CommandName List-DevOpsProcess -MockWith {
+                return @(
+                    @{ id = 'live-id'; name = 'MyProcess' }
+                    @{ id = 'other-id'; name = 'Other' }
+                )
+            }
+        }
+
+        It 'returns the live process and caches it' {
+            $result = Resolve-DevOpsProcess -ProcessName 'MyProcess' -OrganizationName 'myorg'
+            $result.id | Should -Be 'live-id'
+            Assert-MockCalled -CommandName Add-CacheItem -Times 1 -ParameterFilter { $Type -eq 'LiveProcesses' }
+        }
+    }
+
+    Context 'when the process does not exist' {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -MockWith { return $null }
+            Mock -CommandName List-DevOpsProcess -MockWith { return @() }
+        }
+
+        It 'returns null' {
+            $result = Resolve-DevOpsProcess -ProcessName 'Missing' -OrganizationName 'myorg'
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Update-DevOpsProcess.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Process/Update-DevOpsProcess.tests.ps1
@@ -1,0 +1,45 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Update-DevOpsProcess' -Tag "Unit", "Process", "API" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Update-DevOpsProcess.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return @{ typeId = 'id'; name = 'MyProcess' } }
+    }
+
+    Context 'when fields are supplied' {
+
+        It 'PATCHes the work/processes/{id} endpoint' {
+            Update-DevOpsProcess -Organization 'myorg' -ProcessTypeId 'pid' -Name 'MyProcess' -Description 'new'
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+                $ApiUri -like '*/_apis/work/processes/pid*' -and $Method -eq 'PATCH'
+            }
+        }
+    }
+
+    Context 'when no updatable fields are supplied' {
+
+        It 'does not call the API' {
+            Update-DevOpsProcess -Organization 'myorg' -ProcessTypeId 'pid'
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 0
+        }
+    }
+
+    Context 'when the API call fails' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'API call failed' }
+        }
+
+        It 'throws a wrapped error' {
+            { Update-DevOpsProcess -Organization 'myorg' -ProcessTypeId 'pid' -Description 'new' } | Should -Throw '*Failed to edit process*'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Test-AzDoArrayDrift.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Test-AzDoArrayDrift.tests.ps1
@@ -1,0 +1,41 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "Test-AzDoArrayDrift" -Tag "Unit", "Helper" {
+
+    BeforeAll {
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Test-AzDoArrayDrift.tests.ps1'
+        }
+        . (Get-FunctionItem 'Test-AzDoArrayDrift.ps1')
+    }
+
+    Context "when both collections are empty or null" {
+        It "returns false for two nulls" {
+            Test-AzDoArrayDrift -Reference $null -Difference $null | Should -BeFalse
+        }
+        It "returns false for two empty arrays" {
+            Test-AzDoArrayDrift -Reference @() -Difference @() | Should -BeFalse
+        }
+    }
+
+    Context "when one collection is empty and the other is not" {
+        It "returns true when reference is empty but difference has items" {
+            Test-AzDoArrayDrift -Reference @() -Difference @('a') | Should -BeTrue
+        }
+        It "returns true when difference is empty but reference has items" {
+            Test-AzDoArrayDrift -Reference @('a') -Difference @() | Should -BeTrue
+        }
+    }
+
+    Context "when both collections are non-empty" {
+        It "returns false when the contents match (order-insensitive)" {
+            Test-AzDoArrayDrift -Reference @('a', 'b') -Difference @('b', 'a') | Should -BeFalse
+        }
+        It "returns true when the contents differ" {
+            Test-AzDoArrayDrift -Reference @('a', 'b') -Difference @('a', 'c') | Should -BeTrue
+        }
+        It "returns true when the counts differ" {
+            Test-AzDoArrayDrift -Reference @('a') -Difference @('a', 'b') | Should -BeTrue
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Get-AzDoArtifactFeedSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Get-AzDoArtifactFeedSettings.tests.ps1
@@ -21,6 +21,7 @@ Describe "Get-AzDoArtifactFeedSettings" -Tag "Unit", "ArtifactFeedSettings" {
         . (Get-ClassFilePath '000.CacheItem')
         . (Get-ClassFilePath 'Ensure')
         . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+        . (Get-FunctionItem 'Test-AzDoArrayDrift.ps1')
 
         $mockFeed = [PSCustomObject]@{
             id                         = 'feed-id-001'
@@ -34,6 +35,15 @@ Describe "Get-AzDoArtifactFeedSettings" -Tag "Unit", "ArtifactFeedSettings" {
         Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $mockFeed }
         Mock -CommandName Get-DevOpsArtifactFeedRetentionPolicy -MockWith {
             return [PSCustomObject]@{ countLimit = 100; daysToKeepRecentlyDownloadedPackages = 30 }
+        }
+    }
+
+    Context "when Ensure is Absent (no-op)" {
+
+        It "short-circuits to NotFound without resolving the feed" {
+            $result = Get-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' -Ensure 'Absent'
+            $result.status | Should -Be 'NotFound'
+            Assert-MockCalled -CommandName Resolve-DevOpsArtifactFeed -Exactly -Times 0
         }
     }
 
@@ -67,8 +77,14 @@ Describe "Get-AzDoArtifactFeedSettings" -Tag "Unit", "ArtifactFeedSettings" {
             $result.propertiesChanged | Should -Contain 'HideDeletedPackageVersions'
         }
 
-        It "detects drift on UpstreamSources" {
+        It "detects drift on UpstreamSources given as names" {
             $result = Get-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' -UpstreamSources @('NuGet Gallery')
+            $result.propertiesChanged | Should -Contain 'UpstreamSources'
+        }
+
+        It "detects drift on UpstreamSources given as objects" {
+            $result = Get-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' `
+                -UpstreamSources @([PSCustomObject]@{ name = 'NuGet Gallery' })
             $result.propertiesChanged | Should -Contain 'UpstreamSources'
         }
 

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Get-AzDoArtifactFeedSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Get-AzDoArtifactFeedSettings.tests.ps1
@@ -1,0 +1,85 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "Get-AzDoArtifactFeedSettings" -Tag "Unit", "ArtifactFeedSettings" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-AzDoArtifactFeedSettings.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        $mockFeed = [PSCustomObject]@{
+            id                         = 'feed-id-001'
+            name                       = 'TestFeed'
+            hideDeletedPackageVersions = $true
+            upstreamSources            = @([PSCustomObject]@{ name = 'npmjs' })
+        }
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $mockFeed }
+        Mock -CommandName Get-DevOpsArtifactFeedRetentionPolicy -MockWith {
+            return [PSCustomObject]@{ countLimit = 100; daysToKeepRecentlyDownloadedPackages = 30 }
+        }
+    }
+
+    Context "when the feed cannot be resolved" {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $null }
+        }
+
+        It "returns status NotFound" {
+            $result = Get-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'Missing'
+            $result.status | Should -Be 'NotFound'
+        }
+    }
+
+    Context "when the feed resolves and settings match" {
+
+        It "returns status Unchanged" {
+            $result = Get-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' `
+                -HideDeletedPackageVersions $true -RetentionCountLimit 100 -DaysToKeepRecentlyDownloadedPackages 30
+            $result.status | Should -Be 'Unchanged'
+            $result.Ensure | Should -Be 'Present'
+        }
+    }
+
+    Context "when the feed resolves but settings drift" {
+
+        It "returns Changed and reports HideDeletedPackageVersions" {
+            $result = Get-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' -HideDeletedPackageVersions $false
+            $result.status | Should -Be 'Changed'
+            $result.propertiesChanged | Should -Contain 'HideDeletedPackageVersions'
+        }
+
+        It "detects drift on UpstreamSources" {
+            $result = Get-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' -UpstreamSources @('NuGet Gallery')
+            $result.propertiesChanged | Should -Contain 'UpstreamSources'
+        }
+
+        It "detects drift on the retention policy" {
+            $result = Get-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' -RetentionCountLimit 500
+            $result.propertiesChanged | Should -Contain 'RetentionCountLimit'
+        }
+
+        It "does not query the retention policy when RetentionCountLimit is 0" {
+            Get-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' -HideDeletedPackageVersions $true
+            Assert-MockCalled -CommandName Get-DevOpsArtifactFeedRetentionPolicy -Exactly -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/New-AzDoArtifactFeedSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/New-AzDoArtifactFeedSettings.tests.ps1
@@ -1,0 +1,29 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "New-AzDoArtifactFeedSettings" -Tag "Unit", "ArtifactFeedSettings" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'New-AzDoArtifactFeedSettings.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'Ensure')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Set-AzDoArtifactFeedSettings
+    }
+
+    Context "when invoked" {
+
+        It "delegates to Set-AzDoArtifactFeedSettings" {
+            New-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' -RetentionCountLimit 100
+            Assert-MockCalled -CommandName Set-AzDoArtifactFeedSettings -Exactly -Times 1 -ParameterFilter {
+                $ProjectName -eq 'TestProject' -and $FeedName -eq 'TestFeed' -and $RetentionCountLimit -eq 100
+            }
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Remove-AzDoArtifactFeedSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Remove-AzDoArtifactFeedSettings.tests.ps1
@@ -1,0 +1,31 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "Remove-AzDoArtifactFeedSettings" -Tag "Unit", "ArtifactFeedSettings" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Remove-AzDoArtifactFeedSettings.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'Ensure')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Set-DevOpsArtifactFeedSettings
+    }
+
+    Context "when invoked" {
+
+        It "does not throw (feed settings cannot be removed independently)" {
+            { Remove-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' } | Should -Not -Throw
+        }
+
+        It "is a no-op and makes no API call" {
+            Remove-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed'
+            Assert-MockCalled -CommandName Set-DevOpsArtifactFeedSettings -Exactly -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Set-AzDoArtifactFeedSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Set-AzDoArtifactFeedSettings.tests.ps1
@@ -71,4 +71,19 @@ Describe "Set-AzDoArtifactFeedSettings" -Tag "Unit", "ArtifactFeedSettings" {
             Assert-MockCalled -CommandName Set-DevOpsArtifactFeedSettings -Exactly -Times 0
         }
     }
+
+    Context "when the update returns null" {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $mockFeed }
+            Mock -CommandName Set-DevOpsArtifactFeedSettings -MockWith { return $null }
+            Mock -CommandName Write-Error -Verifiable
+        }
+
+        It "writes an error and does not cache" {
+            Set-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed'
+            Assert-VerifiableMock
+            Assert-MockCalled -CommandName Add-CacheItem -Exactly -Times 0
+        }
+    }
 }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Set-AzDoArtifactFeedSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Set-AzDoArtifactFeedSettings.tests.ps1
@@ -1,0 +1,74 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "Set-AzDoArtifactFeedSettings" -Tag "Unit", "ArtifactFeedSettings" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Set-AzDoArtifactFeedSettings.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        $mockFeed = [PSCustomObject]@{ id = 'feed-id-001'; name = 'TestFeed' }
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $mockFeed }
+        Mock -CommandName Set-DevOpsArtifactFeedSettings -MockWith { return $mockFeed }
+        Mock -CommandName Add-CacheItem
+        Mock -CommandName Export-CacheObject
+        Mock -CommandName Refresh-CacheObject
+    }
+
+    Context "when the feed is resolved" {
+
+        It "calls Set-DevOpsArtifactFeedSettings with the resolved FeedId" {
+            Set-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' -HideDeletedPackageVersions $false
+            Assert-MockCalled -CommandName Set-DevOpsArtifactFeedSettings -Exactly -Times 1 -ParameterFilter {
+                $FeedId -eq 'feed-id-001' -and $HideDeletedPackageVersions -eq $false
+            }
+        }
+
+        It "forwards UpstreamSources and the retention policy" {
+            Set-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed' `
+                -UpstreamSources @('npmjs') -RetentionCountLimit 100 -DaysToKeepRecentlyDownloadedPackages 30
+            Assert-MockCalled -CommandName Set-DevOpsArtifactFeedSettings -Exactly -Times 1 -ParameterFilter {
+                $RetentionCountLimit -eq 100 -and $DaysToKeepRecentlyDownloadedPackages -eq 30
+            }
+        }
+
+        It "caches the updated feed" {
+            Set-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'TestFeed'
+            Assert-MockCalled -CommandName Add-CacheItem -Exactly -Times 1 -ParameterFilter {
+                $Key -eq 'TestProject\TestFeed' -and $Type -eq 'LiveArtifactFeeds'
+            }
+        }
+    }
+
+    Context "when the feed cannot be resolved" {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $null }
+            Mock -CommandName Write-Error -Verifiable
+        }
+
+        It "writes an error and does not call Set-DevOpsArtifactFeedSettings" {
+            Set-AzDoArtifactFeedSettings -ProjectName 'TestProject' -FeedName 'Missing'
+            Assert-VerifiableMock
+            Assert-MockCalled -CommandName Set-DevOpsArtifactFeedSettings -Exactly -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Get-AzDoArtifactFeedView.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Get-AzDoArtifactFeedView.tests.ps1
@@ -68,5 +68,11 @@ Describe "Get-AzDoArtifactFeedView" -Tag "Unit", "ArtifactFeedView" {
             $result.status | Should -Be 'Changed'
             $result.propertiesChanged | Should -Contain 'ViewVisibility'
         }
+
+        It "returns Changed and reports ViewType" {
+            $result = Get-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'TestFeed' -ViewName 'Release' -ViewType 'implicit'
+            $result.status | Should -Be 'Changed'
+            $result.propertiesChanged | Should -Contain 'ViewType'
+        }
     }
 }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Get-AzDoArtifactFeedView.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Get-AzDoArtifactFeedView.tests.ps1
@@ -1,0 +1,72 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "Get-AzDoArtifactFeedView" -Tag "Unit", "ArtifactFeedView" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-AzDoArtifactFeedView.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        $mockFeed = [PSCustomObject]@{ id = 'feed-id-001'; name = 'TestFeed' }
+        $mockView = [PSCustomObject]@{ id = 'view-id-001'; name = 'Release'; type = 'release'; visibility = 'collection' }
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $mockFeed }
+        Mock -CommandName List-DevOpsArtifactFeedViews -MockWith { return @($mockView) }
+    }
+
+    Context "when the feed cannot be resolved" {
+
+        BeforeEach { Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $null } }
+
+        It "returns status NotFound" {
+            $result = Get-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'Missing' -ViewName 'Release'
+            $result.status | Should -Be 'NotFound'
+        }
+    }
+
+    Context "when the view does not exist" {
+
+        BeforeEach { Mock -CommandName List-DevOpsArtifactFeedViews -MockWith { return @() } }
+
+        It "returns status NotFound" {
+            $result = Get-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'TestFeed' -ViewName 'Missing'
+            $result.status | Should -Be 'NotFound'
+        }
+    }
+
+    Context "when the view exists and matches" {
+
+        It "returns status Unchanged" {
+            $result = Get-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'TestFeed' -ViewName 'Release' `
+                -ViewType 'release' -ViewVisibility 'collection'
+            $result.status | Should -Be 'Unchanged'
+            $result.Ensure | Should -Be 'Present'
+        }
+    }
+
+    Context "when the view exists but drifts" {
+
+        It "returns Changed and reports ViewVisibility" {
+            $result = Get-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'TestFeed' -ViewName 'Release' -ViewVisibility 'organization'
+            $result.status | Should -Be 'Changed'
+            $result.propertiesChanged | Should -Contain 'ViewVisibility'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/New-AzDoArtifactFeedView.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/New-AzDoArtifactFeedView.tests.ps1
@@ -1,0 +1,55 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "New-AzDoArtifactFeedView" -Tag "Unit", "ArtifactFeedView" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'New-AzDoArtifactFeedView.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'Ensure')
+
+        $mockFeed = [PSCustomObject]@{ id = 'feed-id-001'; name = 'TestFeed' }
+        $mockView = [PSCustomObject]@{ id = 'view-id-001'; name = 'Release' }
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $mockFeed }
+        Mock -CommandName New-DevOpsArtifactFeedView -MockWith { return $mockView }
+    }
+
+    Context "when the feed is resolved" {
+
+        It "calls New-DevOpsArtifactFeedView with the resolved FeedId and view details" {
+            New-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'TestFeed' -ViewName 'Release' `
+                -ViewType 'release' -ViewVisibility 'organization'
+            Assert-MockCalled -CommandName New-DevOpsArtifactFeedView -Exactly -Times 1 -ParameterFilter {
+                $FeedId -eq 'feed-id-001' -and $ViewName -eq 'Release' -and $ViewVisibility -eq 'organization'
+            }
+        }
+    }
+
+    Context "when the feed cannot be resolved" {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $null }
+            Mock -CommandName Write-Error -Verifiable
+        }
+
+        It "writes an error and does not call New-DevOpsArtifactFeedView" {
+            New-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'Missing' -ViewName 'Release'
+            Assert-VerifiableMock
+            Assert-MockCalled -CommandName New-DevOpsArtifactFeedView -Exactly -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/New-AzDoArtifactFeedView.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/New-AzDoArtifactFeedView.tests.ps1
@@ -52,4 +52,17 @@ Describe "New-AzDoArtifactFeedView" -Tag "Unit", "ArtifactFeedView" {
             Assert-MockCalled -CommandName New-DevOpsArtifactFeedView -Exactly -Times 0
         }
     }
+
+    Context "when the view creation returns null" {
+
+        BeforeEach {
+            Mock -CommandName New-DevOpsArtifactFeedView -MockWith { return $null }
+            Mock -CommandName Write-Error -Verifiable
+        }
+
+        It "writes an error" {
+            New-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'TestFeed' -ViewName 'Release'
+            Assert-VerifiableMock
+        }
+    }
 }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Remove-AzDoArtifactFeedView.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Remove-AzDoArtifactFeedView.tests.ps1
@@ -1,0 +1,51 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "Remove-AzDoArtifactFeedView" -Tag "Unit", "ArtifactFeedView" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Remove-AzDoArtifactFeedView.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'Ensure')
+
+        $mockFeed = [PSCustomObject]@{ id = 'feed-id-001'; name = 'TestFeed' }
+        $mockView = [PSCustomObject]@{ id = 'view-id-001'; name = 'Release' }
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $mockFeed }
+        Mock -CommandName List-DevOpsArtifactFeedViews -MockWith { return @($mockView) }
+        Mock -CommandName Remove-DevOpsArtifactFeedView
+    }
+
+    Context "when the feed and view are resolved" {
+
+        It "calls Remove-DevOpsArtifactFeedView with the resolved FeedId and ViewId" {
+            Remove-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'TestFeed' -ViewName 'Release'
+            Assert-MockCalled -CommandName Remove-DevOpsArtifactFeedView -Exactly -Times 1 -ParameterFilter {
+                $FeedId -eq 'feed-id-001' -and $ViewId -eq 'view-id-001'
+            }
+        }
+    }
+
+    Context "when the view is already absent" {
+
+        BeforeEach { Mock -CommandName List-DevOpsArtifactFeedViews -MockWith { return @() } }
+
+        It "treats a missing view as already absent (no removal, no throw)" {
+            { Remove-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'TestFeed' -ViewName 'Missing' } | Should -Not -Throw
+            Assert-MockCalled -CommandName Remove-DevOpsArtifactFeedView -Exactly -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Remove-AzDoArtifactFeedView.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Remove-AzDoArtifactFeedView.tests.ps1
@@ -48,4 +48,18 @@ Describe "Remove-AzDoArtifactFeedView" -Tag "Unit", "ArtifactFeedView" {
             Assert-MockCalled -CommandName Remove-DevOpsArtifactFeedView -Exactly -Times 0
         }
     }
+
+    Context "when the feed cannot be resolved" {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $null }
+            Mock -CommandName Write-Error -Verifiable
+        }
+
+        It "writes an error and does not remove anything" {
+            Remove-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'Missing' -ViewName 'Release'
+            Assert-VerifiableMock
+            Assert-MockCalled -CommandName Remove-DevOpsArtifactFeedView -Exactly -Times 0
+        }
+    }
 }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Set-AzDoArtifactFeedView.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Set-AzDoArtifactFeedView.tests.ps1
@@ -1,0 +1,55 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "Set-AzDoArtifactFeedView" -Tag "Unit", "ArtifactFeedView" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Set-AzDoArtifactFeedView.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'Ensure')
+
+        $mockFeed = [PSCustomObject]@{ id = 'feed-id-001'; name = 'TestFeed' }
+        $mockView = [PSCustomObject]@{ id = 'view-id-001'; name = 'Release'; type = 'release'; visibility = 'collection' }
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $mockFeed }
+        Mock -CommandName List-DevOpsArtifactFeedViews -MockWith { return @($mockView) }
+        Mock -CommandName Set-DevOpsArtifactFeedView -MockWith { return $mockView }
+    }
+
+    Context "when the feed and view are resolved" {
+
+        It "calls Set-DevOpsArtifactFeedView with the resolved FeedId and ViewId" {
+            Set-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'TestFeed' -ViewName 'Release' -ViewVisibility 'organization'
+            Assert-MockCalled -CommandName Set-DevOpsArtifactFeedView -Exactly -Times 1 -ParameterFilter {
+                $FeedId -eq 'feed-id-001' -and $ViewId -eq 'view-id-001' -and $ViewVisibility -eq 'organization'
+            }
+        }
+    }
+
+    Context "when the view cannot be found" {
+
+        BeforeEach {
+            Mock -CommandName List-DevOpsArtifactFeedViews -MockWith { return @() }
+            Mock -CommandName Write-Error -Verifiable
+        }
+
+        It "writes an error and does not call Set-DevOpsArtifactFeedView" {
+            Set-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'TestFeed' -ViewName 'Missing'
+            Assert-VerifiableMock
+            Assert-MockCalled -CommandName Set-DevOpsArtifactFeedView -Exactly -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Set-AzDoArtifactFeedView.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Set-AzDoArtifactFeedView.tests.ps1
@@ -52,4 +52,31 @@ Describe "Set-AzDoArtifactFeedView" -Tag "Unit", "ArtifactFeedView" {
             Assert-MockCalled -CommandName Set-DevOpsArtifactFeedView -Exactly -Times 0
         }
     }
+
+    Context "when the feed cannot be resolved" {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsArtifactFeed -MockWith { return $null }
+            Mock -CommandName Write-Error -Verifiable
+        }
+
+        It "writes an error and does not list views" {
+            Set-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'Missing' -ViewName 'Release'
+            Assert-VerifiableMock
+            Assert-MockCalled -CommandName List-DevOpsArtifactFeedViews -Exactly -Times 0
+        }
+    }
+
+    Context "when the update returns null" {
+
+        BeforeEach {
+            Mock -CommandName Set-DevOpsArtifactFeedView -MockWith { return $null }
+            Mock -CommandName Write-Error -Verifiable
+        }
+
+        It "writes an error" {
+            Set-AzDoArtifactFeedView -ProjectName 'TestProject' -FeedName 'TestFeed' -ViewName 'Release'
+            Assert-VerifiableMock
+        }
+    }
 }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Get-AzDoProcess.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Get-AzDoProcess.tests.ps1
@@ -1,0 +1,61 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Get-AzDoProcess' -Tag "Unit", "Process" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-AzDoProcess.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+    }
+
+    Context 'when the process exists' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsProcess -MockWith {
+                return @{ id = 'mock-process-id'; name = 'MyProcess'; description = 'ExistingDescription' }
+            }
+        }
+
+        It 'returns Unchanged when the description matches' {
+            $result = Get-AzDoProcess -ProcessName 'MyProcess' -ParentProcessName 'Agile' -Description 'ExistingDescription'
+            $result.status | Should -Be 'Unchanged'
+            $result.ProcessName | Should -Be 'MyProcess'
+        }
+
+        It 'returns Changed when the description differs' {
+            $result = Get-AzDoProcess -ProcessName 'MyProcess' -ParentProcessName 'Agile' -Description 'NewDescription'
+            $result.status | Should -Be 'Changed'
+            $result.propertiesChanged | Should -Contain 'Description'
+        }
+    }
+
+    Context 'when the process does not exist' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsProcess -MockWith { return $null }
+        }
+
+        It 'returns status NotFound' {
+            $result = Get-AzDoProcess -ProcessName 'Missing' -ParentProcessName 'Agile' -Description 'whatever'
+            $result.status | Should -Be 'NotFound'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/New-AzDoProcess.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/New-AzDoProcess.tests.ps1
@@ -1,0 +1,70 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'New-AzDoProcess' -Tag "Unit", "Process" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'New-AzDoProcess.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Add-CacheItem
+        Mock -CommandName New-DevOpsProcess -MockWith {
+            return @{ typeId = 'new-process-id'; name = 'MyProcess'; description = 'A description' }
+        }
+    }
+
+    Context 'when the parent process is found' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsProcess -MockWith { return @{ id = 'parent-id'; name = 'Agile' } }
+        }
+
+        It 'resolves the parent and calls New-DevOpsProcess with the parent type id' {
+            New-AzDoProcess -ProcessName 'MyProcess' -ParentProcessName 'Agile' -Description 'A description'
+            Assert-MockCalled -CommandName New-DevOpsProcess -Times 1 -ParameterFilter {
+                $ParentProcessTypeId -eq 'parent-id' -and $Name -eq 'MyProcess'
+            }
+        }
+
+        It 'adds the created process to the LiveProcesses cache' {
+            New-AzDoProcess -ProcessName 'MyProcess' -ParentProcessName 'Agile' -Description 'A description'
+            Assert-MockCalled -CommandName Add-CacheItem -Times 1 -ParameterFilter { $Type -eq 'LiveProcesses' }
+        }
+    }
+
+    Context 'when the parent process is not found' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsProcess -MockWith { return $null }
+        }
+
+        It 'throws and does not call New-DevOpsProcess' {
+            { New-AzDoProcess -ProcessName 'MyProcess' -ParentProcessName 'Nope' -Description 'x' } | Should -Throw
+            Assert-MockCalled -CommandName New-DevOpsProcess -Times 0
+        }
+    }
+
+    Context 'when no parent process name is supplied' {
+
+        It 'throws' {
+            { New-AzDoProcess -ProcessName 'MyProcess' -ParentProcessName '' -Description 'x' } | Should -Throw
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Remove-AzDoProcess.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Remove-AzDoProcess.tests.ps1
@@ -1,0 +1,59 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Remove-AzDoProcess' -Tag "Unit", "Process" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Remove-AzDoProcess.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Remove-DevOpsProcess
+        Mock -CommandName Remove-CacheItem
+    }
+
+    Context 'when the process exists' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsProcess -MockWith { return @{ id = 'mock-process-id'; name = 'MyProcess' } }
+        }
+
+        It 'calls Remove-DevOpsProcess with the resolved process id' {
+            Remove-AzDoProcess -ProcessName 'MyProcess' -ParentProcessName 'Agile'
+            Assert-MockCalled -CommandName Remove-DevOpsProcess -Times 1 -ParameterFilter { $ProcessTypeId -eq 'mock-process-id' }
+        }
+
+        It 'removes the process from the cache' {
+            Remove-AzDoProcess -ProcessName 'MyProcess' -ParentProcessName 'Agile'
+            Assert-MockCalled -CommandName Remove-CacheItem -Times 1 -ParameterFilter { $Type -eq 'LiveProcesses' }
+        }
+    }
+
+    Context 'when the process does not exist' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsProcess -MockWith { return $null }
+        }
+
+        It 'is a no-op and does not call Remove-DevOpsProcess' {
+            Remove-AzDoProcess -ProcessName 'Missing' -ParentProcessName 'Agile'
+            Assert-MockCalled -CommandName Remove-DevOpsProcess -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Set-AzDoProcess.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcess/Set-AzDoProcess.tests.ps1
@@ -1,0 +1,63 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Set-AzDoProcess' -Tag "Unit", "Process" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Set-AzDoProcess.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Add-CacheItem
+        Mock -CommandName Update-DevOpsProcess
+    }
+
+    Context 'when the process exists' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsProcess -MockWith {
+                return [PSCustomObject]@{ id = 'mock-process-id'; name = 'MyProcess'; description = 'old' }
+            }
+        }
+
+        It 'calls Update-DevOpsProcess with the resolved process id' {
+            Set-AzDoProcess -ProcessName 'MyProcess' -ParentProcessName 'Agile' -Description 'new'
+            Assert-MockCalled -CommandName Update-DevOpsProcess -Times 1 -ParameterFilter {
+                $ProcessTypeId -eq 'mock-process-id' -and $Description -eq 'new'
+            }
+        }
+
+        It 'refreshes the cache entry' {
+            Set-AzDoProcess -ProcessName 'MyProcess' -ParentProcessName 'Agile' -Description 'new'
+            Assert-MockCalled -CommandName Add-CacheItem -Times 1 -ParameterFilter { $Type -eq 'LiveProcesses' }
+        }
+    }
+
+    Context 'when the process does not exist' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsProcess -MockWith { return $null }
+        }
+
+        It 'throws and does not call Update-DevOpsProcess' {
+            { Set-AzDoProcess -ProcessName 'Missing' -ParentProcessName 'Agile' -Description 'x' } | Should -Throw
+            Assert-MockCalled -CommandName Update-DevOpsProcess -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Get-AzDoProcessPermission.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Get-AzDoProcessPermission.tests.ps1
@@ -1,0 +1,115 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Get-AzDoProcessPermission' -Tag "Unit", "ProcessPermission" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-AzDoProcessPermission.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Write-Error
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+
+        Mock -CommandName Get-DevOpsProcessAclToken -MockWith { return '$PROCESS' }
+
+        Mock -CommandName Get-CacheItem -MockWith {
+            param ($Key, $Type)
+            switch ($Type) {
+                'SecurityNamespaces' { return @{ namespaceId = 'mock-namespace-id' } }
+                default              { return $null }
+            }
+        }
+
+        Mock -CommandName Get-DevOpsACL -MockWith {
+            return @( @{ token = '$PROCESS'; ace = 'mock-ace' } )
+        }
+
+        Mock -CommandName ConvertTo-FormattedACL -MockWith {
+            return @( @{ Token = @{ Type = 'ProcessRoot' }; aces = @() } )
+        }
+
+        Mock -CommandName ConvertTo-ACL -MockWith {
+            return @( @{ token = @{ Type = 'ProcessRoot' }; aces = @() } )
+        }
+
+        Mock -CommandName Test-ACLListforChanges -MockWith {
+            return @{ propertiesChanged = @(); status = 'Unchanged'; reason = 'No changes' }
+        }
+    }
+
+    Context 'when the namespace and token resolve' {
+
+        It 'calls Get-DevOpsACL' {
+            Get-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false
+            Assert-MockCalled -CommandName Get-DevOpsACL -Times 1
+        }
+
+        It 'calls Test-ACLListforChanges and returns its status' {
+            $result = Get-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false
+            Assert-MockCalled -CommandName Test-ACLListforChanges -Times 1
+            $result.status | Should -Be 'Unchanged'
+        }
+
+        It 'returns Changed when Test-ACLListforChanges reports changes' {
+            Mock -CommandName Test-ACLListforChanges -MockWith {
+                return @{ propertiesChanged = @('Permission'); status = 'Changed'; reason = 'Mismatch' }
+            }
+            $result = Get-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false
+            $result.status | Should -Be 'Changed'
+            $result.propertiesChanged | Should -Contain 'Permission'
+        }
+    }
+
+    Context 'when the process token cannot be resolved' {
+
+        BeforeEach {
+            Mock -CommandName Get-DevOpsProcessAclToken -MockWith { return $null }
+        }
+
+        It 'returns status Error and does not call Get-DevOpsACL' {
+            $result = Get-AzDoProcessPermission -ProcessName 'Missing' -isInherited $false
+            $result.status | Should -Be 'Error'
+            Assert-MockCalled -CommandName Get-DevOpsACL -Times 0
+        }
+    }
+
+    Context 'when the security namespace is not found' {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'SecurityNamespaces' } -MockWith { return $null }
+        }
+
+        It 'returns status Error' {
+            $result = Get-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false
+            $result.status | Should -Be 'Error'
+        }
+    }
+
+    Context 'when Get-DevOpsACL returns null' {
+
+        BeforeEach {
+            Mock -CommandName Get-DevOpsACL -MockWith { return $null }
+        }
+
+        It 'returns status Error' {
+            $result = Get-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false
+            $result.status | Should -Be 'Error'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/New-AzDoProcessPermission.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/New-AzDoProcessPermission.tests.ps1
@@ -1,0 +1,78 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'New-AzDoProcessPermission' -Tag "Unit", "ProcessPermission" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'New-AzDoProcessPermission.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Write-Error
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Get-DevOpsProcessAclToken -MockWith { return '$PROCESS' }
+
+        Mock -CommandName Get-CacheItem -MockWith {
+            param ($Key, $Type)
+            switch ($Type) {
+                'SecurityNamespaces' { return @{ namespaceId = 'mock-namespace-id' } }
+                'LiveACLList'        { return @{} }
+                default              { return $null }
+            }
+        }
+
+        Mock -CommandName ConvertTo-ACLHashtable -MockWith { return @{ aces = @() } }
+        Mock -CommandName Set-AzDoPermission
+    }
+
+    It 'calls ConvertTo-ACLHashtable' {
+        New-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false -LookupResult @{ propertiesChanged = @() }
+        Assert-MockCalled -CommandName ConvertTo-ACLHashtable -Times 1
+    }
+
+    It 'calls Set-AzDoPermission' {
+        New-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false -LookupResult @{ propertiesChanged = @() }
+        Assert-MockCalled -CommandName Set-AzDoPermission -Times 1
+    }
+
+    Context 'when the security namespace is not found' {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'SecurityNamespaces' } -MockWith { return $null }
+        }
+
+        It 'writes an error and does not call Set-AzDoPermission' {
+            New-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false
+            Assert-MockCalled -CommandName Write-Error -Times 1
+            Assert-MockCalled -CommandName Set-AzDoPermission -Times 0
+        }
+    }
+
+    Context 'when the process token cannot be resolved' {
+
+        BeforeEach {
+            Mock -CommandName Get-DevOpsProcessAclToken -MockWith { return $null }
+        }
+
+        It 'writes an error and does not call Set-AzDoPermission' {
+            New-AzDoProcessPermission -ProcessName 'Missing' -isInherited $false
+            Assert-MockCalled -CommandName Write-Error -Times 1
+            Assert-MockCalled -CommandName Set-AzDoPermission -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Remove-AzDoProcessPermission.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Remove-AzDoProcessPermission.tests.ps1
@@ -1,0 +1,71 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Remove-AzDoProcessPermission' -Tag "Unit", "ProcessPermission" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Remove-AzDoProcessPermission.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Write-Error
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Get-DevOpsProcessAclToken -MockWith { return '$PROCESS' }
+
+        Mock -CommandName Get-CacheItem -MockWith {
+            param ($Key, $Type)
+            switch ($Type) {
+                'SecurityNamespaces' { return @{ namespaceId = 'mock-namespace-id' } }
+                default              { return $null }
+            }
+        }
+
+        Mock -CommandName Remove-AzDoPermission
+    }
+
+    It 'calls Remove-AzDoPermission with the resolved token' {
+        Remove-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false
+        Assert-MockCalled -CommandName Remove-AzDoPermission -Times 1 -ParameterFilter { $TokenName -eq '$PROCESS' }
+    }
+
+    Context 'when the security namespace is not found' {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'SecurityNamespaces' } -MockWith { return $null }
+        }
+
+        It 'writes an error and does not call Remove-AzDoPermission' {
+            Remove-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false
+            Assert-MockCalled -CommandName Write-Error -Times 1
+            Assert-MockCalled -CommandName Remove-AzDoPermission -Times 0
+        }
+    }
+
+    Context 'when the process token cannot be resolved' {
+
+        BeforeEach {
+            Mock -CommandName Get-DevOpsProcessAclToken -MockWith { return $null }
+        }
+
+        It 'writes an error and does not call Remove-AzDoPermission' {
+            Remove-AzDoProcessPermission -ProcessName 'Missing' -isInherited $false
+            Assert-MockCalled -CommandName Write-Error -Times 1
+            Assert-MockCalled -CommandName Remove-AzDoPermission -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Set-AzDoProcessPermission.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProcessPermission/Set-AzDoProcessPermission.tests.ps1
@@ -1,0 +1,77 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Set-AzDoProcessPermission' -Tag "Unit", "ProcessPermission" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Set-AzDoProcessPermission.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Write-Error
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Get-DevOpsProcessAclToken -MockWith { return '$PROCESS' }
+
+        Mock -CommandName Get-CacheItem -MockWith {
+            param ($Key, $Type)
+            switch ($Type) {
+                'SecurityNamespaces' { return @{ namespaceId = 'mock-namespace-id' } }
+                default              { return $null }
+            }
+        }
+
+        Mock -CommandName ConvertTo-ACLHashtable -MockWith { return @{ aces = @() } }
+        Mock -CommandName Set-AzDoPermission
+    }
+
+    It 'calls ConvertTo-ACLHashtable' {
+        Set-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false -LookupResult @{ propertiesChanged = @() }
+        Assert-MockCalled -CommandName ConvertTo-ACLHashtable -Times 1
+    }
+
+    It 'calls Set-AzDoPermission' {
+        Set-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false -LookupResult @{ propertiesChanged = @() }
+        Assert-MockCalled -CommandName Set-AzDoPermission -Times 1
+    }
+
+    Context 'when the security namespace is not found' {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'SecurityNamespaces' } -MockWith { return $null }
+        }
+
+        It 'writes an error and does not call Set-AzDoPermission' {
+            Set-AzDoProcessPermission -ProcessName 'AllProcesses' -isInherited $false
+            Assert-MockCalled -CommandName Write-Error -Times 1
+            Assert-MockCalled -CommandName Set-AzDoPermission -Times 0
+        }
+    }
+
+    Context 'when the process token cannot be resolved' {
+
+        BeforeEach {
+            Mock -CommandName Get-DevOpsProcessAclToken -MockWith { return $null }
+        }
+
+        It 'writes an error and does not call Set-AzDoPermission' {
+            Set-AzDoProcessPermission -ProcessName 'Missing' -isInherited $false
+            Assert-MockCalled -CommandName Write-Error -Times 1
+            Assert-MockCalled -CommandName Set-AzDoPermission -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Get-AzDoTeamSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Get-AzDoTeamSettings.tests.ps1
@@ -21,6 +21,7 @@ Describe "Get-AzDoTeamSettings" -Tag "Unit", "TeamSettings" {
         . (Get-ClassFilePath '000.CacheItem')
         . (Get-ClassFilePath 'Ensure')
         . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+        . (Get-FunctionItem 'Test-AzDoArrayDrift.ps1')
 
         $mockProject = @{ id = 'project-id-001'; name = 'TestProject' }
         $mockTeam    = @{ id = 'team-id-001';    name = 'TestTeam' }
@@ -41,6 +42,15 @@ Describe "Get-AzDoTeamSettings" -Tag "Unit", "TeamSettings" {
         Mock -CommandName List-DevOpsTeams -MockWith { return @($mockTeam) }
         Mock -CommandName Add-CacheItem
         Mock -CommandName Get-DevOpsTeamSettings -MockWith { return $mockLiveSettings }
+    }
+
+    Context "when Ensure is Absent (no-op)" {
+
+        It "short-circuits to NotFound without resolving the team" {
+            $result = Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' -Ensure 'Absent'
+            $result.status | Should -Be 'NotFound'
+            Assert-MockCalled -CommandName Get-DevOpsTeamSettings -Exactly -Times 0
+        }
     }
 
     Context "when the project or team cannot be resolved" {
@@ -99,6 +109,46 @@ Describe "Get-AzDoTeamSettings" -Tag "Unit", "TeamSettings" {
                 -DefaultAreaPath 'TestProject\Backend' -IterationPaths @('TestProject\Sprint 9')
             $result.propertiesChanged | Should -Contain 'DefaultAreaPath'
             $result.propertiesChanged | Should -Contain 'IterationPaths'
+        }
+
+        It "detects drift on the backlog and default iteration paths" {
+            $result = Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' `
+                -BacklogIterationPath 'TestProject\Other' -DefaultIterationPath 'TestProject\Sprint 9'
+            $result.propertiesChanged | Should -Contain 'BacklogIterationPath'
+            $result.propertiesChanged | Should -Contain 'DefaultIterationPath'
+        }
+
+        It "detects drift on working days" {
+            $result = Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' -WorkingDays @('monday')
+            $result.propertiesChanged | Should -Contain 'WorkingDays'
+        }
+
+        It "detects drift on the team area paths" {
+            $result = Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' -AreaPaths @('TestProject\Backend', 'TestProject\Api')
+            $result.propertiesChanged | Should -Contain 'AreaPaths'
+        }
+    }
+
+    Context "when project and team are resolved via the live API (cache miss)" {
+
+        BeforeEach {
+            # Cache misses for both project and team force the live-API fallback paths.
+            Mock -CommandName Get-CacheItem -MockWith { return $null }
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return $mockProject }
+            Mock -CommandName List-DevOpsTeams -MockWith { return @($mockTeam) }
+        }
+
+        It "resolves project and team from the API and returns Unchanged" {
+            $result = Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam'
+            $result.status | Should -Be 'Unchanged'
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1
+            Assert-MockCalled -CommandName List-DevOpsTeams -Times 1
+        }
+
+        It "returns NotFound when the team is not in the live list" {
+            Mock -CommandName List-DevOpsTeams -MockWith { return @() }
+            $result = Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'Ghost'
+            $result.status | Should -Be 'NotFound'
         }
     }
 }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Get-AzDoTeamSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Get-AzDoTeamSettings.tests.ps1
@@ -1,0 +1,104 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "Get-AzDoTeamSettings" -Tag "Unit", "TeamSettings" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-AzDoTeamSettings.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        $mockProject = @{ id = 'project-id-001'; name = 'TestProject' }
+        $mockTeam    = @{ id = 'team-id-001';    name = 'TestTeam' }
+
+        $mockLiveSettings = [PSCustomObject]@{
+            BacklogIterationPath = 'TestProject'
+            DefaultIterationPath = 'TestProject\Sprint 1'
+            IterationPaths       = @('TestProject\Sprint 1')
+            DefaultAreaPath      = 'TestProject\Frontend'
+            AreaPaths            = @('TestProject\Frontend')
+            WorkingDays          = @('monday', 'tuesday')
+            BugsBehavior         = 'asRequirements'
+        }
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return $null }
+        Mock -CommandName List-DevOpsTeams -MockWith { return @($mockTeam) }
+        Mock -CommandName Add-CacheItem
+        Mock -CommandName Get-DevOpsTeamSettings -MockWith { return $mockLiveSettings }
+    }
+
+    Context "when the project or team cannot be resolved" {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'LiveProjects' } -MockWith { return $null }
+            Mock -CommandName List-DevOpsTeams -MockWith { return @() }
+        }
+
+        It "returns status NotFound" {
+            $result = Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam'
+            $result.status | Should -Be 'NotFound'
+        }
+
+        It "does not call Get-DevOpsTeamSettings" {
+            Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam'
+            Assert-MockCalled -CommandName Get-DevOpsTeamSettings -Exactly -Times 0
+        }
+    }
+
+    Context "when project and team resolve and settings match desired state" {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'LiveProjects' } -MockWith { return $mockProject }
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'LiveTeams' }    -MockWith { return $mockTeam }
+        }
+
+        It "returns status Unchanged when no properties drift" {
+            $result = Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' `
+                -DefaultIterationPath 'TestProject\Sprint 1' -BugsBehavior 'asRequirements'
+            $result.status | Should -Be 'Unchanged'
+            $result.Ensure | Should -Be 'Present'
+        }
+
+        It "populates liveCache with the live settings" {
+            $result = Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam'
+            $result.liveCache.BugsBehavior | Should -Be 'asRequirements'
+        }
+    }
+
+    Context "when project and team resolve but settings drift" {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'LiveProjects' } -MockWith { return $mockProject }
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'LiveTeams' }    -MockWith { return $mockTeam }
+        }
+
+        It "returns status Changed and reports the changed property" {
+            $result = Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' -BugsBehavior 'off'
+            $result.status | Should -Be 'Changed'
+            $result.propertiesChanged | Should -Contain 'BugsBehavior'
+        }
+
+        It "detects drift on iteration and area paths" {
+            $result = Get-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' `
+                -DefaultAreaPath 'TestProject\Backend' -IterationPaths @('TestProject\Sprint 9')
+            $result.propertiesChanged | Should -Contain 'DefaultAreaPath'
+            $result.propertiesChanged | Should -Contain 'IterationPaths'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/New-AzDoTeamSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/New-AzDoTeamSettings.tests.ps1
@@ -1,0 +1,34 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "New-AzDoTeamSettings" -Tag "Unit", "TeamSettings" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'New-AzDoTeamSettings.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'Ensure')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Set-AzDoTeamSettings
+    }
+
+    Context "when invoked" {
+
+        It "delegates to Set-AzDoTeamSettings (settings always exist for a team)" {
+            New-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' -BugsBehavior 'asRequirements'
+            Assert-MockCalled -CommandName Set-AzDoTeamSettings -Exactly -Times 1
+        }
+
+        It "forwards its parameters to Set-AzDoTeamSettings" {
+            New-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' -DefaultAreaPath 'TestProject\Frontend'
+            Assert-MockCalled -CommandName Set-AzDoTeamSettings -Exactly -Times 1 -ParameterFilter {
+                $ProjectName -eq 'TestProject' -and $TeamName -eq 'TestTeam' -and $DefaultAreaPath -eq 'TestProject\Frontend'
+            }
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Remove-AzDoTeamSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Remove-AzDoTeamSettings.tests.ps1
@@ -1,0 +1,31 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "Remove-AzDoTeamSettings" -Tag "Unit", "TeamSettings" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Remove-AzDoTeamSettings.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'Ensure')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Set-DevOpsTeamSettings
+    }
+
+    Context "when invoked" {
+
+        It "does not throw (team settings cannot be removed)" {
+            { Remove-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' } | Should -Not -Throw
+        }
+
+        It "is a no-op and makes no API call" {
+            Remove-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam'
+            Assert-MockCalled -CommandName Set-DevOpsTeamSettings -Exactly -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Set-AzDoTeamSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Set-AzDoTeamSettings.tests.ps1
@@ -85,4 +85,32 @@ Describe "Set-AzDoTeamSettings" -Tag "Unit", "TeamSettings" {
             Assert-MockCalled -CommandName Set-DevOpsTeamSettings -Exactly -Times 0
         }
     }
+
+    Context "when the team is resolved via the live API (cache miss)" {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'LiveTeams' } -MockWith { return $null }
+            Mock -CommandName List-DevOpsTeams -MockWith { return @($mockTeam) }
+        }
+
+        It "falls back to List-DevOpsTeams and calls Set-DevOpsTeamSettings" {
+            Set-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' -BugsBehavior 'asTasks'
+            Assert-MockCalled -CommandName List-DevOpsTeams -Times 1
+            Assert-MockCalled -CommandName Set-DevOpsTeamSettings -Exactly -Times 1 -ParameterFilter { $TeamId -eq 'team-id-001' }
+        }
+    }
+
+    Context "when Set-DevOpsTeamSettings returns null" {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'LiveTeams' } -MockWith { return $mockTeam }
+            Mock -CommandName Set-DevOpsTeamSettings -MockWith { return $null }
+            Mock -CommandName Write-Error -Verifiable
+        }
+
+        It "writes an error" {
+            Set-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' -BugsBehavior 'asTasks'
+            Assert-VerifiableMock
+        }
+    }
 }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Set-AzDoTeamSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Set-AzDoTeamSettings.tests.ps1
@@ -1,0 +1,88 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe "Set-AzDoTeamSettings" -Tag "Unit", "TeamSettings" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Set-AzDoTeamSettings.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        $mockProject = @{ id = 'project-id-001'; name = 'TestProject' }
+        $mockTeam    = @{ id = 'team-id-001';    name = 'TestTeam' }
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Resolve-AzDoProject -MockWith { return $mockProject }
+        Mock -CommandName List-DevOpsTeams -MockWith { return @($mockTeam) }
+        Mock -CommandName Set-DevOpsTeamSettings -MockWith { return [PSCustomObject]@{ BugsBehavior = 'asTasks' } }
+    }
+
+    Context "when project and team are resolved" {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'LiveTeams' } -MockWith { return $mockTeam }
+        }
+
+        It "calls Set-DevOpsTeamSettings with the resolved ProjectId and TeamId" {
+            Set-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' -BugsBehavior 'asTasks'
+            Assert-MockCalled -CommandName Set-DevOpsTeamSettings -Exactly -Times 1 -ParameterFilter {
+                $ProjectId -eq 'project-id-001' -and $TeamId -eq 'team-id-001'
+            }
+        }
+
+        It "forwards the iteration, area, working-day and bugs-behavior parameters" {
+            Set-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'TestTeam' `
+                -DefaultIterationPath 'TestProject\Sprint 1' -DefaultAreaPath 'TestProject\Frontend' `
+                -WorkingDays @('monday') -BugsBehavior 'off'
+            Assert-MockCalled -CommandName Set-DevOpsTeamSettings -Exactly -Times 1 -ParameterFilter {
+                $DefaultIterationPath -eq 'TestProject\Sprint 1' -and
+                $DefaultAreaPath -eq 'TestProject\Frontend' -and
+                $BugsBehavior -eq 'off'
+            }
+        }
+    }
+
+    Context "when the project cannot be resolved" {
+
+        BeforeEach {
+            Mock -CommandName Resolve-AzDoProject -MockWith { return $null }
+            Mock -CommandName Write-Error -Verifiable
+        }
+
+        It "writes an error and does not call Set-DevOpsTeamSettings" {
+            Set-AzDoTeamSettings -ProjectName 'NonExistentProject' -TeamName 'TestTeam'
+            Assert-VerifiableMock
+            Assert-MockCalled -CommandName Set-DevOpsTeamSettings -Exactly -Times 0
+        }
+    }
+
+    Context "when the team cannot be resolved" {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -ParameterFilter { $Type -eq 'LiveTeams' } -MockWith { return $null }
+            Mock -CommandName List-DevOpsTeams -MockWith { return @() }
+            Mock -CommandName Write-Error -Verifiable
+        }
+
+        It "writes an error and does not call Set-DevOpsTeamSettings" {
+            Set-AzDoTeamSettings -ProjectName 'TestProject' -TeamName 'NonExistentTeam'
+            Assert-VerifiableMock
+            Assert-MockCalled -CommandName Set-DevOpsTeamSettings -Exactly -Times 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new DSC resources for Azure DevOps **inherited processes** and **process-level permissions**, and the documentation for these *and* the teams/artifact-feed resources from the base branch.

- **`AzDoProcess`** — create/update/remove inherited processes (process templates) via `_apis/work/processes`. `ParentProcessName` is immutable; the description is reconciled.
- **`AzDoProcessPermission`** — manage the **Process** security namespace. `ProcessName = 'AllProcesses'` targets the org-wide root token (`$PROCESS`) governing who can create inherited (child) processes; a specific process name targets `$PROCESS:{parent}:{id}`.

```powershell
AzDoProcess ContosoAgile {
    ProcessName       = 'Contoso Agile'
    ParentProcessName = 'Agile'
    Ensure            = 'Present'
}

# Allow a group to create inherited (child) processes org-wide
AzDoProcessPermission AllowCreate {
    ProcessName = 'AllProcesses'
    Permissions = @(@{ Identity = '[MyOrg]\Process Authors'; Permission = @{ Create = 'Allow'; Edit = 'Allow' } })
}
```

## ACL plumbing

Wires the Process namespace through all four ACL stages (token patterns / `New-ACLToken` / `Parse-ACLToken` / `ConvertTo-FormattedToken`). The token format (`$PROCESS` root and `$PROCESS:{parentProcessTypeId}:{processTypeId}`) was **verified against the live Process namespace**; permission bits resolve dynamically from the cached namespace (none hardcoded).

## Documentation

Adds example docs + README rows + CHANGELOG entries for all five new resources (`AzDoProcess`, `AzDoProcessPermission`, `AzDoTeamSettings`, `AzDoArtifactFeedSettings`, `AzDoArtifactFeedView`), and backfills the CHANGELOG with the ~35 pre-existing resources it was missing.

## Testing

- Unit: 47/47 for the two process resources (resource functions + Process API helpers).
- Integration: verified in a full suite run (348 passed / 0 failed / 8 skipped) including both new resources; targeted run 16/16.
- Also fixed a self-conflicting `[Alias('Description')]` on `AzDoProcess` (would throw `MetadataException` at runtime), caught by the unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)