### PR TITLE
Fix AzDoArtifactFeed: support organization-scoped feeds (ProjectName optional)

### DIFF
--- a/source/Classes/077.AzDoArtifactFeed.ps1
+++ b/source/Classes/077.AzDoArtifactFeed.ps1
@@ -8,10 +8,11 @@
 class AzDoArtifactFeed : AzDevOpsDscResourceBase
 {
     [DscProperty(Key, Mandatory)]
-    [System.String]$ProjectName
-
-    [DscProperty(Mandatory)]
     [System.String]$FeedName
+
+    # Optional: when supplied the feed is project-scoped; when omitted the feed is organization-scoped.
+    [DscProperty()]
+    [System.String]$ProjectName
 
     [DscProperty()]
     [System.String]$Description

--- a/source/Examples/Resources/AzDoArtifactFeed.md
+++ b/source/Examples/Resources/AzDoArtifactFeed.md
@@ -5,8 +5,8 @@
 ```PowerShell
 AzDoArtifactFeed [string] #ResourceName
 {
-    ProjectName       = [String]$ProjectName
     FeedName          = [String]$FeedName
+    [ ProjectName     = [String]$ProjectName ]
     [ Description     = [String]$Description ]
     [ BadgesEnabled   = [Boolean]$BadgesEnabled ]
     [ UpstreamEnabled = [Boolean]$UpstreamEnabled ]
@@ -18,8 +18,8 @@ AzDoArtifactFeed [string] #ResourceName
 
 ### Common Properties
 
-- **ProjectName**: The name of the Azure DevOps project. This property is mandatory and serves as a key property for the resource.
-- **FeedName**: The name of the artifact feed. This is a key property.
+- **FeedName**: The name of the artifact feed. This property is mandatory and is the key property for the resource.
+- **ProjectName**: The name of the Azure DevOps project. **Optional** — when supplied, the feed is **project-scoped**; when omitted, the feed is **organization-scoped**.
 - **Description**: An optional description for the feed.
 - **BadgesEnabled**: Whether to enable badges for the feed. Defaults to `$false`.
 - **UpstreamEnabled**: Whether to enable upstream sources. Defaults to `$true`.
@@ -27,7 +27,7 @@ AzDoArtifactFeed [string] #ResourceName
 
 ## Additional Information
 
-This resource manages Azure Artifacts feeds within a project. Artifact feeds allow teams to share packages (NuGet, npm, Maven, Python, Universal Packages) across the organization.
+This resource manages Azure Artifacts feeds. A feed can be **project-scoped** (set `ProjectName`) or **organization-scoped** (omit `ProjectName`). Artifact feeds allow teams to share packages (NuGet, npm, Maven, Python, Universal Packages).
 
 ## Examples
 
@@ -45,6 +45,25 @@ Configuration ExampleConfig {
             Description     = 'My package feed'
             BadgesEnabled   = $false
             UpstreamEnabled = $true
+        }
+    }
+}
+
+Start-DscConfiguration -Path ./ExampleConfig -Wait -Verbose
+```
+
+## Example 1b: Organization-scoped feed (omit ProjectName)
+
+``` PowerShell
+Configuration ExampleConfig {
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    Node localhost {
+        AzDoArtifactFeed AddOrgFeed {
+            Ensure      = 'Present'
+            FeedName    = 'SharedOrgFeed'
+            Description = 'Organization-wide package feed'
+            # No ProjectName -> the feed is created at the organization scope.
         }
     }
 }

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Get-AzDoArtifactFeed.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Get-AzDoArtifactFeed.ps1
@@ -3,7 +3,7 @@ Function Get-AzDoArtifactFeed
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSObject[]])]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][string]$Description,
         [Parameter()][bool]$BadgesEnabled = $false,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/New-AzDoArtifactFeed.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/New-AzDoArtifactFeed.ps1
@@ -2,7 +2,7 @@ Function New-AzDoArtifactFeed
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][string]$Description,
         [Parameter()][bool]$BadgesEnabled = $false,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Remove-AzDoArtifactFeed.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Remove-AzDoArtifactFeed.ps1
@@ -2,7 +2,7 @@ Function Remove-AzDoArtifactFeed
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][string]$Description,
         [Parameter()][bool]$BadgesEnabled = $false,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Set-AzDoArtifactFeed.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Set-AzDoArtifactFeed.ps1
@@ -2,7 +2,7 @@ Function Set-AzDoArtifactFeed
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][string]$Description,
         [Parameter()][bool]$BadgesEnabled = $false,

--- a/tests/Integration/Resources/AzDoArtifactFeed.tests.ps1
+++ b/tests/Integration/Resources/AzDoArtifactFeed.tests.ps1
@@ -97,3 +97,74 @@ Describe "AzDoArtifactFeed Integration Tests" -Tag "Integration", "ArtifactFeed"
         }
     }
 }
+
+Describe "AzDoArtifactFeed Integration Tests - Organization scoped" -Tag "Integration", "ArtifactFeed" {
+
+    BeforeAll {
+
+        # Organization-scoped feed: no ProjectName is supplied. Unique name per run to avoid the
+        # post-deletion name-reservation cooldown.
+        $ORGFEEDNAME = "testorgfeed$(Get-Random -Maximum 99999)"
+
+        $parameters = @{
+            Name       = 'AzDoArtifactFeed'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                FeedName        = $ORGFEEDNAME
+                Description     = 'Org-scoped test artifact feed'
+                UpstreamEnabled = $false
+            }
+        }
+    }
+
+    Context "Testing if the organization feed exists" {
+
+        BeforeAll { $parameters.Method = 'Test' }
+
+        It "Should not throw any exceptions (ProjectName not required)" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return False (feed does not exist yet)" {
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeFalse
+        }
+    }
+
+    Context "Creating the organization feed" {
+
+        BeforeAll { $parameters.Method = 'Set' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after creation" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Removing the organization feed" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property = @{
+                FeedName = $ORGFEEDNAME
+                Ensure   = 'Absent'
+            }
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True (Absent is desired state)" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+}

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/New-DevOpsArtifactFeed.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/New-DevOpsArtifactFeed.tests.ps1
@@ -33,4 +33,21 @@ Describe 'New-DevOpsArtifactFeed' -Tag "Unit", "ArtifactFeed", "API" {
         { New-DevOpsArtifactFeed -ApiUri 'https://feeds.dev.azure.com/myorg' -FeedName 'TestFeed' } | Should -Throw
     }
 
+    It 'Targets the ORGANIZATION-scoped endpoint when no ProjectName is supplied' {
+        New-DevOpsArtifactFeed -ApiUri 'https://feeds.dev.azure.com/myorg' -FeedName 'OrgFeed'
+        Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and
+            $ApiUri -like 'https://feeds.dev.azure.com/myorg/_apis/packaging/feeds*' -and
+            $ApiUri -notlike '*MyProject*'
+        }
+    }
+
+    It 'Targets the PROJECT-scoped endpoint when ProjectName is supplied' {
+        New-DevOpsArtifactFeed -ApiUri 'https://feeds.dev.azure.com/myorg' -ProjectName 'MyProject' -FeedName 'ProjFeed'
+        Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and
+            $ApiUri -like 'https://feeds.dev.azure.com/myorg/MyProject/_apis/packaging/feeds*'
+        }
+    }
+
 }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/New-AzDoArtifactFeed.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/New-AzDoArtifactFeed.tests.ps1
@@ -101,4 +101,26 @@ Describe "New-AzDoArtifactFeed" -Tag "Unit", "ArtifactFeed" {
             }
         }
     }
+
+    Context "when creating an organization-scoped feed (no ProjectName)" {
+
+        It "creates the feed without requiring ProjectName" {
+            { New-AzDoArtifactFeed -FeedName 'OrgFeed' } | Should -Not -Throw
+            Assert-MockCalled -CommandName New-DevOpsArtifactFeed -Exactly -Times 1
+        }
+
+        It "does not pass a ProjectName through to New-DevOpsArtifactFeed" {
+            New-AzDoArtifactFeed -FeedName 'OrgFeed'
+            Assert-MockCalled -CommandName New-DevOpsArtifactFeed -Exactly -Times 1 -ParameterFilter {
+                [string]::IsNullOrEmpty($ProjectName) -and $FeedName -eq 'OrgFeed'
+            }
+        }
+
+        It "caches the org feed under a project-less key" {
+            New-AzDoArtifactFeed -FeedName 'OrgFeed'
+            Assert-MockCalled -CommandName Add-CacheItem -Exactly -Times 1 -ParameterFilter {
+                $Key -eq '\OrgFeed' -and $Type -eq 'LiveArtifactFeeds'
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`AzDoArtifactFeed` supports both **project-scoped** and **organization-scoped** feeds, but `ProjectName` was the resource's **mandatory key** — so organization-scoped feeds (which have no project) could not be created. This makes `ProjectName` optional and promotes `FeedName` to the key.

- Supply `ProjectName` → the feed is **project-scoped**.
- Omit `ProjectName` → the feed is **organization-scoped**.

```powershell
# Organization-scoped feed (previously impossible)
AzDoArtifactFeed AddOrgFeed {
    Ensure      = 'Present'
    FeedName    = 'SharedOrgFeed'
    Description = 'Organization-wide package feed'
    # No ProjectName -> created at the organization scope
}
```

## Root cause / fix

The entire API layer (`New`/`Set`/`Remove`/`List-DevOpsArtifactFeed`) already branched on `if ($ProjectName)` to choose the org vs project REST URL, so the bug was purely at the surface:

- **Class (`077.AzDoArtifactFeed.ps1`)** — `FeedName` is now `[DscProperty(Key, Mandatory)]`; `ProjectName` is now an optional `[DscProperty()]`.
- **Public functions (`Get`/`New`/`Set`/`Remove-AzDoArtifactFeed`)** — dropped `Mandatory` on `ProjectName`.
- No lower-layer (API helper) changes were needed.

## ⚠️ Breaking change

The resource's **key changes from `ProjectName` to `FeedName`**. Org-scoped feeds have no project (an empty value can't be a DSC key), and a feed is naturally identified by its name. Existing configurations relying on the old key identity should be reviewed.

## Testing

- **Unit: 42/42 ArtifactFeed tests pass** (37 existing + 5 new). New tests assert the API targets the **org** endpoint (`/{org}/_apis/packaging/feeds`, no project segment) when `ProjectName` is omitted and the **project** endpoint when supplied, plus public-layer tests that creation works with no `ProjectName` and caches under a project-less key.
- **Integration:** a new **organization-scoped** `Describe` (`Test → create → Test True → remove → Test True`, no `ProjectName`) passes **6/6** against a live org.
- Docs updated (`AzDoArtifactFeed.md`): `ProjectName` documented as optional, with an org-scoped example.

### Note on the project-scoped integration Describe
The pre-existing project-scoped `Describe` currently fails in `BeforeAll` because the **test organization has reached Azure DevOps's 1000-project limit** (`InvalidProjectCreateException`), so `New-TestProject` cannot provision a test project. This is an environment/capacity issue (accumulated leftover `TEST_*` projects), **unrelated to this change** — the project-scoped feed path is behaviourally unchanged, and the org-scoped run confirms the resource works. Cleaning up stale test projects will unblock it.

## Commits
- `Fix AzDoArtifactFeed: support organization-scoped feeds (ProjectName optional)`
- `Add organization-scoped integration tests for AzDoArtifactFeed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)