### PR TITLE
Add AzDoUserEntitlement, AzDoServiceHook and AzDoPipelineSettings resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - AzDoGroupMember
   - AzDoGitRepository
   - AzDoGitPermission
+  - AzDoUserEntitlement
+  - AzDoServiceHook
+  - AzDoPipelineSettings
 - AzureDevOpsDsc.Common
   - Added New-AzDoAuthenticationProvider. This is invoked prior to the resource invocation.
   - Added 'wrapper' functionality around the [Azure DevOps REST API](https://docs.microsoft.com/en-us/rest/api/azure/devops/)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Each resource links to its example/usage documentation.
 | [AzDoGroupMember](source/Examples/Resources/AzDoGroupMember.md) | Manages membership of users, groups and service principals in a group. |
 | [AzDoTeam](source/Examples/Resources/AzDoTeam.md) | Creates and manages teams within a project. |
 | [AzDoTeamMember](source/Examples/Resources/AzDoTeamMember.md) | Manages membership of a team. |
+| [AzDoUserEntitlement](source/Examples/Resources/AzDoUserEntitlement.md) | Adds/removes organization users and manages their access level (license). |
 
 ### Repositories and policies
 
@@ -155,6 +156,7 @@ Each resource links to its example/usage documentation.
 | [AzDoTaskGroup](source/Examples/Resources/AzDoTaskGroup.md) | Creates and manages task groups. |
 | [AzDoVariableGroup](source/Examples/Resources/AzDoVariableGroup.md) | Creates and manages variable groups (library). |
 | [AzDoServiceConnection](source/Examples/Resources/AzDoServiceConnection.md) | Creates and manages service connections (service endpoints). |
+| [AzDoPipelineSettings](source/Examples/Resources/AzDoPipelineSettings.md) | Manages a project's pipeline general settings (job auth scope, settable variables, etc.). |
 
 ### Boards and work items
 
@@ -173,6 +175,7 @@ Each resource links to its example/usage documentation.
 | [AzDoWiki](source/Examples/Resources/AzDoWiki.md) | Creates and manages project and code wikis. |
 | [AzDoExtension](source/Examples/Resources/AzDoExtension.md) | Installs and uninstalls organization extensions. |
 | [AzDoAuditStream](source/Examples/Resources/AzDoAuditStream.md) | Manages audit log streaming. |
+| [AzDoServiceHook](source/Examples/Resources/AzDoServiceHook.md) | Creates and manages service hook subscriptions (e.g. webhooks). |
 
 ## Documentation
 

--- a/source/AzureDevOpsDsc.psd1
+++ b/source/AzureDevOpsDsc.psd1
@@ -84,7 +84,8 @@
       'AzDoRepositorySettings',
       'AzDoCheckConfiguration',
       'AzDoUserEntitlement',
-      'AzDoServiceHook'
+      'AzDoServiceHook',
+      'AzDoPipelineSettings'
     )
 
     RequiredAssemblies = @()

--- a/source/AzureDevOpsDsc.psd1
+++ b/source/AzureDevOpsDsc.psd1
@@ -82,7 +82,8 @@
       'AzDoWiki',
       'AzDoNotificationSubscription',
       'AzDoRepositorySettings',
-      'AzDoCheckConfiguration'
+      'AzDoCheckConfiguration',
+      'AzDoUserEntitlement'
     )
 
     RequiredAssemblies = @()

--- a/source/AzureDevOpsDsc.psd1
+++ b/source/AzureDevOpsDsc.psd1
@@ -83,7 +83,8 @@
       'AzDoNotificationSubscription',
       'AzDoRepositorySettings',
       'AzDoCheckConfiguration',
-      'AzDoUserEntitlement'
+      'AzDoUserEntitlement',
+      'AzDoServiceHook'
     )
 
     RequiredAssemblies = @()

--- a/source/Classes/098.AzDoUserEntitlement.ps1
+++ b/source/Classes/098.AzDoUserEntitlement.ps1
@@ -1,0 +1,63 @@
+<#
+.SYNOPSIS
+    DSC resource for managing Azure DevOps user entitlements (organization membership + access level).
+
+.DESCRIPTION
+    The AzDoUserEntitlement resource adds and removes users from an Azure DevOps organization and manages
+    their access level (account license type) via the Member Entitlement Management API. It inherits
+    Test()/Set() from the AzDevOpsDscResourceBase class.
+
+.PARAMETER UserPrincipalName
+    The user's principal name (email / UPN).
+
+.PARAMETER AccountLicenseType
+    The account license type to assign. Valid values are 'stakeholder', 'express' (Basic),
+    'advanced' (Basic + Test Plans), 'professional', 'earlyAdopter' and 'none'.
+
+.EXAMPLE
+    AzDoUserEntitlement JaneBasic
+    {
+        UserPrincipalName  = 'jane@contoso.com'
+        AccountLicenseType = 'express'
+        Ensure             = 'Present'
+    }
+#>
+
+[DscResource()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSDSCStandardDSCFunctionsInResource', '', Justification='Test() and Set() method are inherited from base, "AzDevOpsDscResourceBase" class')]
+class AzDoUserEntitlement : AzDevOpsDscResourceBase
+{
+    [DscProperty(Key, Mandatory)]
+    [Alias('PrincipalName')]
+    [System.String]$UserPrincipalName
+
+    [DscProperty(Mandatory)]
+    [ValidateSet('stakeholder', 'express', 'advanced', 'professional', 'earlyAdopter', 'none')]
+    [System.String]$AccountLicenseType
+
+    AzDoUserEntitlement()
+    {
+        $this.Construct()
+    }
+
+    [AzDoUserEntitlement] Get()
+    {
+        return [AzDoUserEntitlement]$($this.GetDscCurrentStateProperties())
+    }
+
+    hidden [System.String[]]GetDscResourcePropertyNamesWithNoSetSupport()
+    {
+        return @()
+    }
+
+    hidden [Hashtable]GetDscCurrentStateProperties([PSCustomObject]$CurrentResourceObject)
+    {
+        $properties = @{ Ensure = [Ensure]::Absent }
+        if ($null -eq $CurrentResourceObject) { return $properties }
+        $properties.UserPrincipalName  = $CurrentResourceObject.UserPrincipalName
+        $properties.AccountLicenseType = $CurrentResourceObject.AccountLicenseType
+        $properties.LookupResult        = $CurrentResourceObject.LookupResult
+        $properties.Ensure              = $CurrentResourceObject.Ensure
+        return $properties
+    }
+}

--- a/source/Classes/099.AzDoServiceHook.ps1
+++ b/source/Classes/099.AzDoServiceHook.ps1
@@ -1,0 +1,116 @@
+<#
+.SYNOPSIS
+    DSC resource for managing Azure DevOps service hook subscriptions.
+
+.DESCRIPTION
+    The AzDoServiceHook resource creates and manages service hook subscriptions (e.g. webhooks to
+    external systems) via the Service Hooks REST API. Subscriptions have no native name, so the Name
+    property is a logical DSC handle; the live subscription is matched by its identity tuple
+    (publisherId + eventType + consumerId + consumerActionId, plus the consumer 'url'). It inherits
+    Test()/Set() from the AzDevOpsDscResourceBase class.
+
+.PARAMETER Name
+    A logical name for the subscription. This is the key; it is not sent to Azure DevOps.
+
+.PARAMETER ProjectName
+    Optional project to scope the subscription to; its id is added to the publisher inputs.
+
+.PARAMETER PublisherId
+    The event publisher id (e.g. 'tfs', 'rm').
+
+.PARAMETER EventType
+    The event type (e.g. 'git.push', 'build.complete').
+
+.PARAMETER ConsumerId
+    The consumer id (e.g. 'webHooks').
+
+.PARAMETER ConsumerActionId
+    The consumer action id (e.g. 'httpRequest').
+
+.PARAMETER ConsumerInputs
+    The consumer input values (e.g. @{ url = 'https://...' }).
+
+.PARAMETER PublisherInputs
+    The publisher input values (e.g. @{ repository = '...' }).
+
+.PARAMETER ResourceVersion
+    The event resource version. Defaults to '1.0'.
+
+.EXAMPLE
+    AzDoServiceHook PushWebhook
+    {
+        Name             = 'notify-ci-on-push'
+        ProjectName      = 'MyProject'
+        PublisherId      = 'tfs'
+        EventType        = 'git.push'
+        ConsumerId       = 'webHooks'
+        ConsumerActionId = 'httpRequest'
+        ConsumerInputs   = @{ url = 'https://ci.contoso.com/hook' }
+        Ensure           = 'Present'
+    }
+#>
+
+[DscResource()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSDSCStandardDSCFunctionsInResource', '', Justification='Test() and Set() method are inherited from base, "AzDevOpsDscResourceBase" class')]
+class AzDoServiceHook : AzDevOpsDscResourceBase
+{
+    [DscProperty(Key)]
+    [System.String]$Name
+
+    [DscProperty()]
+    [System.String]$ProjectName
+
+    [DscProperty(Mandatory)]
+    [System.String]$PublisherId
+
+    [DscProperty(Mandatory)]
+    [System.String]$EventType
+
+    [DscProperty(Mandatory)]
+    [System.String]$ConsumerId
+
+    [DscProperty(Mandatory)]
+    [System.String]$ConsumerActionId
+
+    [DscProperty()]
+    [HashTable]$ConsumerInputs
+
+    [DscProperty()]
+    [HashTable]$PublisherInputs
+
+    [DscProperty()]
+    [System.String]$ResourceVersion = '1.0'
+
+    AzDoServiceHook()
+    {
+        $this.Construct()
+    }
+
+    [AzDoServiceHook] Get()
+    {
+        return [AzDoServiceHook]$($this.GetDscCurrentStateProperties())
+    }
+
+    hidden [System.String[]]GetDscResourcePropertyNamesWithNoSetSupport()
+    {
+        return @()
+    }
+
+    hidden [Hashtable]GetDscCurrentStateProperties([PSCustomObject]$CurrentResourceObject)
+    {
+        $properties = @{ Ensure = [Ensure]::Absent }
+        if ($null -eq $CurrentResourceObject) { return $properties }
+        $properties.Name             = $CurrentResourceObject.Name
+        $properties.ProjectName      = $CurrentResourceObject.ProjectName
+        $properties.PublisherId      = $CurrentResourceObject.PublisherId
+        $properties.EventType        = $CurrentResourceObject.EventType
+        $properties.ConsumerId       = $CurrentResourceObject.ConsumerId
+        $properties.ConsumerActionId = $CurrentResourceObject.ConsumerActionId
+        $properties.ConsumerInputs   = $CurrentResourceObject.ConsumerInputs
+        $properties.PublisherInputs  = $CurrentResourceObject.PublisherInputs
+        $properties.ResourceVersion  = $CurrentResourceObject.ResourceVersion
+        $properties.LookupResult     = $CurrentResourceObject.LookupResult
+        $properties.Ensure           = $CurrentResourceObject.Ensure
+        return $properties
+    }
+}

--- a/source/Classes/100.AzDoPipelineSettings.ps1
+++ b/source/Classes/100.AzDoPipelineSettings.ps1
@@ -1,0 +1,126 @@
+<#
+.SYNOPSIS
+    DSC resource for managing Azure DevOps project pipeline general settings.
+
+.DESCRIPTION
+    The AzDoPipelineSettings resource manages a project's pipeline general settings (the
+    Project Settings -> Pipelines -> Settings page) via the Build REST API. Only the settings explicitly
+    specified in the configuration are reconciled; unspecified settings are left untouched. The settings
+    are intrinsic to a project and cannot be removed, so Ensure = 'Absent' is a no-op. Test()/Set() are
+    inherited from the AzDevOpsDscResourceBase class.
+
+.PARAMETER ProjectName
+    The name of the Azure DevOps project.
+
+.PARAMETER EnforceJobAuthScope
+    Limit job authorization scope to the current project for non-release pipelines.
+
+.PARAMETER EnforceJobAuthScopeForReleases
+    Limit job authorization scope to the current project for release pipelines.
+
+.PARAMETER EnforceReferencedRepoScopedToken
+    Protect access to repositories in YAML pipelines.
+
+.PARAMETER EnforceSettableVar
+    Limit variables that can be set at queue time.
+
+.PARAMETER PublishPipelineMetadata
+    Publish metadata from pipelines.
+
+.PARAMETER StatusBadgesArePrivate
+    Disable anonymous access to status badges.
+
+.PARAMETER DisableClassicPipelineCreation
+    Disable creation of classic build and release pipelines.
+
+.PARAMETER DisableImpliedYAMLCiTrigger
+    Disable implied YAML CI triggers.
+
+.EXAMPLE
+    AzDoPipelineSettings HardenPipelines
+    {
+        ProjectName                      = 'MyProject'
+        EnforceJobAuthScope              = $true
+        EnforceReferencedRepoScopedToken = $true
+        StatusBadgesArePrivate           = $true
+    }
+#>
+
+[DscResource()]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSDSCStandardDSCFunctionsInResource', '', Justification='Test() and Set() method are inherited from base, "AzDevOpsDscResourceBase" class')]
+class AzDoPipelineSettings : AzDevOpsDscResourceBase
+{
+    [DscProperty(Key, Mandatory)]
+    [System.String]$ProjectName
+
+    [DscProperty()]
+    [System.Boolean]$EnforceJobAuthScope
+
+    [DscProperty()]
+    [System.Boolean]$EnforceJobAuthScopeForReleases
+
+    [DscProperty()]
+    [System.Boolean]$EnforceReferencedRepoScopedToken
+
+    [DscProperty()]
+    [System.Boolean]$EnforceSettableVar
+
+    [DscProperty()]
+    [System.Boolean]$PublishPipelineMetadata
+
+    [DscProperty()]
+    [System.Boolean]$StatusBadgesArePrivate
+
+    [DscProperty()]
+    [System.Boolean]$DisableClassicPipelineCreation
+
+    [DscProperty()]
+    [System.Boolean]$DisableImpliedYAMLCiTrigger
+
+    AzDoPipelineSettings()
+    {
+        $this.Construct()
+    }
+
+    [AzDoPipelineSettings] Get()
+    {
+        return [AzDoPipelineSettings]$($this.GetDscCurrentStateProperties())
+    }
+
+    hidden [System.String[]]GetDscResourcePropertyNamesWithNoSetSupport()
+    {
+        return @('ProjectName')
+    }
+
+    hidden [Hashtable]GetDscCurrentStateProperties([PSCustomObject]$CurrentResourceObject)
+    {
+        $properties = @{ Ensure = [Ensure]::Absent }
+        if ($null -eq $CurrentResourceObject) { return $properties }
+
+        $properties.ProjectName  = $CurrentResourceObject.ProjectName
+        $properties.LookupResult = $CurrentResourceObject.LookupResult
+        $properties.Ensure       = $CurrentResourceObject.Ensure
+
+        $names = @(
+            'EnforceJobAuthScope', 'EnforceJobAuthScopeForReleases', 'EnforceReferencedRepoScopedToken',
+            'EnforceSettableVar', 'PublishPipelineMetadata', 'StatusBadgesArePrivate',
+            'DisableClassicPipelineCreation', 'DisableImpliedYAMLCiTrigger'
+        )
+
+        # Prefer the live API values carried in LookupResult so idempotency compares actual project state.
+        $lr = $CurrentResourceObject.LookupResult
+        foreach ($name in $names)
+        {
+            if ($null -ne $lr -and $lr -is [Hashtable] -and $null -ne $lr.$name)
+            {
+                $properties.$name = $lr.$name
+            }
+            else
+            {
+                $properties.$name = $CurrentResourceObject.$name
+            }
+        }
+
+        return $properties
+    }
+}

--- a/source/Classes/100.AzDoPipelineSettings.ps1
+++ b/source/Classes/100.AzDoPipelineSettings.ps1
@@ -89,7 +89,9 @@ class AzDoPipelineSettings : AzDevOpsDscResourceBase
 
     hidden [System.String[]]GetDscResourcePropertyNamesWithNoSetSupport()
     {
-        return @('ProjectName')
+        # ProjectName is the key and must be passed to Set (the base class removes any name returned
+        # here from the Set parameters), so this must be empty.
+        return @()
     }
 
     hidden [Hashtable]GetDscCurrentStateProperties([PSCustomObject]$CurrentResourceObject)

--- a/source/Classes/100.AzDoPipelineSettings.ps1
+++ b/source/Classes/100.AzDoPipelineSettings.ps1
@@ -53,29 +53,42 @@ class AzDoPipelineSettings : AzDevOpsDscResourceBase
     [DscProperty(Key, Mandatory)]
     [System.String]$ProjectName
 
-    [DscProperty()]
-    [System.Boolean]$EnforceJobAuthScope
+    # Each setting is a tri-state string: '' (default) means "not managed by this resource" — only
+    # settings set to 'true'/'false' are compared and applied. A plain [bool] cannot express
+    # "unmanaged" (it defaults to $false), which would make the resource drive every omitted setting
+    # to false (destructive, and never converging because the base class passes all properties).
 
     [DscProperty()]
-    [System.Boolean]$EnforceJobAuthScopeForReleases
+    [ValidateSet('', 'true', 'false')]
+    [System.String]$EnforceJobAuthScope
 
     [DscProperty()]
-    [System.Boolean]$EnforceReferencedRepoScopedToken
+    [ValidateSet('', 'true', 'false')]
+    [System.String]$EnforceJobAuthScopeForReleases
 
     [DscProperty()]
-    [System.Boolean]$EnforceSettableVar
+    [ValidateSet('', 'true', 'false')]
+    [System.String]$EnforceReferencedRepoScopedToken
 
     [DscProperty()]
-    [System.Boolean]$PublishPipelineMetadata
+    [ValidateSet('', 'true', 'false')]
+    [System.String]$EnforceSettableVar
 
     [DscProperty()]
-    [System.Boolean]$StatusBadgesArePrivate
+    [ValidateSet('', 'true', 'false')]
+    [System.String]$PublishPipelineMetadata
 
     [DscProperty()]
-    [System.Boolean]$DisableClassicPipelineCreation
+    [ValidateSet('', 'true', 'false')]
+    [System.String]$StatusBadgesArePrivate
 
     [DscProperty()]
-    [System.Boolean]$DisableImpliedYAMLCiTrigger
+    [ValidateSet('', 'true', 'false')]
+    [System.String]$DisableClassicPipelineCreation
+
+    [DscProperty()]
+    [ValidateSet('', 'true', 'false')]
+    [System.String]$DisableImpliedYAMLCiTrigger
 
     AzDoPipelineSettings()
     {

--- a/source/Examples/Resources/AzDoPipelineSettings.md
+++ b/source/Examples/Resources/AzDoPipelineSettings.md
@@ -6,14 +6,14 @@
 AzDoPipelineSettings [string] #ResourceName
 {
     ProjectName                          = [String]$ProjectName
-    [ EnforceJobAuthScope               = [Boolean]$EnforceJobAuthScope ]
-    [ EnforceJobAuthScopeForReleases    = [Boolean]$EnforceJobAuthScopeForReleases ]
-    [ EnforceReferencedRepoScopedToken  = [Boolean]$EnforceReferencedRepoScopedToken ]
-    [ EnforceSettableVar                = [Boolean]$EnforceSettableVar ]
-    [ PublishPipelineMetadata           = [Boolean]$PublishPipelineMetadata ]
-    [ StatusBadgesArePrivate            = [Boolean]$StatusBadgesArePrivate ]
-    [ DisableClassicPipelineCreation    = [Boolean]$DisableClassicPipelineCreation ]
-    [ DisableImpliedYAMLCiTrigger       = [Boolean]$DisableImpliedYAMLCiTrigger ]
+    [ EnforceJobAuthScope               = [String] {'', 'true', 'false'} ]
+    [ EnforceJobAuthScopeForReleases    = [String] {'', 'true', 'false'} ]
+    [ EnforceReferencedRepoScopedToken  = [String] {'', 'true', 'false'} ]
+    [ EnforceSettableVar                = [String] {'', 'true', 'false'} ]
+    [ PublishPipelineMetadata           = [String] {'', 'true', 'false'} ]
+    [ StatusBadgesArePrivate            = [String] {'', 'true', 'false'} ]
+    [ DisableClassicPipelineCreation    = [String] {'', 'true', 'false'} ]
+    [ DisableImpliedYAMLCiTrigger       = [String] {'', 'true', 'false'} ]
     [ Ensure                           = [String] {'Present', 'Absent'} ]
 }
 ```
@@ -33,9 +33,11 @@ AzDoPipelineSettings [string] #ResourceName
 - **DisableImpliedYAMLCiTrigger**: Disable implied YAML CI triggers.
 - **Ensure**: Specifies the desired state. These settings are intrinsic to a project and cannot be removed, so `Absent` is a no-op.
 
+Each setting is a tri-state string: `'true'`, `'false'`, or `''` (the default). Only settings set to `'true'` or `'false'` are reconciled; a setting left as `''` is **not managed** by this resource and is left untouched.
+
 ## Additional Information
 
-This resource manages a project's pipeline general settings (Project Settings → Pipelines → Settings). Only the settings you explicitly specify are reconciled; any setting you omit is left untouched.
+This resource manages a project's pipeline general settings (Project Settings → Pipelines → Settings). Only the settings you set to `'true'`/`'false'` are compared and applied; omitted settings (`''`) are left untouched.
 
 ## Examples
 
@@ -49,9 +51,9 @@ Configuration ExampleConfig {
         AzDoPipelineSettings HardenPipelines {
             Ensure                           = 'Present'
             ProjectName                      = 'MyProject'
-            EnforceJobAuthScope              = $true
-            EnforceReferencedRepoScopedToken = $true
-            StatusBadgesArePrivate           = $true
+            EnforceJobAuthScope              = 'true'
+            EnforceReferencedRepoScopedToken = 'true'
+            StatusBadgesArePrivate           = 'true'
         }
     }
 }
@@ -65,7 +67,7 @@ Start-DscConfiguration -Path ./ExampleConfig -Wait -Verbose
 # Return the current configuration for AzDoPipelineSettings
 $properties = @{
     ProjectName         = 'MyProject'
-    EnforceJobAuthScope = $true
+    EnforceJobAuthScope = 'true'
 }
 
 Invoke-DscResource -Name 'AzDoPipelineSettings' -Method Get -Property $properties -ModuleName 'AzureDevOpsDsc'
@@ -87,9 +89,9 @@ resources:
     - AzureDevOpsDsc/AzDevOpsProject/MyProject
   properties:
     ProjectName: $ProjectName
-    EnforceJobAuthScope: true
-    EnforceReferencedRepoScopedToken: true
-    StatusBadgesArePrivate: true
+    EnforceJobAuthScope: 'true'
+    EnforceReferencedRepoScopedToken: 'true'
+    StatusBadgesArePrivate: 'true'
     Ensure: Present
 ```
 

--- a/source/Examples/Resources/AzDoPipelineSettings.md
+++ b/source/Examples/Resources/AzDoPipelineSettings.md
@@ -1,0 +1,111 @@
+# DSC AzDoPipelineSettings Resource
+
+## Syntax
+
+```PowerShell
+AzDoPipelineSettings [string] #ResourceName
+{
+    ProjectName                          = [String]$ProjectName
+    [ EnforceJobAuthScope               = [Boolean]$EnforceJobAuthScope ]
+    [ EnforceJobAuthScopeForReleases    = [Boolean]$EnforceJobAuthScopeForReleases ]
+    [ EnforceReferencedRepoScopedToken  = [Boolean]$EnforceReferencedRepoScopedToken ]
+    [ EnforceSettableVar                = [Boolean]$EnforceSettableVar ]
+    [ PublishPipelineMetadata           = [Boolean]$PublishPipelineMetadata ]
+    [ StatusBadgesArePrivate            = [Boolean]$StatusBadgesArePrivate ]
+    [ DisableClassicPipelineCreation    = [Boolean]$DisableClassicPipelineCreation ]
+    [ DisableImpliedYAMLCiTrigger       = [Boolean]$DisableImpliedYAMLCiTrigger ]
+    [ Ensure                           = [String] {'Present', 'Absent'} ]
+}
+```
+
+## Properties
+
+### Common Properties
+
+- **ProjectName**: The name of the Azure DevOps project. This property is mandatory and serves as the key property for the resource.
+- **EnforceJobAuthScope**: Limit job authorization scope to the current project for non-release pipelines.
+- **EnforceJobAuthScopeForReleases**: Limit job authorization scope to the current project for release pipelines.
+- **EnforceReferencedRepoScopedToken**: Protect access to repositories in YAML pipelines.
+- **EnforceSettableVar**: Limit variables that can be set at queue time.
+- **PublishPipelineMetadata**: Publish metadata from pipelines.
+- **StatusBadgesArePrivate**: Disable anonymous access to status badges.
+- **DisableClassicPipelineCreation**: Disable creation of classic build and release pipelines.
+- **DisableImpliedYAMLCiTrigger**: Disable implied YAML CI triggers.
+- **Ensure**: Specifies the desired state. These settings are intrinsic to a project and cannot be removed, so `Absent` is a no-op.
+
+## Additional Information
+
+This resource manages a project's pipeline general settings (Project Settings → Pipelines → Settings). Only the settings you explicitly specify are reconciled; any setting you omit is left untouched.
+
+## Examples
+
+## Example 1: Sample Configuration using AzDoPipelineSettings Resource
+
+``` PowerShell
+Configuration ExampleConfig {
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    Node localhost {
+        AzDoPipelineSettings HardenPipelines {
+            Ensure                           = 'Present'
+            ProjectName                      = 'MyProject'
+            EnforceJobAuthScope              = $true
+            EnforceReferencedRepoScopedToken = $true
+            StatusBadgesArePrivate           = $true
+        }
+    }
+}
+
+Start-DscConfiguration -Path ./ExampleConfig -Wait -Verbose
+```
+
+## Example 2: Sample Configuration using Invoke-DSCResource
+
+``` PowerShell
+# Return the current configuration for AzDoPipelineSettings
+$properties = @{
+    ProjectName         = 'MyProject'
+    EnforceJobAuthScope = $true
+}
+
+Invoke-DscResource -Name 'AzDoPipelineSettings' -Method Get -Property $properties -ModuleName 'AzureDevOpsDsc'
+```
+
+## Example 3: Sample Configuration using AzDO-DSC-LCM
+
+``` YAML
+parameters: {}
+
+variables: {
+  ProjectName: MyProject
+}
+
+resources:
+- name: Harden pipeline settings
+  type: AzureDevOpsDsc/AzDoPipelineSettings
+  dependsOn:
+    - AzureDevOpsDsc/AzDevOpsProject/MyProject
+  properties:
+    ProjectName: $ProjectName
+    EnforceJobAuthScope: true
+    EnforceReferencedRepoScopedToken: true
+    StatusBadgesArePrivate: true
+    Ensure: Present
+```
+
+LCM Initialization:
+
+``` PowerShell
+
+$params = @{
+    AzureDevopsOrganizationName = "SampleAzDoOrgName"
+    ConfigurationDirectory      = "C:\Datum\DSCOutput\"
+    ConfigurationUrl            = 'https://configuration-path'
+    JITToken                    = 'SampleJITToken'
+    Mode                        = 'Set'
+    AuthenticationType          = 'ManagedIdentity'
+    ReportPath                  = 'C:\Datum\DSCOutput\Reports'
+}
+
+Invoke-AzDoLCM @params
+```

--- a/source/Examples/Resources/AzDoServiceHook.md
+++ b/source/Examples/Resources/AzDoServiceHook.md
@@ -1,0 +1,123 @@
+# DSC AzDoServiceHook Resource
+
+## Syntax
+
+```PowerShell
+AzDoServiceHook [string] #ResourceName
+{
+    Name               = [String]$Name
+    PublisherId        = [String]$PublisherId
+    EventType          = [String]$EventType
+    ConsumerId         = [String]$ConsumerId
+    ConsumerActionId   = [String]$ConsumerActionId
+    [ ProjectName      = [String]$ProjectName ]
+    [ ConsumerInputs   = [HashTable]$ConsumerInputs ]
+    [ PublisherInputs  = [HashTable]$PublisherInputs ]
+    [ ResourceVersion  = [String]$ResourceVersion ]
+    [ Ensure          = [String] {'Present', 'Absent'} ]
+}
+```
+
+## Properties
+
+### Common Properties
+
+- **Name**: A logical name for the subscription. This is the key property and is **not** sent to Azure DevOps — service hook subscriptions have no native name, so the live subscription is matched by its identity tuple (`PublisherId` + `EventType` + `ConsumerId` + `ConsumerActionId`, plus the consumer `url` input when present).
+- **ProjectName**: Optional project to scope the subscription to. When supplied, its id is added to the publisher inputs as `projectId`.
+- **PublisherId**: The event publisher id (e.g. `tfs` for repos/boards/builds, `rm` for releases). Mandatory.
+- **EventType**: The event type (e.g. `git.push`, `build.complete`, `ms.vss-pipelines.run-state-changed-event`). Mandatory.
+- **ConsumerId**: The consumer id (e.g. `webHooks`). Mandatory.
+- **ConsumerActionId**: The consumer action id (e.g. `httpRequest`). Mandatory.
+- **ConsumerInputs**: The consumer input values (e.g. `@{ url = 'https://...' }`).
+- **PublisherInputs**: The publisher input values (e.g. `@{ repository = '...'; branch = 'main' }`).
+- **ResourceVersion**: The event resource version. Defaults to `1.0`.
+- **Ensure**: Specifies whether the subscription should exist. Valid values are `Present` and `Absent`.
+
+## Additional Information
+
+This resource manages service hook subscriptions via the Service Hooks REST API — for example a webhook that fires an HTTP request to an external system when code is pushed.
+
+## Examples
+
+## Example 1: Sample Configuration using AzDoServiceHook Resource
+
+``` PowerShell
+Configuration ExampleConfig {
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    Node localhost {
+        AzDoServiceHook NotifyOnPush {
+            Ensure           = 'Present'
+            Name             = 'notify-ci-on-push'
+            ProjectName      = 'MyProject'
+            PublisherId      = 'tfs'
+            EventType        = 'git.push'
+            ConsumerId       = 'webHooks'
+            ConsumerActionId = 'httpRequest'
+            ConsumerInputs   = @{ url = 'https://ci.contoso.com/hook' }
+        }
+    }
+}
+
+Start-DscConfiguration -Path ./ExampleConfig -Wait -Verbose
+```
+
+## Example 2: Sample Configuration using Invoke-DSCResource
+
+``` PowerShell
+# Return the current configuration for AzDoServiceHook
+$properties = @{
+    Name             = 'notify-ci-on-push'
+    ProjectName      = 'MyProject'
+    PublisherId      = 'tfs'
+    EventType        = 'git.push'
+    ConsumerId       = 'webHooks'
+    ConsumerActionId = 'httpRequest'
+    ConsumerInputs   = @{ url = 'https://ci.contoso.com/hook' }
+}
+
+Invoke-DscResource -Name 'AzDoServiceHook' -Method Get -Property $properties -ModuleName 'AzureDevOpsDsc'
+```
+
+## Example 3: Sample Configuration using AzDO-DSC-LCM
+
+``` YAML
+parameters: {}
+
+variables: {
+  ProjectName: MyProject
+}
+
+resources:
+- name: Notify CI on push
+  type: AzureDevOpsDsc/AzDoServiceHook
+  dependsOn:
+    - AzureDevOpsDsc/AzDevOpsProject/MyProject
+  properties:
+    Name: notify-ci-on-push
+    ProjectName: $ProjectName
+    PublisherId: tfs
+    EventType: git.push
+    ConsumerId: webHooks
+    ConsumerActionId: httpRequest
+    ConsumerInputs:
+      url: https://ci.contoso.com/hook
+    Ensure: Present
+```
+
+LCM Initialization:
+
+``` PowerShell
+
+$params = @{
+    AzureDevopsOrganizationName = "SampleAzDoOrgName"
+    ConfigurationDirectory      = "C:\Datum\DSCOutput\"
+    ConfigurationUrl            = 'https://configuration-path'
+    JITToken                    = 'SampleJITToken'
+    Mode                        = 'Set'
+    AuthenticationType          = 'ManagedIdentity'
+    ReportPath                  = 'C:\Datum\DSCOutput\Reports'
+}
+
+Invoke-AzDoLCM @params
+```

--- a/source/Examples/Resources/AzDoUserEntitlement.md
+++ b/source/Examples/Resources/AzDoUserEntitlement.md
@@ -1,0 +1,89 @@
+# DSC AzDoUserEntitlement Resource
+
+## Syntax
+
+```PowerShell
+AzDoUserEntitlement [string] #ResourceName
+{
+    UserPrincipalName    = [String]$UserPrincipalName
+    AccountLicenseType   = [String] {'stakeholder', 'express', 'advanced', 'professional', 'earlyAdopter', 'none'}
+    [ Ensure            = [String] {'Present', 'Absent'} ]
+}
+```
+
+## Properties
+
+### Common Properties
+
+- **UserPrincipalName**: The user's principal name (email / UPN). This property is mandatory and serves as the key property for the resource.
+- **AccountLicenseType**: The access level (license) to assign. Valid values are `stakeholder`, `express` (Basic), `advanced` (Basic + Test Plans), `professional`, `earlyAdopter` and `none`.
+- **Ensure**: Specifies whether the user should be a member of the organization. Valid values are `Present` and `Absent`. Removing a user unassigns their license/extensions and removes them from all project memberships.
+
+## Additional Information
+
+This resource adds and removes organization users and manages their access level via the Member Entitlement Management API. The user must be a resolvable identity in the backing directory (e.g. Microsoft Entra ID) to be added. Adding a user consumes a license of the specified type.
+
+## Examples
+
+## Example 1: Sample Configuration using AzDoUserEntitlement Resource
+
+``` PowerShell
+Configuration ExampleConfig {
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    Node localhost {
+        AzDoUserEntitlement JaneBasic {
+            Ensure             = 'Present'
+            UserPrincipalName  = 'jane@contoso.com'
+            AccountLicenseType = 'express'
+        }
+    }
+}
+
+Start-DscConfiguration -Path ./ExampleConfig -Wait -Verbose
+```
+
+## Example 2: Sample Configuration using Invoke-DSCResource
+
+``` PowerShell
+# Return the current configuration for AzDoUserEntitlement
+$properties = @{
+    UserPrincipalName  = 'jane@contoso.com'
+    AccountLicenseType = 'express'
+}
+
+Invoke-DscResource -Name 'AzDoUserEntitlement' -Method Get -Property $properties -ModuleName 'AzureDevOpsDsc'
+```
+
+## Example 3: Sample Configuration using AzDO-DSC-LCM
+
+``` YAML
+parameters: {}
+
+variables: {}
+
+resources:
+- name: Add Jane as a Basic user
+  type: AzureDevOpsDsc/AzDoUserEntitlement
+  properties:
+    UserPrincipalName: jane@contoso.com
+    AccountLicenseType: express
+    Ensure: Present
+```
+
+LCM Initialization:
+
+``` PowerShell
+
+$params = @{
+    AzureDevopsOrganizationName = "SampleAzDoOrgName"
+    ConfigurationDirectory      = "C:\Datum\DSCOutput\"
+    ConfigurationUrl            = 'https://configuration-path'
+    JITToken                    = 'SampleJITToken'
+    Mode                        = 'Set'
+    AuthenticationType          = 'ManagedIdentity'
+    ReportPath                  = 'C:\Datum\DSCOutput\Reports'
+}
+
+Invoke-AzDoLCM @params
+```

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/PipelineSettings/Get-DevOpsPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/PipelineSettings/Get-DevOpsPipelineSettings.ps1
@@ -1,0 +1,55 @@
+<#
+.SYNOPSIS
+Gets the pipeline general settings for an Azure DevOps project.
+
+.DESCRIPTION
+Retrieves the project's pipeline general settings via the Build REST API
+(GET https://dev.azure.com/{org}/{project}/_apis/build/generalsettings). The response is a flat object
+of boolean settings (enforceJobAuthScope, statusBadgesArePrivate, etc.).
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER ProjectName
+The name (or id) of the project.
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1'.
+
+.OUTPUTS
+The pipeline general settings object, or $null.
+
+.EXAMPLE
+Get-DevOpsPipelineSettings -Organization 'myorg' -ProjectName 'MyProject'
+#>
+function Get-DevOpsPipelineSettings
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ProjectName,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1'
+    )
+
+    $params = @{
+        Uri    = 'https://dev.azure.com/{0}/{1}/_apis/build/generalsettings?api-version={2}' -f $Organization, $ProjectName, $ApiVersion
+        Method = 'Get'
+    }
+
+    try
+    {
+        return Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        Write-Verbose "[Get-DevOpsPipelineSettings] Lookup of pipeline settings for '$ProjectName' failed: $_"
+        return $null
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/PipelineSettings/Set-DevOpsPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/PipelineSettings/Set-DevOpsPipelineSettings.ps1
@@ -1,0 +1,68 @@
+<#
+.SYNOPSIS
+Updates the pipeline general settings for an Azure DevOps project.
+
+.DESCRIPTION
+Patches the project's pipeline general settings via the Build REST API
+(PATCH https://dev.azure.com/{org}/{project}/_apis/build/generalsettings). Only the supplied keys are
+changed; the endpoint merges them with the existing settings.
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER ProjectName
+The name (or id) of the project.
+
+.PARAMETER Settings
+A hashtable of the settings to change (API field names mapped to boolean values).
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1'.
+
+.EXAMPLE
+Set-DevOpsPipelineSettings -Organization 'myorg' -ProjectName 'MyProject' -Settings @{ enforceJobAuthScope = $true }
+#>
+function Set-DevOpsPipelineSettings
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ProjectName,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Settings,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1'
+    )
+
+    if ($Settings.Count -eq 0)
+    {
+        Write-Verbose '[Set-DevOpsPipelineSettings] No settings supplied; nothing to do.'
+        return
+    }
+
+    $params = @{
+        Uri    = 'https://dev.azure.com/{0}/{1}/_apis/build/generalsettings?api-version={2}' -f $Organization, $ProjectName, $ApiVersion
+        Method = 'PATCH'
+        Body   = $Settings | ConvertTo-Json -Depth 4
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($ProjectName, 'Update pipeline general settings'))
+    {
+        return
+    }
+
+    try
+    {
+        return Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        throw "[Set-DevOpsPipelineSettings] Failed to update pipeline settings for '$ProjectName' in '$Organization': $_"
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/ConvertTo-DevOpsServiceHookSubscription.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/ConvertTo-DevOpsServiceHookSubscription.ps1
@@ -1,0 +1,95 @@
+<#
+.SYNOPSIS
+Builds a service hook subscription request body from resource properties.
+
+.DESCRIPTION
+Assembles the subscription hashtable sent to the Service Hooks API. When a ProjectName is supplied its
+project id is resolved (cache-first, then a live lookup) and added to the publisher inputs as 'projectId'.
+
+.PARAMETER OrganizationName
+The name of the Azure DevOps organization (used to resolve the project id).
+
+.PARAMETER PublisherId
+The publisher id.
+
+.PARAMETER EventType
+The event type.
+
+.PARAMETER ConsumerId
+The consumer id.
+
+.PARAMETER ConsumerActionId
+The consumer action id.
+
+.PARAMETER ConsumerInputs
+The consumer input values.
+
+.PARAMETER PublisherInputs
+The publisher input values.
+
+.PARAMETER ResourceVersion
+The event resource version.
+
+.PARAMETER ProjectName
+Optional project name to resolve into a 'projectId' publisher input.
+
+.OUTPUTS
+A hashtable suitable for the Service Hooks create/replace body.
+#>
+function ConvertTo-DevOpsServiceHookSubscription
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$OrganizationName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PublisherId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$EventType,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ConsumerId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ConsumerActionId,
+
+        [Parameter()]
+        [hashtable]$ConsumerInputs = @{},
+
+        [Parameter()]
+        [hashtable]$PublisherInputs = @{},
+
+        [Parameter()]
+        [string]$ResourceVersion = '1.0',
+
+        [Parameter()]
+        [string]$ProjectName
+    )
+
+    $pubInputs = @{}
+    foreach ($key in $PublisherInputs.Keys) { $pubInputs[$key] = $PublisherInputs[$key] }
+
+    if (-not [string]::IsNullOrWhiteSpace($ProjectName))
+    {
+        $project = Get-CacheItem -Key $ProjectName -Type 'LiveProjects'
+        if (-not $project)
+        {
+            $project = Invoke-AzDevOpsApiRestMethod -Uri "https://dev.azure.com/$OrganizationName/_apis/projects/$ProjectName?api-version=7.1-preview.4" -Method Get
+        }
+        if ($project.id) { $pubInputs['projectId'] = $project.id }
+    }
+
+    return @{
+        publisherId      = $PublisherId
+        eventType        = $EventType
+        resourceVersion  = $ResourceVersion
+        consumerId       = $ConsumerId
+        consumerActionId = $ConsumerActionId
+        publisherInputs  = $pubInputs
+        consumerInputs   = $ConsumerInputs
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/ConvertTo-DevOpsServiceHookSubscription.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/ConvertTo-DevOpsServiceHookSubscription.ps1
@@ -78,7 +78,7 @@ function ConvertTo-DevOpsServiceHookSubscription
         $project = Get-CacheItem -Key $ProjectName -Type 'LiveProjects'
         if (-not $project)
         {
-            $project = Invoke-AzDevOpsApiRestMethod -Uri "https://dev.azure.com/$OrganizationName/_apis/projects/$ProjectName?api-version=7.1-preview.4" -Method Get
+            $project = Invoke-AzDevOpsApiRestMethod -Uri "https://dev.azure.com/$OrganizationName/_apis/projects/${ProjectName}?api-version=7.1-preview.4" -Method Get
         }
         if ($project.id) { $pubInputs['projectId'] = $project.id }
     }

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/List-DevOpsServiceHookSubscription.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/List-DevOpsServiceHookSubscription.ps1
@@ -1,0 +1,46 @@
+<#
+.SYNOPSIS
+Lists the service hook subscriptions in an Azure DevOps organization.
+
+.DESCRIPTION
+Retrieves all service hook subscriptions via the Service Hooks REST API
+(GET https://dev.azure.com/{org}/_apis/hooks/subscriptions).
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1'.
+
+.OUTPUTS
+An array of subscription objects, or an empty array.
+
+.EXAMPLE
+List-DevOpsServiceHookSubscription -Organization 'myorg'
+#>
+function List-DevOpsServiceHookSubscription
+{
+    [CmdletBinding()]
+    [OutputType([System.Object[]])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1'
+    )
+
+    $params = @{
+        Uri    = 'https://dev.azure.com/{0}/_apis/hooks/subscriptions?api-version={1}' -f $Organization, $ApiVersion
+        Method = 'Get'
+    }
+
+    $response = Invoke-AzDevOpsApiRestMethod @params
+    if ($null -eq $response.value)
+    {
+        return @()
+    }
+
+    return $response.value
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/New-DevOpsServiceHookSubscription.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/New-DevOpsServiceHookSubscription.ps1
@@ -1,0 +1,56 @@
+<#
+.SYNOPSIS
+Creates a service hook subscription in Azure DevOps.
+
+.DESCRIPTION
+Creates a subscription via the Service Hooks REST API
+(POST https://dev.azure.com/{org}/_apis/hooks/subscriptions).
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER Subscription
+A hashtable describing the subscription (publisherId, eventType, resourceVersion, consumerId,
+consumerActionId, publisherInputs, consumerInputs).
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1'.
+
+.EXAMPLE
+New-DevOpsServiceHookSubscription -Organization 'myorg' -Subscription $sub
+#>
+function New-DevOpsServiceHookSubscription
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Subscription,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1'
+    )
+
+    $params = @{
+        Uri    = 'https://dev.azure.com/{0}/_apis/hooks/subscriptions?api-version={1}' -f $Organization, $ApiVersion
+        Method = 'POST'
+        Body   = $Subscription | ConvertTo-Json -Depth 6
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Subscription.eventType, 'Create service hook subscription'))
+    {
+        return
+    }
+
+    try
+    {
+        return Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        throw "[New-DevOpsServiceHookSubscription] Failed to create subscription in '$Organization': $_"
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Remove-DevOpsServiceHookSubscription.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Remove-DevOpsServiceHookSubscription.ps1
@@ -1,0 +1,54 @@
+<#
+.SYNOPSIS
+Removes a service hook subscription from Azure DevOps.
+
+.DESCRIPTION
+Deletes a subscription via the Service Hooks REST API
+(DELETE https://dev.azure.com/{org}/_apis/hooks/subscriptions/{id}).
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER SubscriptionId
+The id (GUID) of the subscription to delete.
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1'.
+
+.EXAMPLE
+Remove-DevOpsServiceHookSubscription -Organization 'myorg' -SubscriptionId '...'
+#>
+function Remove-DevOpsServiceHookSubscription
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SubscriptionId,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1'
+    )
+
+    $params = @{
+        Uri    = 'https://dev.azure.com/{0}/_apis/hooks/subscriptions/{1}?api-version={2}' -f $Organization, $SubscriptionId, $ApiVersion
+        Method = 'DELETE'
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($SubscriptionId, 'Remove service hook subscription'))
+    {
+        return
+    }
+
+    try
+    {
+        return Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        throw "[Remove-DevOpsServiceHookSubscription] Failed to remove subscription '$SubscriptionId' in '$Organization': $_"
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Resolve-DevOpsServiceHookSubscription.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Resolve-DevOpsServiceHookSubscription.ps1
@@ -1,0 +1,66 @@
+<#
+.SYNOPSIS
+Finds an existing service hook subscription matching a desired event/consumer tuple.
+
+.DESCRIPTION
+Service hook subscriptions have no user-assigned name; they are identified by a server-generated id.
+This helper lists the organization's subscriptions and returns the one matching the natural identity
+tuple: publisherId + eventType + consumerId + consumerActionId, plus the consumer 'url' input when one
+is supplied (the discriminator for webhook-style consumers that may share an event type).
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER PublisherId
+The publisher id (e.g. 'tfs', 'rm').
+
+.PARAMETER EventType
+The event type (e.g. 'git.push', 'build.complete').
+
+.PARAMETER ConsumerId
+The consumer id (e.g. 'webHooks').
+
+.PARAMETER ConsumerActionId
+The consumer action id (e.g. 'httpRequest').
+
+.PARAMETER ConsumerInputs
+The desired consumer inputs; the 'url' value (when present) is used as an additional discriminator.
+
+.OUTPUTS
+The matching subscription object, or $null.
+#>
+function Resolve-DevOpsServiceHookSubscription
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PublisherId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$EventType,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ConsumerId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ConsumerActionId,
+
+        [Parameter()]
+        [hashtable]$ConsumerInputs
+    )
+
+    $desiredUrl = if ($ConsumerInputs) { $ConsumerInputs['url'] } else { $null }
+
+    List-DevOpsServiceHookSubscription -Organization $Organization | Where-Object {
+        ($_.publisherId -eq $PublisherId) -and
+        ($_.eventType -eq $EventType) -and
+        ($_.consumerId -eq $ConsumerId) -and
+        ($_.consumerActionId -eq $ConsumerActionId) -and
+        ((-not $desiredUrl) -or ($_.consumerInputs.url -eq $desiredUrl))
+    } | Select-Object -First 1
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Update-DevOpsServiceHookSubscription.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Update-DevOpsServiceHookSubscription.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+Replaces an existing service hook subscription in Azure DevOps.
+
+.DESCRIPTION
+Updates a subscription via the Service Hooks REST API
+(PUT https://dev.azure.com/{org}/_apis/hooks/subscriptions/{id}).
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER SubscriptionId
+The id (GUID) of the subscription to replace.
+
+.PARAMETER Subscription
+A hashtable describing the desired subscription state.
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1'.
+
+.EXAMPLE
+Update-DevOpsServiceHookSubscription -Organization 'myorg' -SubscriptionId '...' -Subscription $sub
+#>
+function Update-DevOpsServiceHookSubscription
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SubscriptionId,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Subscription,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1'
+    )
+
+    # The Replace (PUT) endpoint expects the id in the body as well as the route.
+    $body = $Subscription.Clone()
+    $body.id = $SubscriptionId
+
+    $params = @{
+        Uri    = 'https://dev.azure.com/{0}/_apis/hooks/subscriptions/{1}?api-version={2}' -f $Organization, $SubscriptionId, $ApiVersion
+        Method = 'PUT'
+        Body   = $body | ConvertTo-Json -Depth 6
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($SubscriptionId, 'Update service hook subscription'))
+    {
+        return
+    }
+
+    try
+    {
+        return Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        throw "[Update-DevOpsServiceHookSubscription] Failed to update subscription '$SubscriptionId' in '$Organization': $_"
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Get-DevOpsUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Get-DevOpsUserEntitlement.ps1
@@ -1,0 +1,64 @@
+<#
+.SYNOPSIS
+Finds an Azure DevOps user entitlement by principal name (email / UPN).
+
+.DESCRIPTION
+Searches the Member Entitlement Management service for a user entitlement matching the supplied
+principal name, using the Search User Entitlements API
+(GET https://vsaex.dev.azure.com/{org}/_apis/userentitlements?$filter=name eq '...'). Returns the
+single matching entitlement (which carries the entitlement id and current accessLevel) or $null.
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER PrincipalName
+The user's principal name (email / UPN) to search for.
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1'.
+
+.OUTPUTS
+The matching user entitlement object, or $null when no user matches.
+
+.EXAMPLE
+Get-DevOpsUserEntitlement -Organization 'myorg' -PrincipalName 'jane@contoso.com'
+#>
+function Get-DevOpsUserEntitlement
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PrincipalName,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1'
+    )
+
+    # $filter is a literal OData query-parameter name; the single-quoted format string keeps PowerShell
+    # from interpolating it. The filter value is URL-encoded because it contains spaces and quotes.
+    $filterValue   = "name eq '$PrincipalName'"
+    $encodedFilter = [uri]::EscapeDataString($filterValue)
+    $uri = 'https://vsaex.dev.azure.com/{0}/_apis/userentitlements?api-version={1}&$filter={2}' -f $Organization, $ApiVersion, $encodedFilter
+
+    try
+    {
+        $response = Invoke-AzDevOpsApiRestMethod -Uri $uri -Method Get
+    }
+    catch
+    {
+        Write-Verbose "[Get-DevOpsUserEntitlement] Lookup of '$PrincipalName' failed: $_"
+        return $null
+    }
+
+    # The Search response exposes the matches under 'members'; older shapes used 'value'.
+    $items = if ($null -ne $response.members) { $response.members } elseif ($null -ne $response.value) { $response.value } else { @() }
+
+    return $items | Where-Object {
+        ($_.user.principalName -eq $PrincipalName) -or ($_.user.mailAddress -eq $PrincipalName)
+    } | Select-Object -First 1
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Get-DevOpsUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Get-DevOpsUserEntitlement.ps1
@@ -51,7 +51,8 @@ function Get-DevOpsUserEntitlement
     }
     catch
     {
-        Write-Verbose "[Get-DevOpsUserEntitlement] Lookup of '$PrincipalName' failed: $_"
+        # Deliberately do not log the principal name (it is PII / may be a real user).
+        Write-Verbose "[Get-DevOpsUserEntitlement] User lookup failed: $_"
         return $null
     }
 

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/New-DevOpsUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/New-DevOpsUserEntitlement.ps1
@@ -57,7 +57,8 @@ function New-DevOpsUserEntitlement
         Body   = $body | ConvertTo-Json -Depth 5
     }
 
-    if (-not $PSCmdlet.ShouldProcess($PrincipalName, 'Add user entitlement'))
+    # Use a non-identifying target so the principal name is never written to -WhatIf / verbose output.
+    if (-not $PSCmdlet.ShouldProcess('user entitlement', 'Add'))
     {
         return
     }
@@ -68,14 +69,14 @@ function New-DevOpsUserEntitlement
     }
     catch
     {
-        throw "[New-DevOpsUserEntitlement] Failed to add user '$PrincipalName' to '$Organization': $_"
+        throw "[New-DevOpsUserEntitlement] Failed to add user to '$Organization': $_"
     }
 
     # The Add API returns 200 with an operationResult that reports per-user success/failure.
     if ($null -ne $response.operationResult -and -not $response.operationResult.isSuccess)
     {
         $errText = ($response.operationResult.errors | ForEach-Object { $_.value }) -join '; '
-        throw "[New-DevOpsUserEntitlement] Failed to add user '$PrincipalName': $errText"
+        throw "[New-DevOpsUserEntitlement] Failed to add user: $errText"
     }
 
     return $response

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/New-DevOpsUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/New-DevOpsUserEntitlement.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+Adds a user to an Azure DevOps organization and assigns an access level (license).
+
+.DESCRIPTION
+Creates a user entitlement via the Member Entitlement Management API
+(POST https://vsaex.dev.azure.com/{org}/_apis/userentitlements). The user is identified by principal
+name and assigned the given account license type.
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER PrincipalName
+The user's principal name (email / UPN).
+
+.PARAMETER AccountLicenseType
+The account license type to assign (e.g. stakeholder, express, advanced, professional, none).
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1'.
+
+.EXAMPLE
+New-DevOpsUserEntitlement -Organization 'myorg' -PrincipalName 'jane@contoso.com' -AccountLicenseType 'express'
+#>
+function New-DevOpsUserEntitlement
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$PrincipalName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AccountLicenseType,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1'
+    )
+
+    $body = @{
+        accessLevel = @{
+            licensingSource    = 'account'
+            accountLicenseType = $AccountLicenseType
+        }
+        user = @{
+            principalName = $PrincipalName
+            subjectKind   = 'user'
+        }
+    }
+
+    $params = @{
+        Uri    = 'https://vsaex.dev.azure.com/{0}/_apis/userentitlements?api-version={1}' -f $Organization, $ApiVersion
+        Method = 'POST'
+        Body   = $body | ConvertTo-Json -Depth 5
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($PrincipalName, 'Add user entitlement'))
+    {
+        return
+    }
+
+    try
+    {
+        $response = Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        throw "[New-DevOpsUserEntitlement] Failed to add user '$PrincipalName' to '$Organization': $_"
+    }
+
+    # The Add API returns 200 with an operationResult that reports per-user success/failure.
+    if ($null -ne $response.operationResult -and -not $response.operationResult.isSuccess)
+    {
+        $errText = ($response.operationResult.errors | ForEach-Object { $_.value }) -join '; '
+        throw "[New-DevOpsUserEntitlement] Failed to add user '$PrincipalName': $errText"
+    }
+
+    return $response
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Remove-DevOpsUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Remove-DevOpsUserEntitlement.ps1
@@ -1,0 +1,55 @@
+<#
+.SYNOPSIS
+Removes a user from an Azure DevOps organization.
+
+.DESCRIPTION
+Deletes a user entitlement via the Member Entitlement Management API
+(DELETE https://vsaex.dev.azure.com/{org}/_apis/userentitlements/{id}). This unassigns the user's
+license and extensions and removes them from all project memberships.
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER UserId
+The entitlement/user id (GUID) of the user to remove.
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1'.
+
+.EXAMPLE
+Remove-DevOpsUserEntitlement -Organization 'myorg' -UserId '...'
+#>
+function Remove-DevOpsUserEntitlement
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$UserId,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1'
+    )
+
+    $params = @{
+        Uri    = 'https://vsaex.dev.azure.com/{0}/_apis/userentitlements/{1}?api-version={2}' -f $Organization, $UserId, $ApiVersion
+        Method = 'DELETE'
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($UserId, 'Remove user entitlement'))
+    {
+        return
+    }
+
+    try
+    {
+        return Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        throw "[Remove-DevOpsUserEntitlement] Failed to remove user '$UserId' from '$Organization': $_"
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Update-DevOpsUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Update-DevOpsUserEntitlement.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+Updates the access level (license) of an existing Azure DevOps user entitlement.
+
+.DESCRIPTION
+Edits a user entitlement via the Member Entitlement Management API
+(PATCH https://vsaex.dev.azure.com/{org}/_apis/userentitlements/{id}) using a JSON-Patch document that
+replaces the accessLevel.
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER UserId
+The entitlement/user id (GUID) of the user to update.
+
+.PARAMETER AccountLicenseType
+The new account license type to assign.
+
+.PARAMETER ApiVersion
+The REST API version to use. Defaults to '7.1'.
+
+.EXAMPLE
+Update-DevOpsUserEntitlement -Organization 'myorg' -UserId '...' -AccountLicenseType 'advanced'
+#>
+function Update-DevOpsUserEntitlement
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]$Organization,
+
+        [Parameter(Mandatory = $true)]
+        [string]$UserId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AccountLicenseType,
+
+        [Parameter()]
+        [string]$ApiVersion = '7.1'
+    )
+
+    $patch = @(
+        @{
+            op    = 'replace'
+            path  = '/accessLevel'
+            value = @{
+                accountLicenseType = $AccountLicenseType
+                licensingSource    = 'account'
+            }
+        }
+    )
+
+    $params = @{
+        Uri         = 'https://vsaex.dev.azure.com/{0}/_apis/userentitlements/{1}?api-version={2}' -f $Organization, $UserId, $ApiVersion
+        Method      = 'PATCH'
+        ContentType = 'application/json-patch+json'
+        Body        = ConvertTo-Json -InputObject $patch -Depth 5 -AsArray
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($UserId, 'Update user entitlement access level'))
+    {
+        return
+    }
+
+    try
+    {
+        return Invoke-AzDevOpsApiRestMethod @params
+    }
+    catch
+    {
+        throw "[Update-DevOpsUserEntitlement] Failed to update user '$UserId' in '$Organization': $_"
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Get-AzDoPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Get-AzDoPipelineSettings.ps1
@@ -50,14 +50,14 @@ function Get-AzDoPipelineSettings
     param
     (
         [Parameter(Mandatory = $true)][System.String]$ProjectName,
-        [Parameter()][System.Boolean]$EnforceJobAuthScope,
-        [Parameter()][System.Boolean]$EnforceJobAuthScopeForReleases,
-        [Parameter()][System.Boolean]$EnforceReferencedRepoScopedToken,
-        [Parameter()][System.Boolean]$EnforceSettableVar,
-        [Parameter()][System.Boolean]$PublishPipelineMetadata,
-        [Parameter()][System.Boolean]$StatusBadgesArePrivate,
-        [Parameter()][System.Boolean]$DisableClassicPipelineCreation,
-        [Parameter()][System.Boolean]$DisableImpliedYAMLCiTrigger,
+        [Parameter()][System.String]$EnforceJobAuthScope,
+        [Parameter()][System.String]$EnforceJobAuthScopeForReleases,
+        [Parameter()][System.String]$EnforceReferencedRepoScopedToken,
+        [Parameter()][System.String]$EnforceSettableVar,
+        [Parameter()][System.String]$PublishPipelineMetadata,
+        [Parameter()][System.String]$StatusBadgesArePrivate,
+        [Parameter()][System.String]$DisableClassicPipelineCreation,
+        [Parameter()][System.String]$DisableImpliedYAMLCiTrigger,
         [Parameter()][HashTable]$LookupResult,
         [Parameter()][Ensure]$Ensure,
         [Parameter()][System.Management.Automation.SwitchParameter]$Force
@@ -97,11 +97,13 @@ function Get-AzDoPipelineSettings
     $changed = @()
     foreach ($dscName in $settingMap.Keys)
     {
-        $apiName   = $settingMap[$dscName]
-        $liveValue = [bool]$live.$apiName
-        $result[$dscName] = $liveValue
+        $apiName    = $settingMap[$dscName]
+        $liveString = if ([bool]$live.$apiName) { 'true' } else { 'false' }
+        $result[$dscName] = $liveString
 
-        if ($PSBoundParameters.ContainsKey($dscName) -and ($liveValue -ne $PSBoundParameters[$dscName]))
+        # Only compare settings the caller is managing (set to 'true'/'false'); '' means unmanaged.
+        $desired = [string]$PSBoundParameters[$dscName]
+        if (($desired -ne '') -and ($liveString -ne $desired))
         {
             $changed += $dscName
         }

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Get-AzDoPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Get-AzDoPipelineSettings.ps1
@@ -1,0 +1,114 @@
+<#
+.SYNOPSIS
+Retrieves the current pipeline general settings for an Azure DevOps project.
+
+.DESCRIPTION
+Fetches the project's live pipeline general settings and compares only the settings the caller actually
+specified (via PSBoundParameters) against the live values, reporting drift. Unspecified settings are left
+untouched.
+
+.PARAMETER ProjectName
+The name of the Azure DevOps project.
+
+.PARAMETER EnforceJobAuthScope
+Limit job authorization scope to the current project for non-release pipelines.
+
+.PARAMETER EnforceJobAuthScopeForReleases
+Limit job authorization scope to the current project for release pipelines.
+
+.PARAMETER EnforceReferencedRepoScopedToken
+Protect access to repositories in YAML pipelines.
+
+.PARAMETER EnforceSettableVar
+Limit variables that can be set at queue time.
+
+.PARAMETER PublishPipelineMetadata
+Publish metadata from pipelines.
+
+.PARAMETER StatusBadgesArePrivate
+Disable anonymous access to status badges.
+
+.PARAMETER DisableClassicPipelineCreation
+Disable creation of classic build and release pipelines.
+
+.PARAMETER DisableImpliedYAMLCiTrigger
+Disable implied YAML CI triggers.
+
+.PARAMETER LookupResult
+A hashtable to store the lookup result.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.OUTPUTS
+System.Collections.Hashtable
+#>
+function Get-AzDoPipelineSettings
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)][System.String]$ProjectName,
+        [Parameter()][System.Boolean]$EnforceJobAuthScope,
+        [Parameter()][System.Boolean]$EnforceJobAuthScopeForReleases,
+        [Parameter()][System.Boolean]$EnforceReferencedRepoScopedToken,
+        [Parameter()][System.Boolean]$EnforceSettableVar,
+        [Parameter()][System.Boolean]$PublishPipelineMetadata,
+        [Parameter()][System.Boolean]$StatusBadgesArePrivate,
+        [Parameter()][System.Boolean]$DisableClassicPipelineCreation,
+        [Parameter()][System.Boolean]$DisableImpliedYAMLCiTrigger,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Get-AzDoPipelineSettings] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    # Map DSC property names to the API's camelCase field names.
+    $settingMap = [ordered]@{
+        EnforceJobAuthScope              = 'enforceJobAuthScope'
+        EnforceJobAuthScopeForReleases   = 'enforceJobAuthScopeForReleases'
+        EnforceReferencedRepoScopedToken = 'enforceReferencedRepoScopedToken'
+        EnforceSettableVar               = 'enforceSettableVar'
+        PublishPipelineMetadata          = 'publishPipelineMetadata'
+        StatusBadgesArePrivate           = 'statusBadgesArePrivate'
+        DisableClassicPipelineCreation   = 'disableClassicPipelineCreation'
+        DisableImpliedYAMLCiTrigger      = 'disableImpliedYAMLCiTrigger'
+    }
+
+    $result = @{
+        Ensure            = [Ensure]::Present
+        ProjectName       = $ProjectName
+        propertiesChanged = @()
+        status            = $null
+    }
+
+    $live = Get-DevOpsPipelineSettings -Organization $OrganizationName -ProjectName $ProjectName
+    if ($null -eq $live)
+    {
+        $result.status = [DSCGetSummaryState]::Error
+        $result.reason = "Could not retrieve pipeline settings for project '$ProjectName'."
+        return $result
+    }
+
+    $changed = @()
+    foreach ($dscName in $settingMap.Keys)
+    {
+        $apiName   = $settingMap[$dscName]
+        $liveValue = [bool]$live.$apiName
+        $result[$dscName] = $liveValue
+
+        if ($PSBoundParameters.ContainsKey($dscName) -and ($liveValue -ne $PSBoundParameters[$dscName]))
+        {
+            $changed += $dscName
+        }
+    }
+
+    $result.propertiesChanged = $changed
+    $result.status = if ($changed.Count -eq 0) { [DSCGetSummaryState]::Unchanged } else { [DSCGetSummaryState]::Changed }
+
+    return $result
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/New-AzDoPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/New-AzDoPipelineSettings.ps1
@@ -1,0 +1,66 @@
+<#
+.SYNOPSIS
+Applies pipeline general settings for an Azure DevOps project.
+
+.DESCRIPTION
+Pipeline general settings always exist for a project, so there is nothing to "create". This function
+delegates to Set-AzDoPipelineSettings so the base-class dispatch behaves correctly if ever invoked.
+
+.PARAMETER ProjectName
+The name of the Azure DevOps project.
+
+.PARAMETER EnforceJobAuthScope
+Limit job authorization scope to the current project for non-release pipelines.
+
+.PARAMETER EnforceJobAuthScopeForReleases
+Limit job authorization scope to the current project for release pipelines.
+
+.PARAMETER EnforceReferencedRepoScopedToken
+Protect access to repositories in YAML pipelines.
+
+.PARAMETER EnforceSettableVar
+Limit variables that can be set at queue time.
+
+.PARAMETER PublishPipelineMetadata
+Publish metadata from pipelines.
+
+.PARAMETER StatusBadgesArePrivate
+Disable anonymous access to status badges.
+
+.PARAMETER DisableClassicPipelineCreation
+Disable creation of classic build and release pipelines.
+
+.PARAMETER DisableImpliedYAMLCiTrigger
+Disable implied YAML CI triggers.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function New-AzDoPipelineSettings
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)][System.String]$ProjectName,
+        [Parameter()][System.Boolean]$EnforceJobAuthScope,
+        [Parameter()][System.Boolean]$EnforceJobAuthScopeForReleases,
+        [Parameter()][System.Boolean]$EnforceReferencedRepoScopedToken,
+        [Parameter()][System.Boolean]$EnforceSettableVar,
+        [Parameter()][System.Boolean]$PublishPipelineMetadata,
+        [Parameter()][System.Boolean]$StatusBadgesArePrivate,
+        [Parameter()][System.Boolean]$DisableClassicPipelineCreation,
+        [Parameter()][System.Boolean]$DisableImpliedYAMLCiTrigger,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[New-AzDoPipelineSettings] Delegating to Set-AzDoPipelineSettings."
+    Set-AzDoPipelineSettings @PSBoundParameters
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/New-AzDoPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/New-AzDoPipelineSettings.ps1
@@ -48,14 +48,14 @@ function New-AzDoPipelineSettings
     param
     (
         [Parameter(Mandatory = $true)][System.String]$ProjectName,
-        [Parameter()][System.Boolean]$EnforceJobAuthScope,
-        [Parameter()][System.Boolean]$EnforceJobAuthScopeForReleases,
-        [Parameter()][System.Boolean]$EnforceReferencedRepoScopedToken,
-        [Parameter()][System.Boolean]$EnforceSettableVar,
-        [Parameter()][System.Boolean]$PublishPipelineMetadata,
-        [Parameter()][System.Boolean]$StatusBadgesArePrivate,
-        [Parameter()][System.Boolean]$DisableClassicPipelineCreation,
-        [Parameter()][System.Boolean]$DisableImpliedYAMLCiTrigger,
+        [Parameter()][System.String]$EnforceJobAuthScope,
+        [Parameter()][System.String]$EnforceJobAuthScopeForReleases,
+        [Parameter()][System.String]$EnforceReferencedRepoScopedToken,
+        [Parameter()][System.String]$EnforceSettableVar,
+        [Parameter()][System.String]$PublishPipelineMetadata,
+        [Parameter()][System.String]$StatusBadgesArePrivate,
+        [Parameter()][System.String]$DisableClassicPipelineCreation,
+        [Parameter()][System.String]$DisableImpliedYAMLCiTrigger,
         [Parameter()][HashTable]$LookupResult,
         [Parameter()][Ensure]$Ensure,
         [Parameter()][System.Management.Automation.SwitchParameter]$Force

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Remove-AzDoPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Remove-AzDoPipelineSettings.ps1
@@ -48,14 +48,14 @@ function Remove-AzDoPipelineSettings
     param
     (
         [Parameter(Mandatory = $true)][System.String]$ProjectName,
-        [Parameter()][System.Boolean]$EnforceJobAuthScope,
-        [Parameter()][System.Boolean]$EnforceJobAuthScopeForReleases,
-        [Parameter()][System.Boolean]$EnforceReferencedRepoScopedToken,
-        [Parameter()][System.Boolean]$EnforceSettableVar,
-        [Parameter()][System.Boolean]$PublishPipelineMetadata,
-        [Parameter()][System.Boolean]$StatusBadgesArePrivate,
-        [Parameter()][System.Boolean]$DisableClassicPipelineCreation,
-        [Parameter()][System.Boolean]$DisableImpliedYAMLCiTrigger,
+        [Parameter()][System.String]$EnforceJobAuthScope,
+        [Parameter()][System.String]$EnforceJobAuthScopeForReleases,
+        [Parameter()][System.String]$EnforceReferencedRepoScopedToken,
+        [Parameter()][System.String]$EnforceSettableVar,
+        [Parameter()][System.String]$PublishPipelineMetadata,
+        [Parameter()][System.String]$StatusBadgesArePrivate,
+        [Parameter()][System.String]$DisableClassicPipelineCreation,
+        [Parameter()][System.String]$DisableImpliedYAMLCiTrigger,
         [Parameter()][HashTable]$LookupResult,
         [Parameter()][Ensure]$Ensure,
         [Parameter()][System.Management.Automation.SwitchParameter]$Force

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Remove-AzDoPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Remove-AzDoPipelineSettings.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+No-op removal for Azure DevOps pipeline general settings.
+
+.DESCRIPTION
+Pipeline general settings are intrinsic to a project and cannot be removed, so Ensure = 'Absent' is a
+no-op. This function exists to satisfy the base-class dispatch and emits a warning if invoked.
+
+.PARAMETER ProjectName
+The name of the Azure DevOps project.
+
+.PARAMETER EnforceJobAuthScope
+Limit job authorization scope to the current project for non-release pipelines.
+
+.PARAMETER EnforceJobAuthScopeForReleases
+Limit job authorization scope to the current project for release pipelines.
+
+.PARAMETER EnforceReferencedRepoScopedToken
+Protect access to repositories in YAML pipelines.
+
+.PARAMETER EnforceSettableVar
+Limit variables that can be set at queue time.
+
+.PARAMETER PublishPipelineMetadata
+Publish metadata from pipelines.
+
+.PARAMETER StatusBadgesArePrivate
+Disable anonymous access to status badges.
+
+.PARAMETER DisableClassicPipelineCreation
+Disable creation of classic build and release pipelines.
+
+.PARAMETER DisableImpliedYAMLCiTrigger
+Disable implied YAML CI triggers.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function Remove-AzDoPipelineSettings
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)][System.String]$ProjectName,
+        [Parameter()][System.Boolean]$EnforceJobAuthScope,
+        [Parameter()][System.Boolean]$EnforceJobAuthScopeForReleases,
+        [Parameter()][System.Boolean]$EnforceReferencedRepoScopedToken,
+        [Parameter()][System.Boolean]$EnforceSettableVar,
+        [Parameter()][System.Boolean]$PublishPipelineMetadata,
+        [Parameter()][System.Boolean]$StatusBadgesArePrivate,
+        [Parameter()][System.Boolean]$DisableClassicPipelineCreation,
+        [Parameter()][System.Boolean]$DisableImpliedYAMLCiTrigger,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Warning "[Remove-AzDoPipelineSettings] Pipeline general settings cannot be removed; ignoring Ensure = 'Absent' for project '$ProjectName'."
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Set-AzDoPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Set-AzDoPipelineSettings.ps1
@@ -48,14 +48,14 @@ function Set-AzDoPipelineSettings
     param
     (
         [Parameter(Mandatory = $true)][System.String]$ProjectName,
-        [Parameter()][System.Boolean]$EnforceJobAuthScope,
-        [Parameter()][System.Boolean]$EnforceJobAuthScopeForReleases,
-        [Parameter()][System.Boolean]$EnforceReferencedRepoScopedToken,
-        [Parameter()][System.Boolean]$EnforceSettableVar,
-        [Parameter()][System.Boolean]$PublishPipelineMetadata,
-        [Parameter()][System.Boolean]$StatusBadgesArePrivate,
-        [Parameter()][System.Boolean]$DisableClassicPipelineCreation,
-        [Parameter()][System.Boolean]$DisableImpliedYAMLCiTrigger,
+        [Parameter()][System.String]$EnforceJobAuthScope,
+        [Parameter()][System.String]$EnforceJobAuthScopeForReleases,
+        [Parameter()][System.String]$EnforceReferencedRepoScopedToken,
+        [Parameter()][System.String]$EnforceSettableVar,
+        [Parameter()][System.String]$PublishPipelineMetadata,
+        [Parameter()][System.String]$StatusBadgesArePrivate,
+        [Parameter()][System.String]$DisableClassicPipelineCreation,
+        [Parameter()][System.String]$DisableImpliedYAMLCiTrigger,
         [Parameter()][HashTable]$LookupResult,
         [Parameter()][Ensure]$Ensure,
         [Parameter()][System.Management.Automation.SwitchParameter]$Force
@@ -79,9 +79,11 @@ function Set-AzDoPipelineSettings
     $settings = @{}
     foreach ($dscName in $settingMap.Keys)
     {
-        if ($PSBoundParameters.ContainsKey($dscName))
+        # Only send settings the caller is managing (set to 'true'/'false'); '' means leave untouched.
+        $desired = [string]$PSBoundParameters[$dscName]
+        if ($desired -ne '')
         {
-            $settings[$settingMap[$dscName]] = [bool]$PSBoundParameters[$dscName]
+            $settings[$settingMap[$dscName]] = ($desired -eq 'true')
         }
     }
 

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Set-AzDoPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Set-AzDoPipelineSettings.ps1
@@ -1,0 +1,95 @@
+<#
+.SYNOPSIS
+Updates the pipeline general settings for an Azure DevOps project.
+
+.DESCRIPTION
+Builds a patch of only the settings the caller specified (via PSBoundParameters) and applies them to the
+project's pipeline general settings. Unspecified settings are left untouched.
+
+.PARAMETER ProjectName
+The name of the Azure DevOps project.
+
+.PARAMETER EnforceJobAuthScope
+Limit job authorization scope to the current project for non-release pipelines.
+
+.PARAMETER EnforceJobAuthScopeForReleases
+Limit job authorization scope to the current project for release pipelines.
+
+.PARAMETER EnforceReferencedRepoScopedToken
+Protect access to repositories in YAML pipelines.
+
+.PARAMETER EnforceSettableVar
+Limit variables that can be set at queue time.
+
+.PARAMETER PublishPipelineMetadata
+Publish metadata from pipelines.
+
+.PARAMETER StatusBadgesArePrivate
+Disable anonymous access to status badges.
+
+.PARAMETER DisableClassicPipelineCreation
+Disable creation of classic build and release pipelines.
+
+.PARAMETER DisableImpliedYAMLCiTrigger
+Disable implied YAML CI triggers.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function Set-AzDoPipelineSettings
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)][System.String]$ProjectName,
+        [Parameter()][System.Boolean]$EnforceJobAuthScope,
+        [Parameter()][System.Boolean]$EnforceJobAuthScopeForReleases,
+        [Parameter()][System.Boolean]$EnforceReferencedRepoScopedToken,
+        [Parameter()][System.Boolean]$EnforceSettableVar,
+        [Parameter()][System.Boolean]$PublishPipelineMetadata,
+        [Parameter()][System.Boolean]$StatusBadgesArePrivate,
+        [Parameter()][System.Boolean]$DisableClassicPipelineCreation,
+        [Parameter()][System.Boolean]$DisableImpliedYAMLCiTrigger,
+        [Parameter()][HashTable]$LookupResult,
+        [Parameter()][Ensure]$Ensure,
+        [Parameter()][System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Set-AzDoPipelineSettings] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    $settingMap = [ordered]@{
+        EnforceJobAuthScope              = 'enforceJobAuthScope'
+        EnforceJobAuthScopeForReleases   = 'enforceJobAuthScopeForReleases'
+        EnforceReferencedRepoScopedToken = 'enforceReferencedRepoScopedToken'
+        EnforceSettableVar               = 'enforceSettableVar'
+        PublishPipelineMetadata          = 'publishPipelineMetadata'
+        StatusBadgesArePrivate           = 'statusBadgesArePrivate'
+        DisableClassicPipelineCreation   = 'disableClassicPipelineCreation'
+        DisableImpliedYAMLCiTrigger      = 'disableImpliedYAMLCiTrigger'
+    }
+
+    $settings = @{}
+    foreach ($dscName in $settingMap.Keys)
+    {
+        if ($PSBoundParameters.ContainsKey($dscName))
+        {
+            $settings[$settingMap[$dscName]] = [bool]$PSBoundParameters[$dscName]
+        }
+    }
+
+    if ($settings.Count -eq 0)
+    {
+        Write-Verbose "[Set-AzDoPipelineSettings] No settings specified; nothing to update."
+        return
+    }
+
+    $null = Set-DevOpsPipelineSettings -Organization $OrganizationName -ProjectName $ProjectName -Settings $settings
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Get-AzDoServiceHook.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Get-AzDoServiceHook.ps1
@@ -1,0 +1,151 @@
+<#
+.SYNOPSIS
+Retrieves the current state of an Azure DevOps service hook subscription.
+
+.DESCRIPTION
+Matches a live service hook subscription by its natural identity tuple (publisher/event/consumer) and
+reports whether it exists and whether the user-specified publisher/consumer inputs match. Only the input
+keys supplied in the configuration are compared — the API adds server-managed keys (hostId, etc.) that
+are ignored.
+
+.PARAMETER Name
+A logical name for the subscription. This is the DSC key; it is not sent to Azure DevOps.
+
+.PARAMETER ProjectName
+Optional project name; when supplied its id is added to the publisher inputs as 'projectId'.
+
+.PARAMETER PublisherId
+The publisher id (e.g. 'tfs', 'rm').
+
+.PARAMETER EventType
+The event type (e.g. 'git.push', 'build.complete').
+
+.PARAMETER ConsumerId
+The consumer id (e.g. 'webHooks').
+
+.PARAMETER ConsumerActionId
+The consumer action id (e.g. 'httpRequest').
+
+.PARAMETER ConsumerInputs
+The consumer input values (e.g. @{ url = 'https://...' }).
+
+.PARAMETER PublisherInputs
+The publisher input values (e.g. @{ repository = '...' }).
+
+.PARAMETER ResourceVersion
+The event resource version. Defaults to '1.0'.
+
+.PARAMETER LookupResult
+A hashtable to store the lookup result.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.OUTPUTS
+System.Collections.Hashtable
+#>
+function Get-AzDoServiceHook
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]$Name,
+
+        [Parameter()]
+        [System.String]$ProjectName,
+
+        [Parameter()]
+        [System.String]$PublisherId,
+
+        [Parameter()]
+        [System.String]$EventType,
+
+        [Parameter()]
+        [System.String]$ConsumerId,
+
+        [Parameter()]
+        [System.String]$ConsumerActionId,
+
+        [Parameter()]
+        [HashTable]$ConsumerInputs,
+
+        [Parameter()]
+        [HashTable]$PublisherInputs,
+
+        [Parameter()]
+        [System.String]$ResourceVersion = '1.0',
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure
+    )
+
+    Write-Verbose "[Get-AzDoServiceHook] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    $result = @{
+        Ensure            = [Ensure]::Absent
+        Name              = $Name
+        propertiesChanged = @()
+        status            = $null
+    }
+
+    $resolveParams = @{
+        Organization     = $OrganizationName
+        PublisherId      = $PublisherId
+        EventType        = $EventType
+        ConsumerId       = $ConsumerId
+        ConsumerActionId = $ConsumerActionId
+        ConsumerInputs   = $ConsumerInputs
+    }
+    $subscription = Resolve-DevOpsServiceHookSubscription @resolveParams
+
+    if ($null -eq $subscription)
+    {
+        Write-Verbose "[Get-AzDoServiceHook] Subscription '$Name' not found."
+        $result.status = [DSCGetSummaryState]::NotFound
+        return $result
+    }
+
+    $result.subscriptionId = $subscription.id
+
+    # Compare only the consumer/publisher input keys the user specified; the API adds server-managed keys.
+    if ($ConsumerInputs)
+    {
+        foreach ($key in $ConsumerInputs.Keys)
+        {
+            if ([string]$subscription.consumerInputs.$key -ne [string]$ConsumerInputs[$key])
+            {
+                $result.propertiesChanged += "consumerInputs.$key"
+            }
+        }
+    }
+    if ($PublisherInputs)
+    {
+        foreach ($key in $PublisherInputs.Keys)
+        {
+            if ([string]$subscription.publisherInputs.$key -ne [string]$PublisherInputs[$key])
+            {
+                $result.propertiesChanged += "publisherInputs.$key"
+            }
+        }
+    }
+
+    if ($result.propertiesChanged.Count -gt 0)
+    {
+        $result.status = [DSCGetSummaryState]::Changed
+        Write-Verbose "[Get-AzDoServiceHook] Subscription '$Name' has drifted: $($result.propertiesChanged -join ', ')"
+    }
+    else
+    {
+        $result.status = [DSCGetSummaryState]::Unchanged
+        Write-Verbose "[Get-AzDoServiceHook] Subscription '$Name' is in the desired state."
+    }
+
+    return $result
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/New-AzDoServiceHook.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/New-AzDoServiceHook.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+Creates an Azure DevOps service hook subscription.
+
+.DESCRIPTION
+Builds the subscription body from the resource properties and creates it via the Service Hooks API.
+
+.PARAMETER Name
+A logical name for the subscription (DSC key; not sent to Azure DevOps).
+
+.PARAMETER ProjectName
+Optional project name; its id is added to the publisher inputs as 'projectId'.
+
+.PARAMETER PublisherId
+The publisher id.
+
+.PARAMETER EventType
+The event type.
+
+.PARAMETER ConsumerId
+The consumer id.
+
+.PARAMETER ConsumerActionId
+The consumer action id.
+
+.PARAMETER ConsumerInputs
+The consumer input values.
+
+.PARAMETER PublisherInputs
+The publisher input values.
+
+.PARAMETER ResourceVersion
+The event resource version. Defaults to '1.0'.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function New-AzDoServiceHook
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]$Name,
+
+        [Parameter()]
+        [System.String]$ProjectName,
+
+        [Parameter()]
+        [System.String]$PublisherId,
+
+        [Parameter()]
+        [System.String]$EventType,
+
+        [Parameter()]
+        [System.String]$ConsumerId,
+
+        [Parameter()]
+        [System.String]$ConsumerActionId,
+
+        [Parameter()]
+        [HashTable]$ConsumerInputs,
+
+        [Parameter()]
+        [HashTable]$PublisherInputs,
+
+        [Parameter()]
+        [System.String]$ResourceVersion = '1.0',
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[New-AzDoServiceHook] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    $buildParams = @{
+        OrganizationName = $OrganizationName
+        PublisherId      = $PublisherId
+        EventType        = $EventType
+        ConsumerId       = $ConsumerId
+        ConsumerActionId = $ConsumerActionId
+        ResourceVersion  = $ResourceVersion
+    }
+    if ($ConsumerInputs)  { $buildParams.ConsumerInputs  = $ConsumerInputs }
+    if ($PublisherInputs) { $buildParams.PublisherInputs = $PublisherInputs }
+    if ($ProjectName)     { $buildParams.ProjectName     = $ProjectName }
+
+    $subscription = ConvertTo-DevOpsServiceHookSubscription @buildParams
+
+    $null = New-DevOpsServiceHookSubscription -Organization $OrganizationName -Subscription $subscription
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Remove-AzDoServiceHook.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Remove-AzDoServiceHook.ps1
@@ -1,0 +1,111 @@
+<#
+.SYNOPSIS
+Removes an Azure DevOps service hook subscription.
+
+.DESCRIPTION
+Resolves the subscription by its identity tuple and deletes it via the Service Hooks API.
+
+.PARAMETER Name
+A logical name for the subscription (DSC key; not sent to Azure DevOps).
+
+.PARAMETER ProjectName
+Optional project name.
+
+.PARAMETER PublisherId
+The publisher id.
+
+.PARAMETER EventType
+The event type.
+
+.PARAMETER ConsumerId
+The consumer id.
+
+.PARAMETER ConsumerActionId
+The consumer action id.
+
+.PARAMETER ConsumerInputs
+The consumer input values (the 'url' is used as a match discriminator).
+
+.PARAMETER PublisherInputs
+The publisher input values.
+
+.PARAMETER ResourceVersion
+The event resource version.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function Remove-AzDoServiceHook
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]$Name,
+
+        [Parameter()]
+        [System.String]$ProjectName,
+
+        [Parameter()]
+        [System.String]$PublisherId,
+
+        [Parameter()]
+        [System.String]$EventType,
+
+        [Parameter()]
+        [System.String]$ConsumerId,
+
+        [Parameter()]
+        [System.String]$ConsumerActionId,
+
+        [Parameter()]
+        [HashTable]$ConsumerInputs,
+
+        [Parameter()]
+        [HashTable]$PublisherInputs,
+
+        [Parameter()]
+        [System.String]$ResourceVersion = '1.0',
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Remove-AzDoServiceHook] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    $subscriptionId = $LookupResult.subscriptionId
+    if (-not $subscriptionId)
+    {
+        $resolveParams = @{
+            Organization     = $OrganizationName
+            PublisherId      = $PublisherId
+            EventType        = $EventType
+            ConsumerId       = $ConsumerId
+            ConsumerActionId = $ConsumerActionId
+            ConsumerInputs   = $ConsumerInputs
+        }
+        $existing = Resolve-DevOpsServiceHookSubscription @resolveParams
+        if ($null -eq $existing)
+        {
+            Write-Verbose "[Remove-AzDoServiceHook] Subscription '$Name' not found; nothing to remove."
+            return
+        }
+        $subscriptionId = $existing.id
+    }
+
+    $null = Remove-DevOpsServiceHookSubscription -Organization $OrganizationName -SubscriptionId $subscriptionId
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Set-AzDoServiceHook.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Set-AzDoServiceHook.ps1
@@ -1,0 +1,125 @@
+<#
+.SYNOPSIS
+Updates an Azure DevOps service hook subscription.
+
+.DESCRIPTION
+Resolves the existing subscription, rebuilds the body from the resource properties and replaces it via
+the Service Hooks API.
+
+.PARAMETER Name
+A logical name for the subscription (DSC key; not sent to Azure DevOps).
+
+.PARAMETER ProjectName
+Optional project name; its id is added to the publisher inputs as 'projectId'.
+
+.PARAMETER PublisherId
+The publisher id.
+
+.PARAMETER EventType
+The event type.
+
+.PARAMETER ConsumerId
+The consumer id.
+
+.PARAMETER ConsumerActionId
+The consumer action id.
+
+.PARAMETER ConsumerInputs
+The consumer input values.
+
+.PARAMETER PublisherInputs
+The publisher input values.
+
+.PARAMETER ResourceVersion
+The event resource version. Defaults to '1.0'.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function Set-AzDoServiceHook
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]$Name,
+
+        [Parameter()]
+        [System.String]$ProjectName,
+
+        [Parameter()]
+        [System.String]$PublisherId,
+
+        [Parameter()]
+        [System.String]$EventType,
+
+        [Parameter()]
+        [System.String]$ConsumerId,
+
+        [Parameter()]
+        [System.String]$ConsumerActionId,
+
+        [Parameter()]
+        [HashTable]$ConsumerInputs,
+
+        [Parameter()]
+        [HashTable]$PublisherInputs,
+
+        [Parameter()]
+        [System.String]$ResourceVersion = '1.0',
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Set-AzDoServiceHook] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    $subscriptionId = $LookupResult.subscriptionId
+    if (-not $subscriptionId)
+    {
+        $resolveParams = @{
+            Organization     = $OrganizationName
+            PublisherId      = $PublisherId
+            EventType        = $EventType
+            ConsumerId       = $ConsumerId
+            ConsumerActionId = $ConsumerActionId
+            ConsumerInputs   = $ConsumerInputs
+        }
+        $existing = Resolve-DevOpsServiceHookSubscription @resolveParams
+        if ($null -eq $existing)
+        {
+            throw "[Set-AzDoServiceHook] Subscription '$Name' not found; cannot update."
+        }
+        $subscriptionId = $existing.id
+    }
+
+    $buildParams = @{
+        OrganizationName = $OrganizationName
+        PublisherId      = $PublisherId
+        EventType        = $EventType
+        ConsumerId       = $ConsumerId
+        ConsumerActionId = $ConsumerActionId
+        ResourceVersion  = $ResourceVersion
+    }
+    if ($ConsumerInputs)  { $buildParams.ConsumerInputs  = $ConsumerInputs }
+    if ($PublisherInputs) { $buildParams.PublisherInputs = $PublisherInputs }
+    if ($ProjectName)     { $buildParams.ProjectName     = $ProjectName }
+
+    $subscription = ConvertTo-DevOpsServiceHookSubscription @buildParams
+
+    $null = Update-DevOpsServiceHookSubscription -Organization $OrganizationName -SubscriptionId $subscriptionId -Subscription $subscription
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Test-AzDoServiceHook.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Test-AzDoServiceHook.ps1
@@ -1,0 +1,89 @@
+<#
+.SYNOPSIS
+Placeholder test function for the AzDoServiceHook resource.
+
+.DESCRIPTION
+Test() is implemented by the AzDevOpsDscResourceBase base class, which compares the desired state against
+the result of Get-AzDoServiceHook. This function exists only to satisfy the resource function naming
+convention and should not be invoked directly.
+
+.PARAMETER Name
+A logical name for the subscription.
+
+.PARAMETER ProjectName
+Optional project name.
+
+.PARAMETER PublisherId
+The publisher id.
+
+.PARAMETER EventType
+The event type.
+
+.PARAMETER ConsumerId
+The consumer id.
+
+.PARAMETER ConsumerActionId
+The consumer action id.
+
+.PARAMETER ConsumerInputs
+The consumer input values.
+
+.PARAMETER PublisherInputs
+The publisher input values.
+
+.PARAMETER ResourceVersion
+The event resource version.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function Test-AzDoServiceHook
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]$Name,
+
+        [Parameter()]
+        [System.String]$ProjectName,
+
+        [Parameter()]
+        [System.String]$PublisherId,
+
+        [Parameter()]
+        [System.String]$EventType,
+
+        [Parameter()]
+        [System.String]$ConsumerId,
+
+        [Parameter()]
+        [System.String]$ConsumerActionId,
+
+        [Parameter()]
+        [HashTable]$ConsumerInputs,
+
+        [Parameter()]
+        [HashTable]$PublisherInputs,
+
+        [Parameter()]
+        [System.String]$ResourceVersion = '1.0',
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    # Should not be triggered. This is a placeholder for the test function.
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Get-AzDoUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Get-AzDoUserEntitlement.ps1
@@ -57,7 +57,7 @@ function Get-AzDoUserEntitlement
 
     if ($null -eq $entitlement)
     {
-        Write-Verbose "[Get-AzDoUserEntitlement] User '$UserPrincipalName' not found."
+        Write-Verbose "[Get-AzDoUserEntitlement] User not found."
         $result.status = [DSCGetSummaryState]::NotFound
         return $result
     }

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Get-AzDoUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Get-AzDoUserEntitlement.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+Retrieves the current state of an Azure DevOps user entitlement.
+
+.DESCRIPTION
+Looks up a user by principal name (email / UPN) and reports whether they exist in the organization and
+whether their assigned access level (account license type) matches the desired state.
+
+.PARAMETER UserPrincipalName
+The user's principal name (email / UPN).
+
+.PARAMETER AccountLicenseType
+The desired account license type.
+
+.PARAMETER LookupResult
+A hashtable to store the lookup result.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.OUTPUTS
+System.Collections.Hashtable
+#>
+function Get-AzDoUserEntitlement
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Alias('PrincipalName')]
+        [System.String]$UserPrincipalName,
+
+        [Parameter()]
+        [System.String]$AccountLicenseType,
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure
+    )
+
+    Write-Verbose "[Get-AzDoUserEntitlement] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    $result = @{
+        Ensure             = [Ensure]::Absent
+        UserPrincipalName  = $UserPrincipalName
+        AccountLicenseType = $AccountLicenseType
+        propertiesChanged  = @()
+        status             = $null
+    }
+
+    $entitlement = Get-DevOpsUserEntitlement -Organization $OrganizationName -PrincipalName $UserPrincipalName
+
+    if ($null -eq $entitlement)
+    {
+        Write-Verbose "[Get-AzDoUserEntitlement] User '$UserPrincipalName' not found."
+        $result.status = [DSCGetSummaryState]::NotFound
+        return $result
+    }
+
+    # Carry the resolved id so callers can reference it without a second lookup.
+    $result.userId = $entitlement.id
+
+    $currentLicense = $entitlement.accessLevel.accountLicenseType
+    if ($AccountLicenseType -and ($AccountLicenseType -ne $currentLicense))
+    {
+        Write-Verbose "[Get-AzDoUserEntitlement] Access level changed. Current: '$currentLicense', Desired: '$AccountLicenseType'."
+        $result.status = [DSCGetSummaryState]::Changed
+        $result.propertiesChanged += 'AccountLicenseType'
+    }
+
+    if ($result.propertiesChanged.Count -eq 0)
+    {
+        $result.status = [DSCGetSummaryState]::Unchanged
+        Write-Verbose "[Get-AzDoUserEntitlement] User entitlement is in the desired state."
+    }
+
+    return $result
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/New-AzDoUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/New-AzDoUserEntitlement.ps1
@@ -49,7 +49,7 @@ function New-AzDoUserEntitlement
 
     if ([string]::IsNullOrWhiteSpace($AccountLicenseType))
     {
-        throw "[New-AzDoUserEntitlement] AccountLicenseType is required to add user '$UserPrincipalName'."
+        throw "[New-AzDoUserEntitlement] AccountLicenseType is required to add the user."
     }
 
     $params = @{

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/New-AzDoUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/New-AzDoUserEntitlement.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+Adds a user to the Azure DevOps organization with the desired access level.
+
+.DESCRIPTION
+Creates a user entitlement (adds the user and assigns an account license) via the Member Entitlement
+Management API.
+
+.PARAMETER UserPrincipalName
+The user's principal name (email / UPN).
+
+.PARAMETER AccountLicenseType
+The account license type to assign.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function New-AzDoUserEntitlement
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Alias('PrincipalName')]
+        [System.String]$UserPrincipalName,
+
+        [Parameter()]
+        [System.String]$AccountLicenseType,
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[New-AzDoUserEntitlement] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    if ([string]::IsNullOrWhiteSpace($AccountLicenseType))
+    {
+        throw "[New-AzDoUserEntitlement] AccountLicenseType is required to add user '$UserPrincipalName'."
+    }
+
+    $params = @{
+        Organization       = $OrganizationName
+        PrincipalName      = $UserPrincipalName
+        AccountLicenseType = $AccountLicenseType
+    }
+
+    $null = New-DevOpsUserEntitlement @params
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Remove-AzDoUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Remove-AzDoUserEntitlement.ps1
@@ -53,7 +53,7 @@ function Remove-AzDoUserEntitlement
         $entitlement = Get-DevOpsUserEntitlement -Organization $OrganizationName -PrincipalName $UserPrincipalName
         if ($null -eq $entitlement)
         {
-            Write-Verbose "[Remove-AzDoUserEntitlement] User '$UserPrincipalName' not found; nothing to remove."
+            Write-Verbose "[Remove-AzDoUserEntitlement] User not found; nothing to remove."
             return
         }
         $userId = $entitlement.id

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Remove-AzDoUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Remove-AzDoUserEntitlement.ps1
@@ -1,0 +1,63 @@
+<#
+.SYNOPSIS
+Removes a user from the Azure DevOps organization.
+
+.DESCRIPTION
+Resolves the user by principal name and deletes their entitlement (license, extensions and project
+memberships) via the Member Entitlement Management API.
+
+.PARAMETER UserPrincipalName
+The user's principal name (email / UPN).
+
+.PARAMETER AccountLicenseType
+The account license type (informational only on removal).
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function Remove-AzDoUserEntitlement
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Alias('PrincipalName')]
+        [System.String]$UserPrincipalName,
+
+        [Parameter()]
+        [System.String]$AccountLicenseType,
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Remove-AzDoUserEntitlement] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    $userId = $LookupResult.userId
+    if (-not $userId)
+    {
+        $entitlement = Get-DevOpsUserEntitlement -Organization $OrganizationName -PrincipalName $UserPrincipalName
+        if ($null -eq $entitlement)
+        {
+            Write-Verbose "[Remove-AzDoUserEntitlement] User '$UserPrincipalName' not found; nothing to remove."
+            return
+        }
+        $userId = $entitlement.id
+    }
+
+    $null = Remove-DevOpsUserEntitlement -Organization $OrganizationName -UserId $userId
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Set-AzDoUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Set-AzDoUserEntitlement.ps1
@@ -1,0 +1,69 @@
+<#
+.SYNOPSIS
+Updates the access level of an existing Azure DevOps user entitlement.
+
+.DESCRIPTION
+Resolves the user by principal name and updates their account license type via the Member Entitlement
+Management API.
+
+.PARAMETER UserPrincipalName
+The user's principal name (email / UPN).
+
+.PARAMETER AccountLicenseType
+The desired account license type.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result from Get.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function Set-AzDoUserEntitlement
+{
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Alias('PrincipalName')]
+        [System.String]$UserPrincipalName,
+
+        [Parameter()]
+        [System.String]$AccountLicenseType,
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    Write-Verbose "[Set-AzDoUserEntitlement] Started."
+
+    $OrganizationName = (Get-AzDoOrganizationName)
+
+    # Prefer the id resolved by Get; fall back to a live lookup.
+    $userId = $LookupResult.userId
+    if (-not $userId)
+    {
+        $entitlement = Get-DevOpsUserEntitlement -Organization $OrganizationName -PrincipalName $UserPrincipalName
+        if ($null -eq $entitlement)
+        {
+            throw "[Set-AzDoUserEntitlement] User '$UserPrincipalName' not found; cannot update."
+        }
+        $userId = $entitlement.id
+    }
+
+    $params = @{
+        Organization       = $OrganizationName
+        UserId             = $userId
+        AccountLicenseType = $AccountLicenseType
+    }
+
+    $null = Update-DevOpsUserEntitlement @params
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Set-AzDoUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Set-AzDoUserEntitlement.ps1
@@ -54,7 +54,7 @@ function Set-AzDoUserEntitlement
         $entitlement = Get-DevOpsUserEntitlement -Organization $OrganizationName -PrincipalName $UserPrincipalName
         if ($null -eq $entitlement)
         {
-            throw "[Set-AzDoUserEntitlement] User '$UserPrincipalName' not found; cannot update."
+            throw "[Set-AzDoUserEntitlement] User not found; cannot update."
         }
         $userId = $entitlement.id
     }

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Test-AzDoUserEntitlement.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Test-AzDoUserEntitlement.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+Placeholder test function for the AzDoUserEntitlement resource.
+
+.DESCRIPTION
+Test() is implemented by the AzDevOpsDscResourceBase base class, which compares the desired state against
+the result of Get-AzDoUserEntitlement. This function exists only to satisfy the resource function naming
+convention and should not be invoked directly.
+
+.PARAMETER UserPrincipalName
+The user's principal name (email / UPN).
+
+.PARAMETER AccountLicenseType
+The account license type.
+
+.PARAMETER LookupResult
+A hashtable containing the lookup result.
+
+.PARAMETER Ensure
+Specifies the desired state.
+
+.PARAMETER Force
+Forces the operation without prompting for confirmation.
+#>
+function Test-AzDoUserEntitlement
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [Alias('PrincipalName')]
+        [System.String]$UserPrincipalName,
+
+        [Parameter()]
+        [System.String]$AccountLicenseType,
+
+        [Parameter()]
+        [HashTable]$LookupResult,
+
+        [Parameter()]
+        [Ensure]$Ensure,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]$Force
+    )
+
+    # Should not be triggered. This is a placeholder for the test function.
+}

--- a/tests/Integration/Resources/AzDoPipelineSettings.tests.ps1
+++ b/tests/Integration/Resources/AzDoPipelineSettings.tests.ps1
@@ -9,10 +9,12 @@ Describe "AzDoPipelineSettings Integration Tests" -Tag "Integration", "PipelineS
         $parameters = @{
             Name       = 'AzDoPipelineSettings'
             ModuleName = 'AzureDevOpsDsc'
+            # PublishPipelineMetadata defaults off and is freely settable at the project level (it is not
+            # org-enforced, unlike e.g. EnforceJobAuthScope which an org policy may pin on), so it can be
+            # toggled both ways and reliably converge.
             property   = @{
-                ProjectName            = $PROJECTNAME
-                EnforceJobAuthScope    = 'true'
-                StatusBadgesArePrivate = 'true'
+                ProjectName             = $PROJECTNAME
+                PublishPipelineMetadata = 'true'
             }
         }
     }
@@ -37,7 +39,7 @@ Describe "AzDoPipelineSettings Integration Tests" -Tag "Integration", "PipelineS
 
         BeforeAll {
             $parameters.Method = 'Set'
-            $parameters.property.EnforceJobAuthScope = 'false'
+            $parameters.property.PublishPipelineMetadata = 'false'
         }
 
         It "Should not throw any exceptions" {

--- a/tests/Integration/Resources/AzDoPipelineSettings.tests.ps1
+++ b/tests/Integration/Resources/AzDoPipelineSettings.tests.ps1
@@ -1,0 +1,54 @@
+Describe "AzDoPipelineSettings Integration Tests" -Tag "Integration", "PipelineSettings" {
+
+    BeforeAll {
+
+        $PROJECTNAME = 'TEST_PIPELINE_SETTINGS'
+
+        New-TestProject -ProjectName $PROJECTNAME
+
+        $parameters = @{
+            Name       = 'AzDoPipelineSettings'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                ProjectName            = $PROJECTNAME
+                EnforceJobAuthScope    = $true
+                StatusBadgesArePrivate = $true
+            }
+        }
+    }
+
+    Context "Applying pipeline settings" {
+
+        BeforeAll { $parameters.Method = 'Set' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after applying" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Changing a pipeline setting" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property.EnforceJobAuthScope = $false
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after the change" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+}

--- a/tests/Integration/Resources/AzDoPipelineSettings.tests.ps1
+++ b/tests/Integration/Resources/AzDoPipelineSettings.tests.ps1
@@ -11,8 +11,8 @@ Describe "AzDoPipelineSettings Integration Tests" -Tag "Integration", "PipelineS
             ModuleName = 'AzureDevOpsDsc'
             property   = @{
                 ProjectName            = $PROJECTNAME
-                EnforceJobAuthScope    = $true
-                StatusBadgesArePrivate = $true
+                EnforceJobAuthScope    = 'true'
+                StatusBadgesArePrivate = 'true'
             }
         }
     }
@@ -37,7 +37,7 @@ Describe "AzDoPipelineSettings Integration Tests" -Tag "Integration", "PipelineS
 
         BeforeAll {
             $parameters.Method = 'Set'
-            $parameters.property.EnforceJobAuthScope = $false
+            $parameters.property.EnforceJobAuthScope = 'false'
         }
 
         It "Should not throw any exceptions" {

--- a/tests/Integration/Resources/AzDoServiceHook.tests.ps1
+++ b/tests/Integration/Resources/AzDoServiceHook.tests.ps1
@@ -1,0 +1,96 @@
+Describe "AzDoServiceHook Integration Tests" -Tag "Integration", "ServiceHook" {
+
+    BeforeAll {
+
+        $PROJECTNAME = 'TEST_SERVICE_HOOK'
+
+        # Unique URL per run so a leftover subscription from a failed prior run does not collide
+        # (subscriptions are matched by publisher/event/consumer + url).
+        $HOOKURL = "https://example.com/azdodsc-hook-$(Get-Random -Maximum 99999)"
+
+        New-TestProject -ProjectName $PROJECTNAME
+
+        $parameters = @{
+            Name       = 'AzDoServiceHook'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                Name             = 'it-push-hook'
+                ProjectName      = $PROJECTNAME
+                PublisherId      = 'tfs'
+                EventType        = 'git.push'
+                ConsumerId       = 'webHooks'
+                ConsumerActionId = 'httpRequest'
+                ConsumerInputs   = @{ url = $HOOKURL }
+            }
+        }
+    }
+
+    Context "Testing if the subscription exists" {
+
+        BeforeAll { $parameters.Method = 'Test' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return False (subscription not yet created)" {
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeFalse
+        }
+    }
+
+    Context "Creating the subscription" {
+
+        BeforeAll { $parameters.Method = 'Set' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after creation" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Updating a non-identity consumer input (httpHeaders)" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            # url is the identity discriminator; change a non-identity input so the same subscription
+            # is matched and reconciled rather than a new one created.
+            $parameters.property.ConsumerInputs = @{ url = $HOOKURL; httpHeaders = 'X-Env:prod' }
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after the update" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Removing the subscription" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property.Ensure = 'Absent'
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after removal" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+}

--- a/tests/Integration/Resources/AzDoServiceHook.tests.ps1
+++ b/tests/Integration/Resources/AzDoServiceHook.tests.ps1
@@ -4,9 +4,17 @@ Describe "AzDoServiceHook Integration Tests" -Tag "Integration", "ServiceHook" {
 
         $PROJECTNAME = 'TEST_SERVICE_HOOK'
 
-        # Unique URL per run so a leftover subscription from a failed prior run does not collide
-        # (subscriptions are matched by publisher/event/consumer + url).
-        $HOOKURL = "https://example.com/azdodsc-hook-$(Get-Random -Maximum 99999)"
+        # The webhook URL can be supplied via the AZDODSC_TEST_HOOK_URL environment variable (set it as a
+        # secret/masked CI variable) so an internal/real endpoint is never committed to this public repo.
+        # When it is not set, fall back to a reserved, non-routable example.com URL with a unique suffix
+        # per run so a leftover subscription from a failed prior run does not collide (subscriptions are
+        # matched by publisher/event/consumer + url). Azure DevOps does not call the URL at create time,
+        # so the default is sufficient to exercise the full lifecycle.
+        $HOOKURL = if (-not [string]::IsNullOrWhiteSpace($env:AZDODSC_TEST_HOOK_URL)) {
+            $env:AZDODSC_TEST_HOOK_URL
+        } else {
+            "https://example.com/azdodsc-hook-$(Get-Random -Maximum 99999)"
+        }
 
         New-TestProject -ProjectName $PROJECTNAME
 

--- a/tests/Integration/Resources/AzDoUserEntitlement.tests.ps1
+++ b/tests/Integration/Resources/AzDoUserEntitlement.tests.ps1
@@ -1,9 +1,14 @@
 # Adding a user entitlement requires a REAL invitable AAD identity and consumes a license, so there is
-# no safe throwaway user to create/destroy in the shared test organization. These tests therefore only
-# run when the AZDODSC_TEST_USER_UPN environment variable is set to a principal name (email/UPN) that is
-# safe to add to and remove from the organization. When it is not set the tests are skipped.
+# no safe throwaway user to create/destroy in the shared test organization. The principal name is also
+# PII, and this is a public repository — so it is NEVER hard-coded here. It is supplied at run time via
+# the AZDODSC_TEST_USER_UPN environment variable (set it as a SECRET / masked pipeline variable in CI so
+# the value is redacted from logs). When it is not set the tests are skipped.
 #
-#   $env:AZDODSC_TEST_USER_UPN = 'testuser@yourtenant.onmicrosoft.com'
+#   # locally:
+#   $env:AZDODSC_TEST_USER_UPN = '<disposable-test-account-upn>'
+#
+# The resource code and these tests are written so the principal name is never written to output (no
+# Write-Host/verbose/exception includes it), so it cannot leak into the test transcript or results XML.
 
 $TEST_USER = $env:AZDODSC_TEST_USER_UPN
 $skipUserEntitlement = [string]::IsNullOrWhiteSpace($TEST_USER)

--- a/tests/Integration/Resources/AzDoUserEntitlement.tests.ps1
+++ b/tests/Integration/Resources/AzDoUserEntitlement.tests.ps1
@@ -1,0 +1,75 @@
+# Adding a user entitlement requires a REAL invitable AAD identity and consumes a license, so there is
+# no safe throwaway user to create/destroy in the shared test organization. These tests therefore only
+# run when the AZDODSC_TEST_USER_UPN environment variable is set to a principal name (email/UPN) that is
+# safe to add to and remove from the organization. When it is not set the tests are skipped.
+#
+#   $env:AZDODSC_TEST_USER_UPN = 'testuser@yourtenant.onmicrosoft.com'
+
+$TEST_USER = $env:AZDODSC_TEST_USER_UPN
+$skipUserEntitlement = [string]::IsNullOrWhiteSpace($TEST_USER)
+
+Describe "AzDoUserEntitlement Integration Tests" -Tag "Integration", "UserEntitlement" {
+
+    BeforeAll {
+        $TEST_USER = $env:AZDODSC_TEST_USER_UPN
+
+        $parameters = @{
+            Name       = 'AzDoUserEntitlement'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                UserPrincipalName  = $TEST_USER
+                AccountLicenseType = 'stakeholder'
+            }
+        }
+    }
+
+    Context "Adding the user" {
+
+        It "Should not throw when adding the user" -Skip:$skipUserEntitlement {
+            $parameters.Method = 'Set'
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after adding" -Skip:$skipUserEntitlement {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Changing the access level" {
+
+        It "Should not throw when changing the license" -Skip:$skipUserEntitlement {
+            $parameters.Method = 'Set'
+            $parameters.property.AccountLicenseType = 'express'
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after the change" -Skip:$skipUserEntitlement {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Removing the user" {
+
+        It "Should not throw when removing the user" -Skip:$skipUserEntitlement {
+            $parameters.Method = 'Set'
+            $parameters.property = @{
+                UserPrincipalName  = $TEST_USER
+                AccountLicenseType = 'stakeholder'
+                Ensure             = 'Absent'
+            }
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after removal" -Skip:$skipUserEntitlement {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/PipelineSettings/Get-DevOpsPipelineSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/PipelineSettings/Get-DevOpsPipelineSettings.tests.ps1
@@ -1,0 +1,33 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Get-DevOpsPipelineSettings' -Tag "Unit", "PipelineSettings", "API" {
+
+    BeforeAll {
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-DevOpsPipelineSettings.tests.ps1'
+        }
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+    }
+
+    Context 'when settings exist' {
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return @{ enforceJobAuthScope = $true } }
+        }
+        It 'GETs the build/generalsettings endpoint' {
+            $result = Get-DevOpsPipelineSettings -Organization 'myorg' -ProjectName 'MyProject'
+            $result.enforceJobAuthScope | Should -BeTrue
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+                $ApiUri -like '*/MyProject/_apis/build/generalsettings*' -and $Method -eq 'Get'
+            }
+        }
+    }
+
+    Context 'when the API call fails' {
+        BeforeEach { Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'boom' } }
+        It 'returns null instead of throwing' {
+            $result = Get-DevOpsPipelineSettings -Organization 'myorg' -ProjectName 'MyProject'
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/PipelineSettings/Set-DevOpsPipelineSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/PipelineSettings/Set-DevOpsPipelineSettings.tests.ps1
@@ -1,0 +1,33 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Set-DevOpsPipelineSettings' -Tag "Unit", "PipelineSettings", "API" {
+
+    BeforeAll {
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Set-DevOpsPipelineSettings.tests.ps1'
+        }
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return @{ enforceJobAuthScope = $true } }
+    }
+
+    It 'PATCHes the build/generalsettings endpoint' {
+        Set-DevOpsPipelineSettings -Organization 'myorg' -ProjectName 'MyProject' -Settings @{ enforceJobAuthScope = $true }
+        Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+            $ApiUri -like '*/MyProject/_apis/build/generalsettings*' -and $Method -eq 'PATCH'
+        }
+    }
+
+    It 'does nothing when no settings are supplied' {
+        Set-DevOpsPipelineSettings -Organization 'myorg' -ProjectName 'MyProject' -Settings @{}
+        Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 0
+    }
+
+    Context 'when the API call fails' {
+        BeforeEach { Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'boom' } }
+        It 'throws a wrapped error' {
+            { Set-DevOpsPipelineSettings -Organization 'myorg' -ProjectName 'MyProject' -Settings @{ enforceJobAuthScope = $true } } | Should -Throw '*Failed to update pipeline settings*'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/ConvertTo-DevOpsServiceHookSubscription.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/ConvertTo-DevOpsServiceHookSubscription.tests.ps1
@@ -1,0 +1,34 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'ConvertTo-DevOpsServiceHookSubscription' -Tag "Unit", "ServiceHook", "API" {
+
+    BeforeAll {
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'ConvertTo-DevOpsServiceHookSubscription.tests.ps1'
+        }
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        # Get-CacheItem's signature references the [CacheItem] class; load it so the mock can bind.
+        . (Get-ClassFilePath '000.CacheItem')
+    }
+
+    It 'builds a subscription body from the supplied inputs' {
+        $sub = ConvertTo-DevOpsServiceHookSubscription -OrganizationName 'myorg' -PublisherId 'tfs' -EventType 'git.push' -ConsumerId 'webHooks' -ConsumerActionId 'httpRequest' -ConsumerInputs @{ url = 'https://ci' }
+        $sub.publisherId | Should -Be 'tfs'
+        $sub.eventType | Should -Be 'git.push'
+        $sub.consumerInputs.url | Should -Be 'https://ci'
+    }
+
+    Context 'when a ProjectName is supplied' {
+
+        BeforeEach {
+            Mock -CommandName Get-CacheItem -MockWith { return @{ id = 'proj-id' } }
+        }
+
+        It 'resolves the project id into the publisher inputs' {
+            $sub = ConvertTo-DevOpsServiceHookSubscription -OrganizationName 'myorg' -PublisherId 'tfs' -EventType 'git.push' -ConsumerId 'webHooks' -ConsumerActionId 'httpRequest' -ProjectName 'MyProject'
+            $sub.publisherInputs.projectId | Should -Be 'proj-id'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/List-DevOpsServiceHookSubscription.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/List-DevOpsServiceHookSubscription.tests.ps1
@@ -1,0 +1,35 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'List-DevOpsServiceHookSubscription' -Tag "Unit", "ServiceHook", "API" {
+
+    BeforeAll {
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'List-DevOpsServiceHookSubscription.tests.ps1'
+        }
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+    }
+
+    Context 'when subscriptions exist' {
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return @{ value = @(@{ id = 's1' }, @{ id = 's2' }) } }
+        }
+        It 'GETs the hooks/subscriptions endpoint and returns the value array' {
+            $result = List-DevOpsServiceHookSubscription -Organization 'myorg'
+            $result.Count | Should -Be 2
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+                $ApiUri -like '*/_apis/hooks/subscriptions*' -and $Method -eq 'Get'
+            }
+        }
+    }
+
+    Context 'when no subscriptions exist' {
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return @{ value = $null } }
+        }
+        It 'returns an empty array' {
+            $result = List-DevOpsServiceHookSubscription -Organization 'myorg'
+            @($result).Count | Should -Be 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/New-DevOpsServiceHookSubscription.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/New-DevOpsServiceHookSubscription.tests.ps1
@@ -1,0 +1,28 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'New-DevOpsServiceHookSubscription' -Tag "Unit", "ServiceHook", "API" {
+
+    BeforeAll {
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'New-DevOpsServiceHookSubscription.tests.ps1'
+        }
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return @{ id = 'new-sub' } }
+    }
+
+    It 'POSTs to the hooks/subscriptions endpoint' {
+        New-DevOpsServiceHookSubscription -Organization 'myorg' -Subscription @{ eventType = 'git.push' }
+        Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+            $ApiUri -like '*/_apis/hooks/subscriptions*' -and $Method -eq 'POST'
+        }
+    }
+
+    Context 'when the API call fails' {
+        BeforeEach { Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'boom' } }
+        It 'throws a wrapped error' {
+            { New-DevOpsServiceHookSubscription -Organization 'myorg' -Subscription @{ eventType = 'git.push' } } | Should -Throw '*Failed to create subscription*'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Remove-DevOpsServiceHookSubscription.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Remove-DevOpsServiceHookSubscription.tests.ps1
@@ -1,0 +1,28 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Remove-DevOpsServiceHookSubscription' -Tag "Unit", "ServiceHook", "API" {
+
+    BeforeAll {
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Remove-DevOpsServiceHookSubscription.tests.ps1'
+        }
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return $null }
+    }
+
+    It 'DELETEs the hooks/subscriptions/{id} endpoint' {
+        Remove-DevOpsServiceHookSubscription -Organization 'myorg' -SubscriptionId 'sid'
+        Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+            $ApiUri -like '*/_apis/hooks/subscriptions/sid*' -and $Method -eq 'DELETE'
+        }
+    }
+
+    Context 'when the API call fails' {
+        BeforeEach { Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'boom' } }
+        It 'throws a wrapped error' {
+            { Remove-DevOpsServiceHookSubscription -Organization 'myorg' -SubscriptionId 'sid' } | Should -Throw '*Failed to remove subscription*'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Resolve-DevOpsServiceHookSubscription.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Resolve-DevOpsServiceHookSubscription.tests.ps1
@@ -1,0 +1,29 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Resolve-DevOpsServiceHookSubscription' -Tag "Unit", "ServiceHook", "API" {
+
+    BeforeAll {
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Resolve-DevOpsServiceHookSubscription.tests.ps1'
+        }
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName List-DevOpsServiceHookSubscription -MockWith {
+            return @(
+                @{ id = 's1'; publisherId = 'tfs'; eventType = 'git.push'; consumerId = 'webHooks'; consumerActionId = 'httpRequest'; consumerInputs = @{ url = 'https://a' } }
+                @{ id = 's2'; publisherId = 'tfs'; eventType = 'git.push'; consumerId = 'webHooks'; consumerActionId = 'httpRequest'; consumerInputs = @{ url = 'https://b' } }
+            )
+        }
+    }
+
+    It 'matches on the tuple plus the consumer url' {
+        $result = Resolve-DevOpsServiceHookSubscription -Organization 'myorg' -PublisherId 'tfs' -EventType 'git.push' -ConsumerId 'webHooks' -ConsumerActionId 'httpRequest' -ConsumerInputs @{ url = 'https://b' }
+        $result.id | Should -Be 's2'
+    }
+
+    It 'returns null when nothing matches' {
+        $result = Resolve-DevOpsServiceHookSubscription -Organization 'myorg' -PublisherId 'tfs' -EventType 'build.complete' -ConsumerId 'webHooks' -ConsumerActionId 'httpRequest' -ConsumerInputs @{ url = 'https://a' }
+        $result | Should -BeNullOrEmpty
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Update-DevOpsServiceHookSubscription.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ServiceHook/Update-DevOpsServiceHookSubscription.tests.ps1
@@ -1,0 +1,28 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Update-DevOpsServiceHookSubscription' -Tag "Unit", "ServiceHook", "API" {
+
+    BeforeAll {
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Update-DevOpsServiceHookSubscription.tests.ps1'
+        }
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return @{ id = 'sub' } }
+    }
+
+    It 'PUTs to the hooks/subscriptions/{id} endpoint' {
+        Update-DevOpsServiceHookSubscription -Organization 'myorg' -SubscriptionId 'sid' -Subscription @{ eventType = 'git.push' }
+        Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+            $ApiUri -like '*/_apis/hooks/subscriptions/sid*' -and $Method -eq 'PUT'
+        }
+    }
+
+    Context 'when the API call fails' {
+        BeforeEach { Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'boom' } }
+        It 'throws a wrapped error' {
+            { Update-DevOpsServiceHookSubscription -Organization 'myorg' -SubscriptionId 'sid' -Subscription @{ eventType = 'git.push' } } | Should -Throw '*Failed to update subscription*'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Get-DevOpsUserEntitlement.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Get-DevOpsUserEntitlement.tests.ps1
@@ -1,0 +1,58 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Get-DevOpsUserEntitlement' -Tag "Unit", "UserEntitlement", "API" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-DevOpsUserEntitlement.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+    }
+
+    Context 'when a matching user is returned' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith {
+                return @{ members = @(
+                    @{ id = 'id-1'; user = @{ principalName = 'jane@contoso.com'; mailAddress = 'jane@contoso.com' }; accessLevel = @{ accountLicenseType = 'express' } }
+                    @{ id = 'id-2'; user = @{ principalName = 'bob@contoso.com'; mailAddress = 'bob@contoso.com' }; accessLevel = @{ accountLicenseType = 'stakeholder' } }
+                ) }
+            }
+        }
+
+        It 'queries the search endpoint and returns the matching entitlement' {
+            $result = Get-DevOpsUserEntitlement -Organization 'myorg' -PrincipalName 'jane@contoso.com'
+            $result.id | Should -Be 'id-1'
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+                $ApiUri -like '*vsaex.dev.azure.com/myorg/_apis/userentitlements*' -and $Method -eq 'Get'
+            }
+        }
+    }
+
+    Context 'when no user matches' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return @{ members = @() } }
+        }
+
+        It 'returns null' {
+            $result = Get-DevOpsUserEntitlement -Organization 'myorg' -PrincipalName 'missing@contoso.com'
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'when the API call fails' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'boom' }
+        }
+
+        It 'returns null instead of throwing' {
+            $result = Get-DevOpsUserEntitlement -Organization 'myorg' -PrincipalName 'jane@contoso.com'
+            $result | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/New-DevOpsUserEntitlement.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/New-DevOpsUserEntitlement.tests.ps1
@@ -1,0 +1,52 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'New-DevOpsUserEntitlement' -Tag "Unit", "UserEntitlement", "API" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'New-DevOpsUserEntitlement.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith {
+            return @{ operationResult = @{ isSuccess = $true; errors = @() }; isSuccess = $true }
+        }
+    }
+
+    Context 'when the user is added successfully' {
+
+        It 'POSTs to the vsaex userentitlements endpoint' {
+            New-DevOpsUserEntitlement -Organization 'myorg' -PrincipalName 'jane@contoso.com' -AccountLicenseType 'express'
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+                $ApiUri -like '*vsaex.dev.azure.com/myorg/_apis/userentitlements*' -and $Method -eq 'POST'
+            }
+        }
+    }
+
+    Context 'when the operation result reports failure' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith {
+                return @{ operationResult = @{ isSuccess = $false; errors = @(@{ value = 'license unavailable' }) } }
+            }
+        }
+
+        It 'throws' {
+            { New-DevOpsUserEntitlement -Organization 'myorg' -PrincipalName 'jane@contoso.com' -AccountLicenseType 'express' } | Should -Throw '*license unavailable*'
+        }
+    }
+
+    Context 'when the API call fails' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'API call failed' }
+        }
+
+        It 'throws a wrapped error' {
+            { New-DevOpsUserEntitlement -Organization 'myorg' -PrincipalName 'jane@contoso.com' -AccountLicenseType 'express' } | Should -Throw '*Failed to add user*'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Remove-DevOpsUserEntitlement.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Remove-DevOpsUserEntitlement.tests.ps1
@@ -1,0 +1,37 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Remove-DevOpsUserEntitlement' -Tag "Unit", "UserEntitlement", "API" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Remove-DevOpsUserEntitlement.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return $null }
+    }
+
+    Context 'when called' {
+
+        It 'DELETEs the userentitlements/{id} endpoint' {
+            Remove-DevOpsUserEntitlement -Organization 'myorg' -UserId 'uid'
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+                $ApiUri -like '*vsaex.dev.azure.com/myorg/_apis/userentitlements/uid*' -and $Method -eq 'DELETE'
+            }
+        }
+    }
+
+    Context 'when the API call fails' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'boom' }
+        }
+
+        It 'throws a wrapped error' {
+            { Remove-DevOpsUserEntitlement -Organization 'myorg' -UserId 'uid' } | Should -Throw '*Failed to remove user*'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Update-DevOpsUserEntitlement.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/UserEntitlement/Update-DevOpsUserEntitlement.tests.ps1
@@ -1,0 +1,37 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Update-DevOpsUserEntitlement' -Tag "Unit", "UserEntitlement", "API" {
+
+    BeforeAll {
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Update-DevOpsUserEntitlement.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { return @{ isSuccess = $true } }
+    }
+
+    Context 'when called' {
+
+        It 'PATCHes the userentitlements/{id} endpoint' {
+            Update-DevOpsUserEntitlement -Organization 'myorg' -UserId 'uid' -AccountLicenseType 'advanced'
+            Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+                $ApiUri -like '*vsaex.dev.azure.com/myorg/_apis/userentitlements/uid*' -and $Method -eq 'PATCH'
+            }
+        }
+    }
+
+    Context 'when the API call fails' {
+
+        BeforeEach {
+            Mock -CommandName Invoke-AzDevOpsApiRestMethod -MockWith { throw 'boom' }
+        }
+
+        It 'throws a wrapped error' {
+            { Update-DevOpsUserEntitlement -Organization 'myorg' -UserId 'uid' -AccountLicenseType 'advanced' } | Should -Throw '*Failed to update user*'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Get-AzDoPipelineSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Get-AzDoPipelineSettings.tests.ps1
@@ -1,0 +1,57 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Get-AzDoPipelineSettings' -Tag "Unit", "PipelineSettings" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-AzDoPipelineSettings.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Get-DevOpsPipelineSettings -MockWith {
+            return @{ enforceJobAuthScope = $true; statusBadgesArePrivate = $false; enforceSettableVar = $true }
+        }
+    }
+
+    It 'returns Unchanged when a specified setting matches live state' {
+        $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope $true
+        $result.status | Should -Be 'Unchanged'
+    }
+
+    It 'returns Changed when a specified setting differs from live state' {
+        $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -StatusBadgesArePrivate $true
+        $result.status | Should -Be 'Changed'
+        $result.propertiesChanged | Should -Contain 'StatusBadgesArePrivate'
+    }
+
+    It 'ignores settings that were not specified' {
+        $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope $true
+        $result.propertiesChanged | Should -Not -Contain 'StatusBadgesArePrivate'
+    }
+
+    Context 'when the settings cannot be retrieved' {
+
+        BeforeEach { Mock -CommandName Get-DevOpsPipelineSettings -MockWith { return $null } }
+
+        It 'returns status Error' {
+            $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope $true
+            $result.status | Should -Be 'Error'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Get-AzDoPipelineSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Get-AzDoPipelineSettings.tests.ps1
@@ -29,19 +29,19 @@ Describe 'Get-AzDoPipelineSettings' -Tag "Unit", "PipelineSettings" {
         }
     }
 
-    It 'returns Unchanged when a specified setting matches live state' {
-        $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope $true
+    It 'returns Unchanged when a managed setting matches live state' {
+        $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope 'true'
         $result.status | Should -Be 'Unchanged'
     }
 
-    It 'returns Changed when a specified setting differs from live state' {
-        $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -StatusBadgesArePrivate $true
+    It 'returns Changed when a managed setting differs from live state' {
+        $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -StatusBadgesArePrivate 'true'
         $result.status | Should -Be 'Changed'
         $result.propertiesChanged | Should -Contain 'StatusBadgesArePrivate'
     }
 
-    It 'ignores settings that were not specified' {
-        $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope $true
+    It 'ignores unmanaged settings (empty string)' {
+        $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope 'true' -StatusBadgesArePrivate ''
         $result.propertiesChanged | Should -Not -Contain 'StatusBadgesArePrivate'
     }
 
@@ -50,7 +50,7 @@ Describe 'Get-AzDoPipelineSettings' -Tag "Unit", "PipelineSettings" {
         BeforeEach { Mock -CommandName Get-DevOpsPipelineSettings -MockWith { return $null } }
 
         It 'returns status Error' {
-            $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope $true
+            $result = Get-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope 'true'
             $result.status | Should -Be 'Error'
         }
     }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Set-AzDoPipelineSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Set-AzDoPipelineSettings.tests.ps1
@@ -27,16 +27,16 @@ Describe 'Set-AzDoPipelineSettings' -Tag "Unit", "PipelineSettings" {
         Mock -CommandName Set-DevOpsPipelineSettings
     }
 
-    It 'sends only the specified settings (mapped to API names)' {
-        Set-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope $true -StatusBadgesArePrivate $true
+    It 'sends only the managed settings (mapped to API names, as booleans)' {
+        Set-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope 'true' -StatusBadgesArePrivate 'false'
         Assert-MockCalled -CommandName Set-DevOpsPipelineSettings -Times 1 -ParameterFilter {
-            $Settings.ContainsKey('enforceJobAuthScope') -and
-            $Settings.ContainsKey('statusBadgesArePrivate') -and
+            ($Settings['enforceJobAuthScope'] -eq $true) -and
+            ($Settings['statusBadgesArePrivate'] -eq $false) -and
             (-not $Settings.ContainsKey('enforceSettableVar'))
         }
     }
 
-    It 'does not call the API when no settings are specified' {
+    It 'does not call the API when no settings are managed' {
         Set-AzDoPipelineSettings -ProjectName 'MyProject'
         Assert-MockCalled -CommandName Set-DevOpsPipelineSettings -Times 0
     }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Set-AzDoPipelineSettings.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Set-AzDoPipelineSettings.tests.ps1
@@ -1,0 +1,43 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Set-AzDoPipelineSettings' -Tag "Unit", "PipelineSettings" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Set-AzDoPipelineSettings.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Set-DevOpsPipelineSettings
+    }
+
+    It 'sends only the specified settings (mapped to API names)' {
+        Set-AzDoPipelineSettings -ProjectName 'MyProject' -EnforceJobAuthScope $true -StatusBadgesArePrivate $true
+        Assert-MockCalled -CommandName Set-DevOpsPipelineSettings -Times 1 -ParameterFilter {
+            $Settings.ContainsKey('enforceJobAuthScope') -and
+            $Settings.ContainsKey('statusBadgesArePrivate') -and
+            (-not $Settings.ContainsKey('enforceSettableVar'))
+        }
+    }
+
+    It 'does not call the API when no settings are specified' {
+        Set-AzDoPipelineSettings -ProjectName 'MyProject'
+        Assert-MockCalled -CommandName Set-DevOpsPipelineSettings -Times 0
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Get-AzDoServiceHook.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Get-AzDoServiceHook.tests.ps1
@@ -1,0 +1,71 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Get-AzDoServiceHook' -Tag "Unit", "ServiceHook" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-AzDoServiceHook.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+
+        $script:commonParams = @{
+            Name             = 'hook1'
+            PublisherId      = 'tfs'
+            EventType        = 'git.push'
+            ConsumerId       = 'webHooks'
+            ConsumerActionId = 'httpRequest'
+            ConsumerInputs   = @{ url = 'https://ci/hook' }
+        }
+    }
+
+    Context 'when a matching subscription exists' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsServiceHookSubscription -MockWith {
+                return @{ id = 'sub-id'; consumerInputs = @{ url = 'https://ci/hook' }; publisherInputs = @{ projectId = 'p1' } }
+            }
+        }
+
+        It 'returns Unchanged when inputs match' {
+            $result = Get-AzDoServiceHook @commonParams
+            $result.status | Should -Be 'Unchanged'
+            $result.subscriptionId | Should -Be 'sub-id'
+        }
+
+        It 'returns Changed when a consumer input differs' {
+            $p = $commonParams.Clone(); $p.ConsumerInputs = @{ url = 'https://ci/other' }
+            $result = Get-AzDoServiceHook @p
+            $result.status | Should -Be 'Changed'
+            $result.propertiesChanged | Should -Contain 'consumerInputs.url'
+        }
+    }
+
+    Context 'when no matching subscription exists' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsServiceHookSubscription -MockWith { return $null }
+        }
+
+        It 'returns status NotFound' {
+            $result = Get-AzDoServiceHook @commonParams
+            $result.status | Should -Be 'NotFound'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/New-AzDoServiceHook.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/New-AzDoServiceHook.tests.ps1
@@ -1,0 +1,36 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'New-AzDoServiceHook' -Tag "Unit", "ServiceHook" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'New-AzDoServiceHook.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName ConvertTo-DevOpsServiceHookSubscription -MockWith { return @{ publisherId = 'tfs' } }
+        Mock -CommandName New-DevOpsServiceHookSubscription
+    }
+
+    It 'builds the subscription body and creates it' {
+        New-AzDoServiceHook -Name 'hook1' -PublisherId 'tfs' -EventType 'git.push' -ConsumerId 'webHooks' -ConsumerActionId 'httpRequest' -ConsumerInputs @{ url = 'https://ci/hook' }
+        Assert-MockCalled -CommandName ConvertTo-DevOpsServiceHookSubscription -Times 1
+        Assert-MockCalled -CommandName New-DevOpsServiceHookSubscription -Times 1
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Remove-AzDoServiceHook.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Remove-AzDoServiceHook.tests.ps1
@@ -1,0 +1,55 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Remove-AzDoServiceHook' -Tag "Unit", "ServiceHook" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Remove-AzDoServiceHook.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Remove-DevOpsServiceHookSubscription
+
+        $script:commonParams = @{
+            Name             = 'hook1'
+            PublisherId      = 'tfs'
+            EventType        = 'git.push'
+            ConsumerId       = 'webHooks'
+            ConsumerActionId = 'httpRequest'
+            ConsumerInputs   = @{ url = 'https://ci/hook' }
+        }
+    }
+
+    It 'uses the id from LookupResult and removes the subscription' {
+        Remove-AzDoServiceHook @commonParams -LookupResult @{ subscriptionId = 'cached-id' }
+        Assert-MockCalled -CommandName Remove-DevOpsServiceHookSubscription -Times 1 -ParameterFilter { $SubscriptionId -eq 'cached-id' }
+    }
+
+    Context 'when the subscription does not exist' {
+
+        BeforeEach {
+            Mock -CommandName Resolve-DevOpsServiceHookSubscription -MockWith { return $null }
+        }
+
+        It 'is a no-op' {
+            Remove-AzDoServiceHook @commonParams
+            Assert-MockCalled -CommandName Remove-DevOpsServiceHookSubscription -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Set-AzDoServiceHook.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceHook/Set-AzDoServiceHook.tests.ps1
@@ -1,0 +1,58 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Set-AzDoServiceHook' -Tag "Unit", "ServiceHook" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Set-AzDoServiceHook.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName ConvertTo-DevOpsServiceHookSubscription -MockWith { return @{ publisherId = 'tfs' } }
+        Mock -CommandName Update-DevOpsServiceHookSubscription
+
+        $script:commonParams = @{
+            Name             = 'hook1'
+            PublisherId      = 'tfs'
+            EventType        = 'git.push'
+            ConsumerId       = 'webHooks'
+            ConsumerActionId = 'httpRequest'
+            ConsumerInputs   = @{ url = 'https://ci/hook' }
+        }
+    }
+
+    It 'uses the id from LookupResult and updates the subscription' {
+        Set-AzDoServiceHook @commonParams -LookupResult @{ subscriptionId = 'cached-id' }
+        Assert-MockCalled -CommandName Update-DevOpsServiceHookSubscription -Times 1 -ParameterFilter { $SubscriptionId -eq 'cached-id' }
+    }
+
+    Context 'when LookupResult has no id' {
+
+        It 'falls back to a live resolve' {
+            Mock -CommandName Resolve-DevOpsServiceHookSubscription -MockWith { return @{ id = 'live-id' } }
+            Set-AzDoServiceHook @commonParams
+            Assert-MockCalled -CommandName Update-DevOpsServiceHookSubscription -Times 1 -ParameterFilter { $SubscriptionId -eq 'live-id' }
+        }
+
+        It 'throws when the subscription cannot be resolved' {
+            Mock -CommandName Resolve-DevOpsServiceHookSubscription -MockWith { return $null }
+            { Set-AzDoServiceHook @commonParams } | Should -Throw
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Get-AzDoUserEntitlement.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Get-AzDoUserEntitlement.tests.ps1
@@ -1,0 +1,61 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Get-AzDoUserEntitlement' -Tag "Unit", "UserEntitlement" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Get-AzDoUserEntitlement.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+    }
+
+    Context 'when the user exists' {
+
+        BeforeEach {
+            Mock -CommandName Get-DevOpsUserEntitlement -MockWith {
+                return @{ id = 'user-id'; user = @{ principalName = 'jane@contoso.com' }; accessLevel = @{ accountLicenseType = 'express' } }
+            }
+        }
+
+        It 'returns Unchanged when the access level matches' {
+            $result = Get-AzDoUserEntitlement -UserPrincipalName 'jane@contoso.com' -AccountLicenseType 'express'
+            $result.status | Should -Be 'Unchanged'
+            $result.userId | Should -Be 'user-id'
+        }
+
+        It 'returns Changed when the access level differs' {
+            $result = Get-AzDoUserEntitlement -UserPrincipalName 'jane@contoso.com' -AccountLicenseType 'stakeholder'
+            $result.status | Should -Be 'Changed'
+            $result.propertiesChanged | Should -Contain 'AccountLicenseType'
+        }
+    }
+
+    Context 'when the user does not exist' {
+
+        BeforeEach {
+            Mock -CommandName Get-DevOpsUserEntitlement -MockWith { return $null }
+        }
+
+        It 'returns status NotFound' {
+            $result = Get-AzDoUserEntitlement -UserPrincipalName 'missing@contoso.com' -AccountLicenseType 'express'
+            $result.status | Should -Be 'NotFound'
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/New-AzDoUserEntitlement.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/New-AzDoUserEntitlement.tests.ps1
@@ -1,0 +1,40 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'New-AzDoUserEntitlement' -Tag "Unit", "UserEntitlement" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'New-AzDoUserEntitlement.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName New-DevOpsUserEntitlement
+    }
+
+    It 'calls New-DevOpsUserEntitlement with the principal name and license' {
+        New-AzDoUserEntitlement -UserPrincipalName 'jane@contoso.com' -AccountLicenseType 'express'
+        Assert-MockCalled -CommandName New-DevOpsUserEntitlement -Times 1 -ParameterFilter {
+            $PrincipalName -eq 'jane@contoso.com' -and $AccountLicenseType -eq 'express'
+        }
+    }
+
+    It 'throws when no AccountLicenseType is supplied' {
+        { New-AzDoUserEntitlement -UserPrincipalName 'jane@contoso.com' -AccountLicenseType '' } | Should -Throw
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Remove-AzDoUserEntitlement.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Remove-AzDoUserEntitlement.tests.ps1
@@ -1,0 +1,46 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Remove-AzDoUserEntitlement' -Tag "Unit", "UserEntitlement" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Remove-AzDoUserEntitlement.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Remove-DevOpsUserEntitlement
+    }
+
+    It 'uses the id from LookupResult and calls Remove-DevOpsUserEntitlement' {
+        Remove-AzDoUserEntitlement -UserPrincipalName 'jane@contoso.com' -LookupResult @{ userId = 'cached-id' }
+        Assert-MockCalled -CommandName Remove-DevOpsUserEntitlement -Times 1 -ParameterFilter { $UserId -eq 'cached-id' }
+    }
+
+    Context 'when the user does not exist' {
+
+        BeforeEach {
+            Mock -CommandName Get-DevOpsUserEntitlement -MockWith { return $null }
+        }
+
+        It 'is a no-op and does not call Remove-DevOpsUserEntitlement' {
+            Remove-AzDoUserEntitlement -UserPrincipalName 'missing@contoso.com'
+            Assert-MockCalled -CommandName Remove-DevOpsUserEntitlement -Times 0
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Set-AzDoUserEntitlement.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoUserEntitlement/Set-AzDoUserEntitlement.tests.ps1
@@ -1,0 +1,50 @@
+$currentFile = $MyInvocation.MyCommand.Path
+
+Describe 'Set-AzDoUserEntitlement' -Tag "Unit", "UserEntitlement" {
+
+    AfterAll {
+        Remove-Variable -Name DSCAZDO_OrganizationName -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    BeforeAll {
+
+        $Global:DSCAZDO_OrganizationName = 'TestOrganization'
+
+        if ($null -eq $currentFile) {
+            $currentFile = Join-Path -Path $PSScriptRoot -ChildPath 'Set-AzDoUserEntitlement.tests.ps1'
+        }
+
+        $files = Get-FunctionItem (Find-MockedFunctions -TestFilePath $currentFile)
+        ForEach ($file in $files) { . $file.FullName }
+
+        . (Get-ClassFilePath 'DSCGetSummaryState')
+        . (Get-ClassFilePath '000.CacheItem')
+        . (Get-ClassFilePath 'Ensure')
+        . (Get-FunctionItem 'Get-AzDoCacheObjects.ps1')
+
+        Mock -CommandName Write-Verbose
+        Mock -CommandName Get-AzDoOrganizationName -MockWith { return 'TestOrganization' }
+        Mock -CommandName Update-DevOpsUserEntitlement
+    }
+
+    It 'uses the id from LookupResult and calls Update-DevOpsUserEntitlement' {
+        Set-AzDoUserEntitlement -UserPrincipalName 'jane@contoso.com' -AccountLicenseType 'advanced' -LookupResult @{ userId = 'cached-id' }
+        Assert-MockCalled -CommandName Update-DevOpsUserEntitlement -Times 1 -ParameterFilter {
+            $UserId -eq 'cached-id' -and $AccountLicenseType -eq 'advanced'
+        }
+    }
+
+    Context 'when LookupResult has no id' {
+
+        It 'falls back to a live lookup' {
+            Mock -CommandName Get-DevOpsUserEntitlement -MockWith { return @{ id = 'live-id' } }
+            Set-AzDoUserEntitlement -UserPrincipalName 'jane@contoso.com' -AccountLicenseType 'advanced'
+            Assert-MockCalled -CommandName Update-DevOpsUserEntitlement -Times 1 -ParameterFilter { $UserId -eq 'live-id' }
+        }
+
+        It 'throws when the user cannot be resolved' {
+            Mock -CommandName Get-DevOpsUserEntitlement -MockWith { return $null }
+            { Set-AzDoUserEntitlement -UserPrincipalName 'missing@contoso.com' -AccountLicenseType 'advanced' } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds three new DSC resources, each with unit and integration tests and example docs:

- **`AzDoUserEntitlement`** — add/remove organization users and manage their access level (license).
- **`AzDoServiceHook`** — create/manage service hook subscriptions (e.g. webhooks).
- **`AzDoPipelineSettings`** — manage a project's pipeline general settings.

Base branch: `main`.

## AzDoUserEntitlement

Adds/removes org users and manages their access level via the Member Entitlement Management API (`vsaex.dev.azure.com/_apis/userentitlements`). Keys on `UserPrincipalName` (email/UPN); resolves users via the search endpoint and updates the license with a JSON-Patch.

```powershell
AzDoUserEntitlement JaneBasic {
    UserPrincipalName  = 'jane@contoso.com'
    AccountLicenseType = 'express'   # stakeholder | express(Basic) | advanced | professional | ...
    Ensure             = 'Present'
}
```

## AzDoServiceHook

Manages service hook subscriptions via `_apis/hooks/subscriptions`. Subscriptions are unnamed server-side, so `Name` is a logical DSC key and the live subscription is matched by its identity tuple (`publisherId` + `eventType` + `consumerId` + `consumerActionId` + consumer `url`). `ProjectName` resolves to a `projectId` publisher input.

```powershell
AzDoServiceHook NotifyOnPush {
    Name             = 'notify-ci-on-push'
    ProjectName      = 'MyProject'
    PublisherId      = 'tfs'
    EventType        = 'git.push'
    ConsumerId       = 'webHooks'
    ConsumerActionId = 'httpRequest'
    ConsumerInputs   = @{ url = 'https://ci.contoso.com/hook' }
    Ensure           = 'Present'
}
```

## AzDoPipelineSettings

Manages a project's pipeline general settings via `_apis/build/generalsettings`. Each setting is a **tri-state string** (`''` | `'true'` | `'false'`) where `''` means *unmanaged* — only settings set to `'true'`/`'false'` are compared and applied; omitted settings are left untouched. (A plain `[bool]` would be destructive here: the base class passes all properties to Set, so omitted settings would be driven to `$false`, including the ones that default to *true*.)

```powershell
AzDoPipelineSettings HardenPipelines {
    ProjectName                      = 'MyProject'
    EnforceJobAuthScope              = 'true'
    EnforceReferencedRepoScopedToken = 'true'
    StatusBadgesArePrivate           = 'true'
}
```

## Public-repo / PII handling

- No usernames or internal URLs are committed. Both sensitive test inputs are supplied **only at runtime** via environment variables (set them as **secret/masked CI variables**):
  - `AZDODSC_TEST_USER_UPN` — `AzDoUserEntitlement` integration test (skips when unset).
  - `AZDODSC_TEST_HOOK_URL` — `AzDoServiceHook` integration test (falls back to a reserved `example.com` URL when unset).
- The resource code **never emits** the principal name or webhook URL value in any throw/verbose/output, so neither can leak into a transcript, results XML or CI log.

## Testing

- **Unit:** 47 new tests (20 + 21 + 6), all passing.
- **Integration:** `AzDoServiceHook` (8/8) and `AzDoPipelineSettings` (4/4) verified green against a live org. `AzDoUserEntitlement` integration is opt-in (needs a real invitable identity + consumes a license), so its lifecycle is covered by unit tests and a skip-by-default integration test.
- Build succeeds with 0 errors/warnings; all three resources export from the manifest. README + CHANGELOG + example docs updated.

## Notes (bugs caught by the integration run, now fixed)

- `AzDoServiceHook`: PowerShell 7 mis-parses `"$ProjectName?api-version=..."` (the `?` is consumed) — fixed with `${ProjectName}`.
- `AzDoPipelineSettings`: returning the key from `GetDscResourcePropertyNamesWithNoSetSupport()` stripped it from Set params; and `[bool]` settings were non-convergent/destructive (now tri-state).

## Not included (deferred)

- `AzDoOrganizationPolicy` / `AzDoProjectPolicy` — no documented or reliably discoverable REST API (the Org Settings → Policies page uses internal contribution endpoints). Deferred until a stable API is confirmed.
- `AzDoSecureFile` — deferred (creating a secure file requires uploading binary content, which doesn't map cleanly to DSC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)