### PR TITLE
Fix AzDoProcessPermission/SecurityNamespacePermission/ArtifactFeed/PipelineSettings convergence bugs

### DIFF
--- a/source/Classes/077.AzDoArtifactFeed.ps1
+++ b/source/Classes/077.AzDoArtifactFeed.ps1
@@ -8,10 +8,11 @@
 class AzDoArtifactFeed : AzDevOpsDscResourceBase
 {
     [DscProperty(Key, Mandatory)]
-    [System.String]$ProjectName
-
-    [DscProperty(Mandatory)]
     [System.String]$FeedName
+
+    # Optional: when supplied the feed is project-scoped; when omitted the feed is organization-scoped.
+    [DscProperty()]
+    [System.String]$ProjectName
 
     [DscProperty()]
     [System.String]$Description

--- a/source/Classes/094.AzDoArtifactFeedSettings.ps1
+++ b/source/Classes/094.AzDoArtifactFeedSettings.ps1
@@ -12,7 +12,7 @@ class AzDoArtifactFeedSettings : AzDevOpsDscResourceBase
 {
     [DscProperty(Key, Mandatory)][System.String]$ProjectName
     [DscProperty(Mandatory)][System.String]$FeedName
-    [DscProperty()][System.String[]]$UpstreamSources
+    [DscProperty()][HashTable[]]$UpstreamSources
     [DscProperty()][System.Boolean]$HideDeletedPackageVersions = $true
 
     # Artifact lifecycle / retention policy. A 'RetentionCountLimit' of 0 means retention is not managed.

--- a/source/Examples/Resources/AzDoArtifactFeed.md
+++ b/source/Examples/Resources/AzDoArtifactFeed.md
@@ -5,8 +5,8 @@
 ```PowerShell
 AzDoArtifactFeed [string] #ResourceName
 {
-    ProjectName       = [String]$ProjectName
     FeedName          = [String]$FeedName
+    [ ProjectName     = [String]$ProjectName ]
     [ Description     = [String]$Description ]
     [ BadgesEnabled   = [Boolean]$BadgesEnabled ]
     [ UpstreamEnabled = [Boolean]$UpstreamEnabled ]
@@ -18,8 +18,8 @@ AzDoArtifactFeed [string] #ResourceName
 
 ### Common Properties
 
-- **ProjectName**: The name of the Azure DevOps project. This property is mandatory and serves as a key property for the resource.
-- **FeedName**: The name of the artifact feed. This is a key property.
+- **FeedName**: The name of the artifact feed. This property is mandatory and is the key property for the resource.
+- **ProjectName**: The name of the Azure DevOps project. **Optional** — when supplied, the feed is **project-scoped**; when omitted, the feed is **organization-scoped**.
 - **Description**: An optional description for the feed.
 - **BadgesEnabled**: Whether to enable badges for the feed. Defaults to `$false`.
 - **UpstreamEnabled**: Whether to enable upstream sources. Defaults to `$true`.
@@ -27,7 +27,7 @@ AzDoArtifactFeed [string] #ResourceName
 
 ## Additional Information
 
-This resource manages Azure Artifacts feeds within a project. Artifact feeds allow teams to share packages (NuGet, npm, Maven, Python, Universal Packages) across the organization.
+This resource manages Azure Artifacts feeds. A feed can be **project-scoped** (set `ProjectName`) or **organization-scoped** (omit `ProjectName`). Artifact feeds allow teams to share packages (NuGet, npm, Maven, Python, Universal Packages).
 
 ## Examples
 
@@ -45,6 +45,25 @@ Configuration ExampleConfig {
             Description     = 'My package feed'
             BadgesEnabled   = $false
             UpstreamEnabled = $true
+        }
+    }
+}
+
+Start-DscConfiguration -Path ./ExampleConfig -Wait -Verbose
+```
+
+## Example 1b: Organization-scoped feed (omit ProjectName)
+
+``` PowerShell
+Configuration ExampleConfig {
+    Import-DscResource -ModuleName 'AzureDevOpsDsc'
+
+    Node localhost {
+        AzDoArtifactFeed AddOrgFeed {
+            Ensure      = 'Present'
+            FeedName    = 'SharedOrgFeed'
+            Description = 'Organization-wide package feed'
+            # No ProjectName -> the feed is created at the organization scope.
         }
     }
 }

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ACE/Clear-AzDoACE.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ACE/Clear-AzDoACE.ps1
@@ -103,7 +103,6 @@ Function Clear-AzDoACE {
     catch
     {
         # If an exception occurs, write an error message to the console with details about the issue.
-        "DELETE EXCEPTION: $($_.Exception.Message)" | Out-File 'C:\Git\clear-ace-debug.log' -Append
         Write-Error "[Clear-AzDoACE] Failed to set ACLs: $($_.Exception.Message)"
     }
 

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/AgentPool/List-DevOpsAgentPools.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/AgentPool/List-DevOpsAgentPools.ps1
@@ -5,10 +5,15 @@ Function List-DevOpsAgentPools
         [Parameter(Mandatory)][string]$ApiUri,
         [Parameter()][string]$ApiVersion = '7.1'
     )
-    $params = @{
-        Uri    = '{0}/_apis/distributedtask/pools?api-version={1}' -f $ApiUri.TrimEnd('/'), $ApiVersion
-        Method = 'GET'
+    # The pools API excludes 'deployment' poolType pools unless explicitly requested via
+    # ?poolType=deployment - and that filter excludes everything else in turn. Query both
+    # and merge so callers see the full live set regardless of pool type.
+    $baseUri = '{0}/_apis/distributedtask/pools' -f $ApiUri.TrimEnd('/')
+    try
+    {
+        $defaultPools    = (Invoke-AzDevOpsApiRestMethod -Uri ('{0}?api-version={1}' -f $baseUri, $ApiVersion) -Method 'GET').value
+        $deploymentPools = (Invoke-AzDevOpsApiRestMethod -Uri ('{0}?poolType=deployment&api-version={1}' -f $baseUri, $ApiVersion) -Method 'GET').value
+        return @($defaultPools) + @($deploymentPools)
     }
-    try   { return (Invoke-AzDevOpsApiRestMethod @params).value }
     catch { Throw "[List-DevOpsAgentPools] Failed to list agent pools: $_" }
 }

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Resolve-DevOpsArtifactFeed.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/Resolve-DevOpsArtifactFeed.ps1
@@ -10,7 +10,7 @@ Function Resolve-DevOpsArtifactFeed
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory)][string]$FeedName
     )
 

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/AzDoPermission/Set-AzDoPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/AzDoPermission/Set-AzDoPermission.ps1
@@ -60,7 +60,13 @@ Function Set-AzDoPermission
     Write-Verbose "[Set-AzDoPermission] Started."
 
     # Check if the ClearACEs switch is set to true. If so clear the ACEs prior to setting the new ACLs.
-    if ($ClearACEs.IsPresent)
+    # Skip the call entirely when $DifferenceACLs is $null (no live ACL yet - e.g. the very first Set
+    # for a brand-new resource): Clear-AzDoACE's own -DifferenceACLs parameter is Mandatory with no
+    # null allowance, so passing $null through threw here before Clear-AzDoACE's own "nothing to
+    # clear" early-return ever got a chance to run - confirmed live, this crashed every first-time Set
+    # for any resource whose Get function returns a genuine $null (rather than an empty array) when no
+    # ACL exists yet, e.g. AzDoAgentPoolPermission.
+    if ($ClearACEs.IsPresent -and $null -ne $DifferenceACLs)
     {
         Write-Verbose "[Set-AzDoPermission] Clearing ACEs."
         Clear-AzDoACE -OrganizationName $OrganizationName -SecurityNamespaceID $SecurityNamespaceID -DifferenceACLs $DifferenceACLs

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Group/Get-DevOpsGroup.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Group/Get-DevOpsGroup.ps1
@@ -1,0 +1,60 @@
+<#
+.SYNOPSIS
+Gets a single Azure DevOps group by its graph descriptor.
+
+.DESCRIPTION
+Retrieves one group via the Graph API's get-by-descriptor endpoint
+(GET https://vssps.dev.azure.com/{organization}/_apis/graph/groups/{groupDescriptor}). Used in place of
+listing and filtering the full organization group set, which can lag behind a group that was created
+moments earlier in the same run (see Find-Identity's subjectDescriptor fallback).
+
+.PARAMETER Organization
+The name of the Azure DevOps organization.
+
+.PARAMETER Descriptor
+The group's graph descriptor (e.g. 'vssgp.Uy0xLTk...').
+
+.PARAMETER ApiVersion
+The version of the Azure DevOps API to use. If not specified, the default API version is used.
+
+.OUTPUTS
+The group object, or $null if not found.
+
+.EXAMPLE
+Get-DevOpsGroup -Organization 'myOrganization' -Descriptor 'vssgp.Uy0xLTk...'
+#>
+Function Get-DevOpsGroup
+{
+    [CmdletBinding()]
+    [OutputType([System.Object])]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Organization,
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Descriptor,
+        [Parameter()]
+        [String]
+        $ApiVersion
+    )
+
+    # vssps graph endpoints are preview-only; a bare '7.1' is rejected. Default to preview.
+    if (-not $ApiVersion) { $ApiVersion = '7.1-preview.1' }
+
+    $params = @{
+        Uri    = 'https://vssps.dev.azure.com/{0}/_apis/graph/groups/{1}?api-version={2}' -f $Organization, $Descriptor, $ApiVersion
+        Method = 'Get'
+    }
+
+    try
+    {
+        return @(Invoke-AzDevOpsApiRestMethod @params)[0]
+    }
+    catch
+    {
+        Write-Verbose "[Get-DevOpsGroup] Lookup of group '$Descriptor' failed: $_"
+        return $null
+    }
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Team/Set-DevOpsTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/Team/Set-DevOpsTeamSettings.ps1
@@ -31,9 +31,15 @@ Function Set-DevOpsTeamSettings
     {
         param([string]$Structure, [string]$Path)
         if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
-        # Strip a leading '<Project>\' prefix so the path is relative to the node root.
-        $relative = ($Path -replace '^[^\\/]+[\\/]', '') -replace '\\', '/'
-        $uri = '{0}/{1}/_apis/wit/classificationnodes/{2}/{3}?api-version={4}' -f $org, $ProjectId, $Structure, $relative, $ApiVersion
+        # Strip a leading '<Project>\' prefix so the path is relative to the node root. A path with
+        # no separator IS the project/root name alone - resolve it to the root node (no trailing
+        # segment), not a non-existent child node named after the project.
+        $relative = if ($Path -match '[\\/]') { ($Path -replace '^[^\\/]+[\\/]', '') -replace '\\', '/' } else { '' }
+        $uri = if ($relative) {
+            '{0}/{1}/_apis/wit/classificationnodes/{2}/{3}?api-version={4}' -f $org, $ProjectId, $Structure, $relative, $ApiVersion
+        } else {
+            '{0}/{1}/_apis/wit/classificationnodes/{2}?api-version={3}' -f $org, $ProjectId, $Structure, $ApiVersion
+        }
         try   { return Invoke-AzDevOpsApiRestMethod -Uri $uri -Method Get }
         catch { Throw "[Set-DevOpsTeamSettings] Failed to resolve $Structure path '$Path': $_" }
     }
@@ -64,21 +70,10 @@ Function Set-DevOpsTeamSettings
                 -ContentType 'application/json' -Body ($settingsBody | ConvertTo-Json -Depth 5) | Out-Null
         }
 
-        # Assign the team's iteration backlog (the iterations the team participates in).
-        if ($PSBoundParameters.ContainsKey('IterationPaths') -and $IterationPaths)
-        {
-            foreach ($iterationPath in $IterationPaths)
-            {
-                $node = Resolve-ClassificationNode -Structure 'iterations' -Path $iterationPath
-                if ($node -and $PSCmdlet.ShouldProcess($iterationPath, 'Assign iteration to team'))
-                {
-                    Invoke-AzDevOpsApiRestMethod -Uri ('{0}/iterations?api-version={1}' -f $base, $ApiVersion) -Method Post `
-                        -ContentType 'application/json' -Body (@{ id = $node.identifier } | ConvertTo-Json) | Out-Null
-                }
-            }
-        }
-
         # --- Area paths (team field values) --------------------------------------------
+        # Must run before iteration assignment below - Azure DevOps rejects adding an
+        # iteration to a team's backlog ("TF400499: You have not set your team field")
+        # until the team has an area path (team field) configured.
         if ($PSBoundParameters.ContainsKey('DefaultAreaPath') -or $PSBoundParameters.ContainsKey('AreaPaths'))
         {
             $values = @()
@@ -96,6 +91,20 @@ Function Set-DevOpsTeamSettings
             {
                 Invoke-AzDevOpsApiRestMethod -Uri ('{0}/teamfieldvalues?api-version={1}' -f $base, $ApiVersion) -Method Patch `
                     -ContentType 'application/json' -Body ($fieldBody | ConvertTo-Json -Depth 5) | Out-Null
+            }
+        }
+
+        # Assign the team's iteration backlog (the iterations the team participates in).
+        if ($PSBoundParameters.ContainsKey('IterationPaths') -and $IterationPaths)
+        {
+            foreach ($iterationPath in $IterationPaths)
+            {
+                $node = Resolve-ClassificationNode -Structure 'iterations' -Path $iterationPath
+                if ($node -and $PSCmdlet.ShouldProcess($iterationPath, 'Assign iteration to team'))
+                {
+                    Invoke-AzDevOpsApiRestMethod -Uri ('{0}/iterations?api-version={1}' -f $base, $ApiVersion) -Method Post `
+                        -ContentType 'application/json' -Body (@{ id = $node.identifier } | ConvertTo-Json) | Out-Null
+                }
             }
         }
     }

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-ACETokenList.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/ConvertTo-ACETokenList.ps1
@@ -26,6 +26,19 @@ Function ConvertTo-ACETokenList
         return
     }
 
+    # Some namespaces expose actions that are documented in the namespace's action list but which the
+    # API refuses to let a caller explicitly Allow/Deny - it rejects the ENTIRE batched ACL update with
+    # a 500 "VS403284: ... reserved by the system" error (confirmed live; matches reports against the
+    # official Terraform azuredevops provider for the same bit). Since Set-AzDoPermission's caller never
+    # sees that failure (non-terminating Write-Error), a config that requests one of these bits silently
+    # drops every ACE in the same batch, not just its own. Strip them here rather than let the whole
+    # write fail - they are implicitly available regardless (that is exactly why the platform reserves
+    # them), so omitting an explicit grant does not change effective access.
+    $reservedActionsByNamespace = @{
+        'Process' = @('ReadProcessPermissions')
+    }
+    $reservedActions = $reservedActionsByNamespace[$SecurityNamespace]
+
     # Iterate through each of the ACEs and construct the ACE Object
     Write-Verbose "[ConvertTo-ACETokenList] Iterating through each of the ACE Permissions."
 
@@ -45,6 +58,19 @@ Function ConvertTo-ACETokenList
 
         $AllowPermissions = $ACEPermission.Keys | Where-Object { $ACEPermission."$_" -eq 'Allow' }
         $DenyPermissions  = $ACEPermission.Keys | Where-Object { $ACEPermission."$_" -eq 'Deny'  }
+
+        if ($reservedActions)
+        {
+            foreach ($reserved in $reservedActions)
+            {
+                if ($reserved -in $AllowPermissions -or $reserved -in $DenyPermissions)
+                {
+                    Write-Warning "[ConvertTo-ACETokenList] '$reserved' is reserved by the '$SecurityNamespace' namespace and cannot be explicitly Allow/Deny'd via the API - omitting it (it is implicitly available regardless)."
+                }
+            }
+            $AllowPermissions = @($AllowPermissions | Where-Object { $_ -notin $reservedActions })
+            $DenyPermissions  = @($DenyPermissions  | Where-Object { $_ -notin $reservedActions })
+        }
 
         Write-Verbose "[ConvertTo-ACETokenList] Iterating through the Allow and Deny Permissions and computing actions."
         $AllowBits = $SecurityDescriptor.actions | Where-Object { ($_.displayName -in $AllowPermissions) -or ($_.name -in $AllowPermissions) }

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/New-ACLToken.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/New-ACLToken.ps1
@@ -65,13 +65,13 @@ Function New-ACLToken
             {
                 # Derive the Token Type GitProject
                 $result.type = 'GitProject'
-                $result.projectId = (Get-CacheItem -Key $matches.ProjectName.Trim() -Type 'LiveProjects').id
+                $result.projectId = Resolve-AzDoProjectIdForToken -ProjectName $matches.ProjectName.Trim()
             }
             elseif ($TokenName -match $LocalizedDataAzResourceTokenPatten.GitRepository)
             {
                 # Derive the Token Type GitRepository
                 $result.type = 'GitRepository'
-                $result.projectId = (Get-CacheItem -Key $matches.ProjectName.Trim() -Type 'LiveProjects').id
+                $result.projectId = Resolve-AzDoProjectIdForToken -ProjectName $matches.ProjectName.Trim()
                 $result.RepoId = (Get-CacheItem -Key $TokenName -Type 'LiveRepositories').id
             }
             else
@@ -202,7 +202,7 @@ Function New-ACLToken
             if ($TokenName -match $LocalizedDataAzResourceTokenPatten.BuildPermission)
             {
                 $result.type      = 'Build'
-                $result.ProjectId = (Get-CacheItem -Key $matches.ProjectName.Trim() -Type 'LiveProjects').id
+                $result.ProjectId = Resolve-AzDoProjectIdForToken -ProjectName $matches.ProjectName.Trim()
                 if ($matches.PipelineName) {
                     $pipelineCacheKey  = '{0}\{1}' -f $matches.ProjectName.Trim(), $matches.PipelineName.Trim()
                     $pipelineEntry     = Get-CacheItem -Key $pipelineCacheKey -Type 'LivePipelines'
@@ -222,7 +222,7 @@ Function New-ACLToken
             if ($TokenName -match $LocalizedDataAzResourceTokenPatten.LibraryPermission)
             {
                 $result.type      = 'Library'
-                $result.ProjectId = (Get-CacheItem -Key $matches.ProjectName.Trim() -Type 'LiveProjects').id
+                $result.ProjectId = Resolve-AzDoProjectIdForToken -ProjectName $matches.ProjectName.Trim()
                 if ($matches.VariableGroupName) {
                     $vgCacheKey             = '{0}\{1}' -f $matches.ProjectName.Trim(), $matches.VariableGroupName.Trim()
                     $vgEntry                = Get-CacheItem -Key $vgCacheKey -Type 'LiveVariableGroups'
@@ -242,7 +242,7 @@ Function New-ACLToken
             if ($TokenName -match $LocalizedDataAzResourceTokenPatten.ServiceEndpointPermission)
             {
                 $result.type      = 'ServiceEndpoints'
-                $result.ProjectId = (Get-CacheItem -Key $matches.ProjectName.Trim() -Type 'LiveProjects').id
+                $result.ProjectId = Resolve-AzDoProjectIdForToken -ProjectName $matches.ProjectName.Trim()
                 if ($matches.EndpointName) {
                     $scCacheKey        = '{0}\{1}' -f $matches.ProjectName.Trim(), $matches.EndpointName.Trim()
                     $scEntry           = Get-CacheItem -Key $scCacheKey -Type 'LiveServiceConnections'
@@ -278,7 +278,7 @@ Function New-ACLToken
             if ($TokenName -match $LocalizedDataAzResourceTokenPatten.EnvironmentPermission)
             {
                 $result.type      = 'Environment'
-                $result.ProjectId = (Get-CacheItem -Key $matches.ProjectName.Trim() -Type 'LiveProjects').id
+                $result.ProjectId = Resolve-AzDoProjectIdForToken -ProjectName $matches.ProjectName.Trim()
                 if ($matches.EnvironmentName) {
                     # Resolve the environment numeric ID from cache so the token matches
                     # what Parse-ACLToken extracts from the API's Environments/{ProjectId}/{EnvironmentId} format.

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Resolve-AzDoProjectIdForToken.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Resolve-AzDoProjectIdForToken.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+Resolves a project's id for ACL token construction, falling back to a live lookup on cache miss.
+
+.DESCRIPTION
+New-ACLToken's Build/Library/ServiceEndpoints/DistributedTask/Git branches all resolve a project name
+to its id via a plain 'LiveProjects' cache lookup with no live-API fallback. When the project is not
+(yet) in cache, that silently produces a token with a $null ProjectId, which the ACL API accepts
+without error but which never matches the intended project - the Set/Get then operate on a token that
+resolves to nothing, so the resource never converges. This centralises the same
+cache-then-live-fallback pattern already used elsewhere (e.g. Get-AzDoProject) for token construction.
+
+.PARAMETER ProjectName
+The name of the project to resolve.
+
+.OUTPUTS
+The project's id (string), or $null if the project genuinely does not exist.
+#>
+Function Resolve-AzDoProjectIdForToken
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ProjectName
+    )
+
+    $project = Get-CacheItem -Key $ProjectName -Type 'LiveProjects'
+    if ($project) { return $project.id }
+
+    Write-Verbose "[Resolve-AzDoProjectIdForToken] Project '$ProjectName' not in cache — falling back to live API lookup."
+    try
+    {
+        $OrganizationName = Get-AzDoOrganizationName
+        $project = Invoke-AzDevOpsApiRestMethod -Uri "https://dev.azure.com/$OrganizationName/_apis/projects/${ProjectName}?api-version=7.1-preview.4" -Method Get
+        if ($project) { Add-CacheItem -Key $ProjectName -Value $project -Type 'LiveProjects' -SuppressWarning }
+    }
+    catch
+    {
+        Write-Verbose "[Resolve-AzDoProjectIdForToken] Live lookup for project '$ProjectName' failed: $_"
+        return $null
+    }
+
+    return $project.id
+}

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Test-ACLListforChanges.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/ACL/Test-ACLListforChanges.ps1
@@ -72,11 +72,13 @@ Function Test-ACLListforChanges
         return $result
     }
 
-    # If the Difference ACL is null, set the status to changed.
+    # If the Difference ACL is null, the desired ACE(s) don't exist live yet - that's drift to
+    # reconcile (Changed), not an absent resource (NotFound would tell the base class Ensure is
+    # Absent, so Set never actually applies the permission and Test keeps reporting the same gap).
     if ($null -eq $DifferenceACLs)
     {
         Write-Verbose "[Test-ACLListforChanges] Difference ACL is null."
-        $result.status = "NotFound"
+        $result.status = "Changed"
         $result.propertiesChanged = $ReferenceACLs
         $result.reason += @{
             Value = $ReferenceACLs

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Find-Identity.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Find-Identity.ps1
@@ -114,6 +114,33 @@ Function Find-Identity
     $resolved = & $resolveUnique $groupIdentity $userIdentity $servicePrincipalIdentity $Name
     if ($null -ne $resolved)
     {
+        # Groups populated by the init-time cache warm-up (AzDoAPI_1_GroupCache) are never enriched
+        # with ACLIdentity - only groups created/refreshed during this run get that, via
+        # Refresh-CacheIdentity. Returning this as-is builds an ACE with a $null descriptor for any
+        # pre-existing group, which the API then silently drops. Lazily backfill it here on first use.
+        if ($resolved.Value -and (-not $resolved.Value.ACLIdentity) -and $resolved.Value.descriptor)
+        {
+            try
+            {
+                $descriptorIdentity = Get-DevOpsDescriptorIdentity -OrganizationName $OrganizationName -SubjectDescriptor $resolved.Value.descriptor
+                if ($descriptorIdentity)
+                {
+                    $resolved.Value | Add-Member -MemberType NoteProperty -Name 'ACLIdentity' -Force -Value ([PSCustomObject]@{
+                        id                  = $descriptorIdentity.id
+                        descriptor          = $descriptorIdentity.descriptor
+                        subjectDescriptor   = $descriptorIdentity.subjectDescriptor
+                        providerDisplayName = $descriptorIdentity.providerDisplayName
+                        isActive            = $descriptorIdentity.isActive
+                        isContainer         = $descriptorIdentity.isContainer
+                    })
+                    Add-CacheItem -Key $resolved.Key -Value $resolved.Value -Type 'LiveGroups' -SuppressWarning
+                }
+            }
+            catch
+            {
+                Write-Verbose "[Find-Identity] Failed to lazily enrich ACLIdentity for '$Name': $_"
+            }
+        }
         Write-Verbose "[Find-Identity] Found identity for '$Name' ($SearchType)."
         return $resolved
     }
@@ -233,18 +260,21 @@ Function Find-Identity
     # this, the live-side ACE Identity is null and the Set->Test comparison never converges).
     if ($identity -and $identity.subjectDescriptor)
     {
-        Write-Verbose "[Find-Identity] '$Name' resolved via API but absent from cache. Matching a live group by subjectDescriptor."
+        # A full List-DevOpsGroups scan can lag behind a group created moments earlier in this same
+        # run (the org-wide groups list endpoint is eventually consistent), which was silently
+        # dropping the ACE for just-created groups. A targeted get-by-descriptor call reads that one
+        # group directly instead of waiting on the list to catch up.
+        Write-Verbose "[Find-Identity] '$Name' resolved via API but absent from cache. Fetching the group directly by its graph descriptor."
         try
         {
-            $liveGroups = List-DevOpsGroups -Organization $OrganizationName
+            $match = Get-DevOpsGroup -Organization $OrganizationName -Descriptor $identity.subjectDescriptor
         }
         catch
         {
-            Write-Error "[Find-Identity] Live groups lookup failed: $_"
-            $liveGroups = @()
+            Write-Error "[Find-Identity] Group lookup by descriptor failed: $_"
+            $match = $null
         }
 
-        $match = $liveGroups | Where-Object { $_.descriptor -eq $identity.subjectDescriptor } | Select-Object -First 1
         if ($match)
         {
             $match | Add-Member -MemberType NoteProperty -Name 'ACLIdentity' -Force -Value ([PSCustomObject]@{

--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Format-AzDoAreaPath.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Format-AzDoAreaPath.ps1
@@ -12,12 +12,29 @@ Function Format-AzDoAreaPath {
 
     Process {
 
-        # Normalise separators, strip leading/trailing backslashes, then prefix with \Project\Area if absent.
+        # Normalise separators, strip leading/trailing backslashes.
         $Path = $AreaPath -replace '\/', '\' -replace '\\+', '\'
         $Path = $Path.Trim('\')
-        if (-not $Path.StartsWith("$ProjectName\Area")) {
-            $Path = "$ProjectName\Area\$Path"
+
+        # Strip a leading '<Project>\' prefix if present (callers may pass either a bare area
+        # name like 'Core' or an already project-qualified path like 'Aurora\Core') so we always
+        # work with a path relative to the project root before re-adding the '<Project>\Area\'
+        # prefix exactly once. Without this, a project-qualified input got double-prefixed into
+        # '<Project>\Area\<Project>\Core' - a real, distinct node one level too deep.
+        if ($Path -eq $ProjectName) {
+            $Path = ''
+        } elseif ($Path.StartsWith("$ProjectName\")) {
+            $Path = $Path.Substring("$ProjectName\".Length)
         }
+
+        # Strip a leading 'Area\' segment too, in case the path was already fully qualified.
+        if ($Path -eq 'Area') {
+            $Path = ''
+        } elseif ($Path.StartsWith('Area\')) {
+            $Path = $Path.Substring('Area\'.Length)
+        }
+
+        $Path = if ($Path) { "$ProjectName\Area\$Path" } else { "$ProjectName\Area" }
         $Path = '\' + ($Path -replace '\\+', '\')
 
         $array += $Path

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoAgentPool/Get-AzDoAgentPool.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoAgentPool/Get-AzDoAgentPool.ps1
@@ -15,6 +15,14 @@ Function Get-AzDoAgentPool
     Write-Verbose "[Get-AzDoAgentPool] Started."
     $result = @{ Ensure = [Ensure]::Absent; propertiesChanged = @(); status = $null }
     $pool = Get-CacheItem -Key $PoolName -Type 'LiveAgentPools'
+    if (-not $pool)
+    {
+        Write-Verbose "[Get-AzDoAgentPool] Pool '$PoolName' not in cache — falling back to live API lookup."
+        $OrgName  = Get-AzDoOrganizationName
+        $allPools = List-DevOpsAgentPools -ApiUri "https://dev.azure.com/$OrgName"
+        $pool     = $allPools | Where-Object { $_.name -eq $PoolName } | Select-Object -First 1
+        if ($pool) { Add-CacheItem -Key $PoolName -Value $pool -Type 'LiveAgentPools' }
+    }
     if ($pool) { $result.liveCache = $pool; $result.status = [DSCGetSummaryState]::Unchanged }
     else        { $result.status = [DSCGetSummaryState]::NotFound }
     return $result

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoAgentQueue/Get-AzDoAgentQueue.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoAgentQueue/Get-AzDoAgentQueue.ps1
@@ -13,7 +13,16 @@ Function Get-AzDoAgentQueue
     )
     Write-Verbose "[Get-AzDoAgentQueue] Started."
     $result = @{ Ensure = [Ensure]::Absent; propertiesChanged = @(); status = $null }
-    $queue = Get-CacheItem -Key ('{0}\{1}' -f $ProjectName, $QueueName) -Type 'LiveAgentQueues'
+    $cacheKey = '{0}\{1}' -f $ProjectName, $QueueName
+    $queue = Get-CacheItem -Key $cacheKey -Type 'LiveAgentQueues'
+    if (-not $queue)
+    {
+        Write-Verbose "[Get-AzDoAgentQueue] Queue '$cacheKey' not in cache — falling back to live API lookup."
+        $OrgName    = Get-AzDoOrganizationName
+        $allQueues  = List-DevOpsAgentQueues -ApiUri "https://dev.azure.com/$OrgName" -ProjectName $ProjectName
+        $queue      = $allQueues | Where-Object { $_.name -eq $QueueName } | Select-Object -First 1
+        if ($queue) { Add-CacheItem -Key $cacheKey -Value $queue -Type 'LiveAgentQueues' }
+    }
     if ($queue) { $result.liveCache = $queue; $result.status = [DSCGetSummaryState]::Unchanged }
     else         { $result.status = [DSCGetSummaryState]::NotFound }
     return $result

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Get-AzDoArtifactFeed.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Get-AzDoArtifactFeed.ps1
@@ -3,7 +3,7 @@ Function Get-AzDoArtifactFeed
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSObject[]])]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][string]$Description,
         [Parameter()][bool]$BadgesEnabled = $false,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/New-AzDoArtifactFeed.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/New-AzDoArtifactFeed.ps1
@@ -2,7 +2,7 @@ Function New-AzDoArtifactFeed
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][string]$Description,
         [Parameter()][bool]$BadgesEnabled = $false,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Remove-AzDoArtifactFeed.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Remove-AzDoArtifactFeed.ps1
@@ -2,7 +2,7 @@ Function Remove-AzDoArtifactFeed
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][string]$Description,
         [Parameter()][bool]$BadgesEnabled = $false,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Set-AzDoArtifactFeed.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/Set-AzDoArtifactFeed.ps1
@@ -2,7 +2,7 @@ Function Set-AzDoArtifactFeed
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][string]$Description,
         [Parameter()][bool]$BadgesEnabled = $false,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedPermission/Get-AzDoArtifactFeedPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedPermission/Get-AzDoArtifactFeedPermission.ps1
@@ -81,21 +81,25 @@ Function Get-AzDoArtifactFeedPermission
     $getResult.desiredPermissions = $desiredPerms
     $getResult.propertiesChanged  = $desiredPerms
 
-    # Compare desired vs actual (match by identityDescriptor + role).
+    # Compare desired vs actual. A desired identity can already be satisfied by a default/inherited
+    # entry - e.g. Azure DevOps grants 'Project Collection Valid Users: Reader' on every new feed as
+    # an inherited role - and PATCHing that identity to the SAME role it already has by inheritance is
+    # a platform no-op (the API never promotes it to an explicit entry), which made this permanently
+    # report drift. So match desired roles against the FULL live list (inherited + explicit); only
+    # extra EXPLICIT permissions not in the desired set count as something to remove.
     $changed = $false
-    if ($desiredPerms.Count -ne $explicitPerms.Count)
+    foreach ($desired in $desiredPerms)
     {
-        $changed = $true
-    }
-    else
-    {
-        foreach ($desired in $desiredPerms)
-        {
-            $match = $explicitPerms | Where-Object {
-                $_.identityDescriptor -eq $desired.identityDescriptor -and $_.role -eq $desired.role
-            }
-            if (-not $match) { $changed = $true; break }
+        $match = $livePerms | Where-Object {
+            $_.identityDescriptor -eq $desired.identityDescriptor -and $_.role -eq $desired.role
         }
+        if (-not $match) { $changed = $true; break }
+    }
+    if (-not $changed)
+    {
+        $desiredDescriptors = @($desiredPerms | ForEach-Object { $_.identityDescriptor })
+        $extraExplicit = @($explicitPerms | Where-Object { $_.identityDescriptor -notin $desiredDescriptors })
+        if ($extraExplicit.Count -gt 0) { $changed = $true }
     }
 
     if ($changed)

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedPermission/Get-AzDoArtifactFeedPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedPermission/Get-AzDoArtifactFeedPermission.ps1
@@ -3,7 +3,7 @@ Function Get-AzDoArtifactFeedPermission
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSObject[]])]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][HashTable[]]$Permissions,
         [Parameter()][HashTable]$LookupResult,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedPermission/New-AzDoArtifactFeedPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedPermission/New-AzDoArtifactFeedPermission.ps1
@@ -2,7 +2,7 @@ Function New-AzDoArtifactFeedPermission
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][HashTable[]]$Permissions,
         [Parameter()][HashTable]$LookupResult,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedPermission/Remove-AzDoArtifactFeedPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedPermission/Remove-AzDoArtifactFeedPermission.ps1
@@ -2,7 +2,7 @@ Function Remove-AzDoArtifactFeedPermission
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][HashTable[]]$Permissions,
         [Parameter()][HashTable]$LookupResult,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedPermission/Set-AzDoArtifactFeedPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedPermission/Set-AzDoArtifactFeedPermission.ps1
@@ -2,7 +2,7 @@ Function Set-AzDoArtifactFeedPermission
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][HashTable[]]$Permissions,
         [Parameter()][HashTable]$LookupResult,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Get-AzDoArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Get-AzDoArtifactFeedSettings.ps1
@@ -3,7 +3,7 @@ Function Get-AzDoArtifactFeedSettings
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSObject[]])]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][object[]]$UpstreamSources,
         [Parameter()][bool]$HideDeletedPackageVersions = $true,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/New-AzDoArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/New-AzDoArtifactFeedSettings.ps1
@@ -2,7 +2,7 @@ Function New-AzDoArtifactFeedSettings
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][object[]]$UpstreamSources,
         [Parameter()][bool]$HideDeletedPackageVersions = $true,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Remove-AzDoArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Remove-AzDoArtifactFeedSettings.ps1
@@ -2,7 +2,7 @@ Function Remove-AzDoArtifactFeedSettings
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][object[]]$UpstreamSources,
         [Parameter()][bool]$HideDeletedPackageVersions = $true,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Set-AzDoArtifactFeedSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedSettings/Set-AzDoArtifactFeedSettings.ps1
@@ -2,7 +2,7 @@ Function Set-AzDoArtifactFeedSettings
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter()][object[]]$UpstreamSources,
         [Parameter()][bool]$HideDeletedPackageVersions = $true,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Get-AzDoArtifactFeedView.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Get-AzDoArtifactFeedView.ps1
@@ -3,7 +3,7 @@ Function Get-AzDoArtifactFeedView
     [CmdletBinding()]
     [OutputType([System.Management.Automation.PSObject[]])]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter(Mandatory = $true)][string]$ViewName,
         [Parameter()][string]$ViewType,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/New-AzDoArtifactFeedView.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/New-AzDoArtifactFeedView.ps1
@@ -2,7 +2,7 @@ Function New-AzDoArtifactFeedView
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter(Mandatory = $true)][string]$ViewName,
         [Parameter()][string]$ViewType = 'release',

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Remove-AzDoArtifactFeedView.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Remove-AzDoArtifactFeedView.ps1
@@ -2,7 +2,7 @@ Function Remove-AzDoArtifactFeedView
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter(Mandatory = $true)][string]$ViewName,
         [Parameter()][string]$ViewType,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Set-AzDoArtifactFeedView.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeedView/Set-AzDoArtifactFeedView.ps1
@@ -2,7 +2,7 @@ Function Set-AzDoArtifactFeedView
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)][string]$ProjectName,
+        [Parameter()][string]$ProjectName,
         [Parameter(Mandatory = $true)][string]$FeedName,
         [Parameter(Mandatory = $true)][string]$ViewName,
         [Parameter()][string]$ViewType,

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoBranchPolicy/Get-AzDoBranchPolicy.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoBranchPolicy/Get-AzDoBranchPolicy.ps1
@@ -41,8 +41,20 @@ Function Get-AzDoBranchPolicy
         }
         if ($repositoryCache)
         {
+            # Live policies carry Azure DevOps' display name (e.g. 'Comment requirements'), not the
+            # short code used in config (e.g. 'CommentRequirements') - translate before matching.
+            $policyDisplayNameAliases = @{
+                'MinimumReviewerCount' = 'Minimum number of reviewers'
+                'BuildValidation'      = 'Build'
+                'CommentRequirements'  = 'Comment requirements'
+                'WorkItemLinking'      = 'Work item linking'
+                'MergeStrategy'        = 'Require a merge strategy'
+                'StatusCheck'          = 'Status'
+            }
+            $lookupDisplayName = if ($policyDisplayNameAliases.ContainsKey($PolicyType)) { $policyDisplayNameAliases[$PolicyType] } else { $PolicyType }
+
             $allPolicies = List-DevOpsBranchPolicies -ApiUri "https://dev.azure.com/$OrgName" -ProjectName $ProjectName -RepositoryId $repositoryCache.id -RefName ('refs/heads/{0}' -f $BranchName.TrimStart('refs/heads/'))
-            $policy = $allPolicies | Where-Object { $_.type.displayName -eq $PolicyType } | Select-Object -First 1
+            $policy = $allPolicies | Where-Object { $_.type.displayName -eq $lookupDisplayName } | Select-Object -First 1
             if ($policy) { Add-CacheItem -Key $cacheKey -Value $policy -Type 'LiveBranchPolicies' }
         }
     }

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoExtension/Get-AzDoExtension.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoExtension/Get-AzDoExtension.ps1
@@ -14,7 +14,16 @@ Function Get-AzDoExtension
     )
     Write-Verbose "[Get-AzDoExtension] Started."
     $result = @{ Ensure = [Ensure]::Absent; propertiesChanged = @(); status = $null }
-    $ext = Get-CacheItem -Key ('{0}\{1}' -f $PublisherId, $ExtensionId) -Type 'LiveExtensions'
+    $cacheKey = '{0}\{1}' -f $PublisherId, $ExtensionId
+    $ext = Get-CacheItem -Key $cacheKey -Type 'LiveExtensions'
+    if (-not $ext)
+    {
+        Write-Verbose "[Get-AzDoExtension] Extension '$cacheKey' not in cache — falling back to live API lookup."
+        $OrgName    = Get-AzDoOrganizationName
+        $allExtensions = List-DevOpsExtensions -ApiUri "https://extmgmt.dev.azure.com/$OrgName" -IncludeDisabled $true
+        $ext = $allExtensions | Where-Object { $_.publisherId -eq $PublisherId -and $_.extensionId -eq $ExtensionId } | Select-Object -First 1
+        if ($ext) { Add-CacheItem -Key $cacheKey -Value $ext -Type 'LiveExtensions' }
+    }
     if ($ext) { $result.liveCache = $ext; $result.status = [DSCGetSummaryState]::Unchanged }
     else       { $result.status = [DSCGetSummaryState]::NotFound }
     return $result

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineEnvironment/Get-AzDoPipelineEnvironment.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineEnvironment/Get-AzDoPipelineEnvironment.ps1
@@ -12,7 +12,16 @@ Function Get-AzDoPipelineEnvironment
     )
     Write-Verbose "[Get-AzDoPipelineEnvironment] Started."
     $result = @{ Ensure = [Ensure]::Absent; propertiesChanged = @(); status = $null }
-    $env = Get-CacheItem -Key ('{0}\{1}' -f $ProjectName, $EnvironmentName) -Type 'LivePipelineEnvironments'
+    $cacheKey = '{0}\{1}' -f $ProjectName, $EnvironmentName
+    $env = Get-CacheItem -Key $cacheKey -Type 'LivePipelineEnvironments'
+    if (-not $env)
+    {
+        Write-Verbose "[Get-AzDoPipelineEnvironment] Environment '$cacheKey' not in cache — falling back to live API lookup."
+        $OrgName = Get-AzDoOrganizationName
+        $allEnvs = List-DevOpsPipelineEnvironments -ApiUri "https://dev.azure.com/$OrgName" -ProjectName $ProjectName
+        $env     = $allEnvs | Where-Object { $_.name -eq $EnvironmentName } | Select-Object -First 1
+        if ($env) { Add-CacheItem -Key $cacheKey -Value $env -Type 'LivePipelineEnvironments' }
+    }
     if ($env) { $result.liveCache = $env; $result.status = [DSCGetSummaryState]::Unchanged }
     else       { $result.status = [DSCGetSummaryState]::NotFound }
     return $result

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Get-AzDoPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Get-AzDoPipelineSettings.ps1
@@ -98,7 +98,16 @@ function Get-AzDoPipelineSettings
     foreach ($dscName in $settingMap.Keys)
     {
         $apiName    = $settingMap[$dscName]
-        $liveString = if ([bool]$live.$apiName) { 'true' } else { 'false' }
+        $liveString = if ($dscName -eq 'DisableClassicPipelineCreation')
+        {
+            # 'disableClassicPipelineCreation' can't actually be set (see Set-AzDoPipelineSettings), so
+            # compare against the two fields that really drive it - true only when both are true.
+            if ([bool]$live.disableClassicBuildPipelineCreation -and [bool]$live.disableClassicReleasePipelineCreation) { 'true' } else { 'false' }
+        }
+        else
+        {
+            if ([bool]$live.$apiName) { 'true' } else { 'false' }
+        }
         $result[$dscName] = $liveString
 
         # Only compare settings the caller is managing (set to 'true'/'false'); '' means unmanaged.

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Set-AzDoPipelineSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelineSettings/Set-AzDoPipelineSettings.ps1
@@ -83,7 +83,20 @@ function Set-AzDoPipelineSettings
         $desired = [string]$PSBoundParameters[$dscName]
         if ($desired -ne '')
         {
-            $settings[$settingMap[$dscName]] = ($desired -eq 'true')
+            $boolValue = ($desired -eq 'true')
+            if ($dscName -eq 'DisableClassicPipelineCreation')
+            {
+                # The API's own 'disableClassicPipelineCreation' field is a read-only aggregate: PATCHing
+                # it returns 200 OK but the live value never changes (a known platform bug - see
+                # https://github.com/microsoft/azure-devops-go-api/issues/133). The two fields it
+                # aggregates ARE independently settable, so drive those instead.
+                $settings['disableClassicBuildPipelineCreation']   = $boolValue
+                $settings['disableClassicReleasePipelineCreation'] = $boolValue
+            }
+            else
+            {
+                $settings[$settingMap[$dscName]] = $boolValue
+            }
         }
     }
 

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoSecurityNamespacePermission/Get-AzDoSecurityNamespacePermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoSecurityNamespacePermission/Get-AzDoSecurityNamespacePermission.ps1
@@ -30,18 +30,41 @@ Function Get-AzDoSecurityNamespacePermission
 
     $getResult.namespace = $namespace
 
-    $DevOpsACLs     = Get-DevOpsACL -OrganizationName $OrganizationName -SecurityDescriptorId $namespace.namespaceId
     # New-ACLToken (called by ConvertTo-FormattedACL) strips [ ] from token names.
     # Strip brackets here so the filter matches: "$/[PROJECT]" → "$/PROJECT".
     $strippedToken  = $Token.Replace('[', '').Replace(']', '')
+
+    # Get-DevOpsACL's -Token must be the API's own wire-format token string (e.g. the bare project
+    # GUID for 'Build'), NOT the human-readable name in $strippedToken - build it the same way the Set
+    # path does, via New-ACLToken + ConvertTo-FormattedToken.
+    $queryToken = ConvertTo-FormattedToken -Token (New-ACLToken -SecurityNamespace $SecurityNamespace -TokenName $Token)
+
+    # Token-scope the ACL fetch instead of pulling every ACL in the namespace: for a namespace with
+    # a large accumulated ACL list (e.g. Build, shared org-wide), an unscoped fetch has to transfer,
+    # parse and Find-Identity-resolve every ACE of every other token too - confirmed via a live wire
+    # capture to take several minutes even though this token's own data is tiny.
+    #
+    # Deliberately NOT falling back to a full-namespace fetch when the scoped query returns $null:
+    # Get-DevOpsACL documents $null as a valid "no explicit ACL for this token" answer, not a failure -
+    # the most common case is exactly this (creating the first-ever ACE for a token), and falling back
+    # to the full scan on $null defeats the whole point of token-scoping for precisely that case.
+    $DevOpsACLs = if ($queryToken) { Get-DevOpsACL -OrganizationName $OrganizationName -SecurityDescriptorId $namespace.namespaceId -Token $queryToken }
+                  else             { Get-DevOpsACL -OrganizationName $OrganizationName -SecurityDescriptorId $namespace.namespaceId }
     # Wrap in @() so $DifferenceACLs is always an array; ConvertTo-FormattedACL returns a
     # generic List that PowerShell unrolls to a bare hashtable when there is only one entry,
     # making [0] indexing in Test-ACLListforChanges return $null.
     # Use the actual $SecurityNamespace so Format-ACEs and Parse-ACLToken can resolve permission
-    # bits against the real namespace descriptor. Both functions fall through to a Generic passthrough
-    # for namespaces not explicitly handled, preserving the raw token string with brackets intact.
+    # bits against the real namespace descriptor.
+    #
+    # Filter on $_.ACL.token (the RAW wire-format token string ConvertTo-FormattedACL preserves
+    # alongside its parsed form), not $_.Token.TokenValue: Parse-ACLToken only populates .TokenValue
+    # for its Generic/unrecognised-namespace fallback - for every explicitly-handled type (Build,
+    # Library, ServiceEndpoints, AgentPool, DistributedTask, etc.) .TokenValue is always $null, so this
+    # filter always matched nothing for those namespaces. Confirmed live: the Set POST succeeded and the
+    # subsequent unfiltered Get-DevOpsACL response DID contain the new ACE, but this filter discarded it
+    # every time. $queryToken is already in the same raw wire format, so it compares directly.
     $DifferenceACLs = @($DevOpsACLs | ConvertTo-FormattedACL -SecurityNamespace $SecurityNamespace -OrganizationName $OrganizationName |
-        Where-Object { $_.Token.TokenValue -eq $strippedToken })
+        Where-Object { $_.ACL.token -eq $queryToken })
 
     $params = @{
         Permissions       = $Permissions

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoSecurityNamespacePermission/Set-AzDoSecurityNamespacePermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoSecurityNamespacePermission/Set-AzDoSecurityNamespacePermission.ps1
@@ -17,9 +17,16 @@ Function Set-AzDoSecurityNamespacePermission
     # New-ACLToken strips [ ] from token names. Strip here too so DescriptorMatchToken matches the
     # live ACL token (e.g. "$/TEST_SNS_PERM") not the bracketed form ("$/[TEST_SNS_PERM]").
     $strippedToken = $Token.Replace('[', '').Replace(']', '')
+    # DescriptorACLList intentionally empty: 'merge=false' on the Set-AzDoPermission POST replaces the
+    # ACL per-token (only tokens present in the request body are touched), so there is no need to
+    # re-submit every other token's ACL. Merging in the whole namespace-wide 'LiveACLList' cache (as
+    # this used to) meant the request body grew with the size of the ENTIRE org's cached ACLs for this
+    # namespace - confirmed via a live wire-level capture to reach ~11,000 lines of JSON for a single
+    # ACE update, after which the API accepted the POST but the write silently never persisted. This
+    # already matches Set-AzDoProcessPermission and Set-AzDoProjectPermission, which never had this bug.
     $serializeACLParams = @{
         ReferenceACLs        = $LookupResult.propertiesChanged
-        DescriptorACLList    = Get-CacheItem -Key $ns.namespaceId -Type 'LiveACLList'
+        DescriptorACLList    = @()
         DescriptorMatchToken = ($LocalizedDataAzSerializationPatten.GenericPermission -f [regex]::Escape($strippedToken))
     }
     $params = @{

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Get-AzDoTeamSettings.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoTeamSettings/Get-AzDoTeamSettings.ps1
@@ -65,14 +65,26 @@ Function Get-AzDoTeamSettings
     $live = Get-DevOpsTeamSettings -ApiUri $ApiUri -ProjectId $project.id -TeamId $team.id
     $result.liveCache = $live
 
+    # Azure DevOps returns iteration paths relative to the node root (e.g. '\Sprint 1', or ''
+    # for the project root), while desired values are project-qualified (e.g. 'Aurora\Sprint 1',
+    # or 'Aurora' for the root). Normalize both to the same relative form before comparing.
+    function ConvertTo-ComparableIterationPath([string]$Path)
+    {
+        if ([string]::IsNullOrWhiteSpace($Path)) { return '' }
+        $p = $Path.Trim('\') -replace '/', '\'
+        if ($p -eq $ProjectName) { return '' }
+        if ($p.StartsWith("$ProjectName\")) { return $p.Substring("$ProjectName\".Length) }
+        return $p
+    }
+
     # Compare desired properties against the live configuration to detect drift.
     $propertiesChanged = @()
 
     if ($PSBoundParameters.ContainsKey('BacklogIterationPath') -and $BacklogIterationPath -and
-        $live.BacklogIterationPath -ne $BacklogIterationPath) { $propertiesChanged += 'BacklogIterationPath' }
+        (ConvertTo-ComparableIterationPath $live.BacklogIterationPath) -ne (ConvertTo-ComparableIterationPath $BacklogIterationPath)) { $propertiesChanged += 'BacklogIterationPath' }
 
     if ($PSBoundParameters.ContainsKey('DefaultIterationPath') -and $DefaultIterationPath -and
-        $live.DefaultIterationPath -ne $DefaultIterationPath) { $propertiesChanged += 'DefaultIterationPath' }
+        (ConvertTo-ComparableIterationPath $live.DefaultIterationPath) -ne (ConvertTo-ComparableIterationPath $DefaultIterationPath)) { $propertiesChanged += 'DefaultIterationPath' }
 
     if ($PSBoundParameters.ContainsKey('DefaultAreaPath') -and $DefaultAreaPath -and
         $live.DefaultAreaPath -ne $DefaultAreaPath) { $propertiesChanged += 'DefaultAreaPath' }

--- a/tests/Integration/Resources/AzDoArtifactFeed.tests.ps1
+++ b/tests/Integration/Resources/AzDoArtifactFeed.tests.ps1
@@ -97,3 +97,74 @@ Describe "AzDoArtifactFeed Integration Tests" -Tag "Integration", "ArtifactFeed"
         }
     }
 }
+
+Describe "AzDoArtifactFeed Integration Tests - Organization scoped" -Tag "Integration", "ArtifactFeed" {
+
+    BeforeAll {
+
+        # Organization-scoped feed: no ProjectName is supplied. Unique name per run to avoid the
+        # post-deletion name-reservation cooldown.
+        $ORGFEEDNAME = "testorgfeed$(Get-Random -Maximum 99999)"
+
+        $parameters = @{
+            Name       = 'AzDoArtifactFeed'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                FeedName        = $ORGFEEDNAME
+                Description     = 'Org-scoped test artifact feed'
+                UpstreamEnabled = $false
+            }
+        }
+    }
+
+    Context "Testing if the organization feed exists" {
+
+        BeforeAll { $parameters.Method = 'Test' }
+
+        It "Should not throw any exceptions (ProjectName not required)" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return False (feed does not exist yet)" {
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeFalse
+        }
+    }
+
+    Context "Creating the organization feed" {
+
+        BeforeAll { $parameters.Method = 'Set' }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after creation" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Removing the organization feed" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property = @{
+                FeedName = $ORGFEEDNAME
+                Ensure   = 'Absent'
+            }
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True (Absent is desired state)" {
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+}

--- a/tests/Integration/Resources/AzDoProcessPermission.tests.ps1
+++ b/tests/Integration/Resources/AzDoProcessPermission.tests.ps1
@@ -2,7 +2,8 @@ Describe "AzDoProcessPermission Integration Tests" -Tag "Integration", "ProcessP
 
     BeforeAll {
 
-        $GROUPNAME = 'ProcessPermGroup'
+        $GROUPNAME  = 'ProcessPermGroup'
+        $GROUPNAME2 = 'ProcessPermGroup2'
 
         # Process permissions apply at the organisation level ($PROCESS root). Create an org-level group
         # to grant the 'Create' permission to (i.e. the ability to create inherited/child processes).
@@ -11,6 +12,18 @@ Describe "AzDoProcessPermission Integration Tests" -Tag "Integration", "ProcessP
         {
             $null = Invoke-RestMethod -Uri "https://vssps.dev.azure.com/$(Resolve-TestOrg)/_apis/graph/groups?api-version=7.1-preview.1" `
                 -Method Post -Headers (Resolve-TestAuthHeader) -Body $body -ContentType 'application/json'
+        }
+        catch { if ("$_" -notmatch '409|already exist') { throw } }
+
+        # Second org-level group, used by the multi-identity Contexts below to mirror the production
+        # shape: a resource granting TWO different identities permissions in the same ACL, one of them
+        # with a mix of Allow and Deny actions (e.g. 'Process Administrators' + 'Security Auditors' in
+        # the real config). Every other Context in this file only ever exercises a single identity.
+        $body2 = @{ displayName = $GROUPNAME2; description = 'Second group for process permission testing' } | ConvertTo-Json
+        try
+        {
+            $null = Invoke-RestMethod -Uri "https://vssps.dev.azure.com/$(Resolve-TestOrg)/_apis/graph/groups?api-version=7.1-preview.1" `
+                -Method Post -Headers (Resolve-TestAuthHeader) -Body $body2 -ContentType 'application/json'
         }
         catch { if ("$_" -notmatch '409|already exist') { throw } }
 
@@ -88,6 +101,157 @@ Describe "AzDoProcessPermission Integration Tests" -Tag "Integration", "ProcessP
             Start-Sleep -Seconds 5
             $parameters.Method = 'Test'
             $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Setting process permissions for two identities (both Allow-only)" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            $parameters.property.Permissions = @(
+                @{
+                    Identity   = "[]\$GROUPNAME"
+                    Permission = @{
+                        Create = 'Allow'
+                        Edit   = 'Allow'
+                    }
+                },
+                @{
+                    Identity   = "[]\$GROUPNAME2"
+                    Permission = @{
+                        Create = 'Allow'
+                    }
+                }
+            )
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after setting permissions for both identities" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Setting process permissions for two identities (one mixed Allow/Deny)" {
+
+        BeforeAll {
+            $parameters.Method = 'Set'
+            # Mirrors the production shape that surfaced this bug: one identity with a pure-Allow ACE
+            # alongside a second identity whose ACE mixes Allow and Deny actions (e.g. a read-only
+            # 'Security Auditors'-style role: ReadProcessPermissions Allow, Edit/Delete Deny).
+            $parameters.property.Permissions = @(
+                @{
+                    Identity   = "[]\$GROUPNAME"
+                    Permission = @{
+                        Create = 'Allow'
+                        Edit   = 'Allow'
+                    }
+                },
+                @{
+                    Identity   = "[]\$GROUPNAME2"
+                    Permission = @{
+                        Create = 'Allow'
+                        Edit   = 'Deny'
+                    }
+                }
+            )
+        }
+
+        It "Should not throw any exceptions" {
+            { Invoke-DscResource @parameters } | Should -Not -Throw
+        }
+
+        It "Should return True after setting mixed Allow/Deny permissions for both identities" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+
+        It "Should still report True on a second, independent Test (no flapping/false drift)" {
+            Start-Sleep -Seconds 5
+            $parameters.Method = 'Test'
+            $result = Invoke-DscResource @parameters
+            $result.InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Setting permissions on a specific inherited process (not the AllProcesses root)" {
+
+        # Every Context above - and every pre-existing test in this file - targets ProcessName
+        # 'AllProcesses', which resolves directly to the literal '$PROCESS' root token
+        # (Get-DevOpsProcessAclToken's early-return). The production resource that surfaced this bug
+        # ('Process Administrators Permissions') instead targets the PROJECT'S OWN inherited process
+        # (ProcessName: $ProcessName), which resolves to a per-process token
+        # '$PROCESS:{parentProcessTypeId}:{processTypeId}' via Resolve-DevOpsProcess + Get-DevOpsProcess -
+        # a materially different code path. Reproduce that exact shape here.
+
+        BeforeAll {
+            $PROCESSNAME = "ITProcessPerm$(Get-Random -Maximum 99999)"
+
+            $null = Invoke-DscResource -Name 'AzDoProcess' -ModuleName 'AzureDevOpsDsc' -Method 'Set' -Property @{
+                ProcessName       = $PROCESSNAME
+                ParentProcessName = 'Agile'
+                Description       = 'Inherited process for process-permission scope testing'
+            }
+            Start-Sleep -Seconds 5
+
+            $processParameters = @{
+                Name       = 'AzDoProcessPermission'
+                ModuleName = 'AzureDevOpsDsc'
+                property   = @{
+                    ProcessName = $PROCESSNAME
+                    isInherited = $false
+                    Permissions = @(
+                        @{
+                            Identity   = "[]\$GROUPNAME"
+                            Permission = @{
+                                Create = 'Allow'
+                                Edit   = 'Allow'
+                            }
+                        },
+                        @{
+                            Identity   = "[]\$GROUPNAME2"
+                            Permission = @{
+                                Create = 'Allow'
+                                Edit   = 'Deny'
+                            }
+                        }
+                    )
+                }
+            }
+        }
+
+        AfterAll {
+            $null = Invoke-DscResource -Name 'AzDoProcess' -ModuleName 'AzureDevOpsDsc' -Method 'Set' -Property @{
+                ProcessName       = $PROCESSNAME
+                ParentProcessName = 'Agile'
+                Ensure            = 'Absent'
+            }
+        }
+
+        It "Should not throw any exceptions on Set" {
+            $processParameters.Method = 'Set'
+            { Invoke-DscResource @processParameters } | Should -Not -Throw
+        }
+
+        It "Should return True after setting mixed Allow/Deny permissions on the specific process" {
+            Start-Sleep -Seconds 5
+            $processParameters.Method = 'Test'
+            $result = Invoke-DscResource @processParameters
+            $result.InDesiredState | Should -BeTrue
+        }
+
+        It "Should still report True on a second, independent Test (no flapping/false drift)" {
+            Start-Sleep -Seconds 5
+            $processParameters.Method = 'Test'
+            $result = Invoke-DscResource @processParameters
             $result.InDesiredState | Should -BeTrue
         }
     }

--- a/tests/Integration/Resources/AzDoSecurityAuditorsMultiNamespace.tests.ps1
+++ b/tests/Integration/Resources/AzDoSecurityAuditorsMultiNamespace.tests.ps1
@@ -1,0 +1,253 @@
+<#
+.SYNOPSIS
+    Reproduction attempt for a live production failure: a single identity granted permissions across
+    MULTIPLE different security namespaces in one continuous LCM session.
+
+.DESCRIPTION
+    Every other integration test in this suite exercises ONE resource type in isolation, and each of
+    those individually passes - including AzDoProcessPermission.tests.ps1's "specific inherited process"
+    and "two identities, one mixed Allow/Deny" Contexts, which were written specifically to rule out
+    those shapes as the cause of a live failure.
+
+    In production, a single identity (an 'ENT Security Auditors' style group) is granted permissions by
+    FOUR different resource types in sequence within the SAME LCM run/session:
+      AzDoProjectPermission -> AzDoSecurityNamespacePermission (Build) -> AzDoProcessPermission -> AzDoIterationPermission
+    All four fail to converge in production; none fail in isolation. This test reproduces that exact
+    sequence - the same identity, touched by all four resource types back-to-back in one Pester session -
+    to test whether the failure depends on session-level state (cache pollution, identity/descriptor
+    reuse across namespaces) that a single-resource test can never exercise.
+
+    It also re-Tests the FIRST TWO resources again at the end, after the identity has been used by the
+    LATER resource types, to check whether an already-converged resource regresses once the same
+    identity is reused elsewhere - a distinct failure mode from "never converges in the first place".
+#>
+Describe "Security Auditors multi-namespace chain (reproduction)" -Tag "Integration", "SecurityAuditorsChain" {
+
+    BeforeAll {
+
+        $PROJECTNAME = "TEST_SECAUD_CHAIN"
+        $AUDITORS    = "ChainSecurityAuditors"
+        $SECONDARY   = "ChainSecondaryGroup"
+
+        New-TestProject -ProjectName $PROJECTNAME
+        New-TestGroup -ProjectName $PROJECTNAME -GroupName $AUDITORS
+        New-TestGroup -ProjectName $PROJECTNAME -GroupName $SECONDARY
+
+        $auditorsIdentity = "[$PROJECTNAME]\$AUDITORS"
+
+        # Mirrors 'Project Permissions - Security Auditors' exactly (single identity, mixed Allow/Deny).
+        $projectPermParams = @{
+            Name       = 'AzDoProjectPermission'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                ProjectName = $PROJECTNAME
+                GroupName   = $auditorsIdentity
+                isInherited = $false
+                Permissions = @(
+                    @{
+                        Identity   = $auditorsIdentity
+                        Permission = @{
+                            GENERIC_READ      = 'Allow'
+                            VIEW_TEST_RUNS    = 'Allow'
+                            GENERIC_WRITE     = 'Deny'
+                            DELETE            = 'Deny'
+                            WORK_ITEM_DELETE  = 'Deny'
+                        }
+                    }
+                )
+            }
+        }
+
+        # Mirrors 'Build Namespace - Security Auditors' exactly (single identity, mixed Allow/Deny).
+        $buildPermParams = @{
+            Name       = 'AzDoSecurityNamespacePermission'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                SecurityNamespace = 'Build'
+                Token             = $PROJECTNAME
+                GroupName         = $auditorsIdentity
+                isInherited       = $false
+                Permissions       = @(
+                    @{
+                        Identity   = $auditorsIdentity
+                        Permission = @{
+                            ViewBuilds          = 'Allow'
+                            ViewBuildDefinition = 'Allow'
+                            QueueBuilds         = 'Deny'
+                        }
+                    }
+                )
+            }
+        }
+
+        # Mirrors 'Process Administrators Permissions' exactly (two identities, one mixed Allow/Deny,
+        # scoped to the project's own inherited process - not the AllProcesses root).
+        $PROCESSNAME = "ITChainProcess$(Get-Random -Maximum 99999)"
+        $processPermParams = @{
+            Name       = 'AzDoProcessPermission'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                ProcessName = $PROCESSNAME
+                isInherited = $false
+                Permissions = @(
+                    @{
+                        Identity   = "[]\$SECONDARY"
+                        Permission = @{
+                            Edit                          = 'Allow'
+                            ReadProcessPermissions        = 'Allow'
+                            AdministerProcessPermissions  = 'Allow'
+                        }
+                    },
+                    @{
+                        Identity   = "[]\$AUDITORS"
+                        Permission = @{
+                            ReadProcessPermissions = 'Allow'
+                            Edit                    = 'Deny'
+                            Delete                  = 'Deny'
+                        }
+                    }
+                )
+            }
+        }
+
+        # Mirrors 'Sprint 1 Iteration Permissions' exactly (two identities, one mixed Allow/Deny) on the
+        # project's default iteration.
+        $iterationPermParams = @{
+            Name       = 'AzDoIterationPermission'
+            ModuleName = 'AzureDevOpsDsc'
+            property   = @{
+                ProjectName   = $PROJECTNAME
+                IterationPath = $null
+                isInherited   = $false
+                Permissions   = @(
+                    @{
+                        Identity   = "[$PROJECTNAME]\$PROJECTNAME Team"
+                        Permission = @{
+                            GENERIC_READ  = 'Allow'
+                            WORK_ITEM_READ  = 'Allow'
+                            WORK_ITEM_WRITE = 'Allow'
+                        }
+                    },
+                    @{
+                        Identity   = $auditorsIdentity
+                        Permission = @{
+                            GENERIC_READ    = 'Allow'
+                            WORK_ITEM_READ  = 'Allow'
+                            GENERIC_WRITE   = 'Deny'
+                        }
+                    }
+                )
+            }
+        }
+    }
+
+    Context "Step 1: AzDoProjectPermission grants the identity its first ACE" {
+
+        It "Should not throw on Set" {
+            $projectPermParams.Method = 'Set'
+            { Invoke-DscResource @projectPermParams } | Should -Not -Throw
+        }
+
+        It "Should converge" {
+            Start-Sleep -Seconds 5
+            $projectPermParams.Method = 'Test'
+            (Invoke-DscResource @projectPermParams).InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Step 2: AzDoSecurityNamespacePermission (Build) grants the SAME identity a second ACE" {
+
+        It "Should not throw on Set" {
+            $buildPermParams.Method = 'Set'
+            { Invoke-DscResource @buildPermParams } | Should -Not -Throw
+        }
+
+        It "Should converge" {
+            Start-Sleep -Seconds 5
+            $buildPermParams.Method = 'Test'
+            (Invoke-DscResource @buildPermParams).InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Step 3: AzDoProcessPermission grants the SAME identity a third ACE (own inherited process)" {
+
+        BeforeAll {
+            $null = Invoke-DscResource -Name 'AzDoProcess' -ModuleName 'AzureDevOpsDsc' -Method 'Set' -Property @{
+                ProcessName       = $PROCESSNAME
+                ParentProcessName = 'Agile'
+                Description       = 'Inherited process for the security-auditors chain reproduction'
+            }
+            Start-Sleep -Seconds 5
+        }
+
+        AfterAll {
+            $null = Invoke-DscResource -Name 'AzDoProcess' -ModuleName 'AzureDevOpsDsc' -Method 'Set' -Property @{
+                ProcessName       = $PROCESSNAME
+                ParentProcessName = 'Agile'
+                Ensure            = 'Absent'
+            }
+        }
+
+        It "Should not throw on Set" {
+            $processPermParams.Method = 'Set'
+            { Invoke-DscResource @processPermParams } | Should -Not -Throw
+        }
+
+        It "Should converge" {
+            Start-Sleep -Seconds 5
+            $processPermParams.Method = 'Test'
+            (Invoke-DscResource @processPermParams).InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Step 4: AzDoIterationPermission grants the SAME identity a fourth ACE" {
+
+        It "Should not throw on Set" {
+            $iterationPermParams.Method = 'Set'
+            { Invoke-DscResource @iterationPermParams } | Should -Not -Throw
+        }
+
+        It "Should converge" {
+            Start-Sleep -Seconds 5
+            $iterationPermParams.Method = 'Test'
+            (Invoke-DscResource @iterationPermParams).InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Regression check: earlier resources still converge after later ones touched the same identity" {
+
+        It "AzDoProjectPermission (Step 1) should still be in the desired state" {
+            $projectPermParams.Method = 'Test'
+            (Invoke-DscResource @projectPermParams).InDesiredState | Should -BeTrue
+        }
+
+        It "AzDoSecurityNamespacePermission (Step 2) should still be in the desired state" {
+            $buildPermParams.Method = 'Test'
+            (Invoke-DscResource @buildPermParams).InDesiredState | Should -BeTrue
+        }
+    }
+
+    Context "Cleanup: revert all four resources to inherited/empty" {
+
+        It "Reverts AzDoProjectPermission" {
+            $projectPermParams.Method = 'Set'
+            $projectPermParams.property.Permissions = @()
+            $projectPermParams.property.isInherited  = $true
+            { Invoke-DscResource @projectPermParams } | Should -Not -Throw
+        }
+
+        It "Reverts AzDoSecurityNamespacePermission" {
+            $buildPermParams.Method = 'Set'
+            $buildPermParams.property.Permissions = @()
+            $buildPermParams.property.isInherited  = $true
+            { Invoke-DscResource @buildPermParams } | Should -Not -Throw
+        }
+
+        It "Reverts AzDoIterationPermission" {
+            $iterationPermParams.Method = 'Set'
+            $iterationPermParams.property.Permissions = @()
+            $iterationPermParams.property.isInherited  = $true
+            { Invoke-DscResource @iterationPermParams } | Should -Not -Throw
+        }
+    }
+}

--- a/tests/Integration/Resources/AzDoSecurityAuditorsMultiNamespace.tests.ps1
+++ b/tests/Integration/Resources/AzDoSecurityAuditorsMultiNamespace.tests.ps1
@@ -25,6 +25,44 @@ Describe "Security Auditors multi-namespace chain (reproduction)" -Tag "Integrat
 
     BeforeAll {
 
+        # Defined here (not at file scope) because Pester v5's Run phase executes It/BeforeAll blocks
+        # in a scope chain that top-level Discovery-phase function definitions do not carry into -
+        # a function declared outside Describe/BeforeAll is invisible from inside It blocks.
+        function Write-AceDiagnostic
+        {
+            param(
+                [Parameter(Mandatory)][string]$Label,
+                [Parameter(Mandatory)][hashtable]$LookupResult
+            )
+
+            Write-Host "===== ACE diagnostic: $Label ====="
+            Write-Host ("Status: {0}" -f $LookupResult.status)
+            try { Write-Host ("Reason: {0}" -f ($LookupResult.reason | ConvertTo-Json -Depth 6 -Compress)) } catch { Write-Host "Reason: <could not serialize>" }
+
+            foreach ($side in 'ReferenceACLs', 'DifferenceACLs')
+            {
+                Write-Host "--- $side ---"
+                $acls = @($LookupResult.$side)
+                if ($acls.Count -eq 0) { Write-Host "  (none)"; continue }
+                foreach ($acl in $acls)
+                {
+                    if (-not $acl) { continue }
+                    Write-Host ("  Token: {0}" -f ($acl.token | ConvertTo-Json -Depth 4 -Compress))
+                    Write-Host ("  Inherited: {0}" -f $acl.inherited)
+                    foreach ($ace in @($acl.aces))
+                    {
+                        if (-not $ace) { continue }
+                        $allow = @($ace.Permissions.Allow | ForEach-Object { $_.displayName })
+                        $deny  = @($ace.Permissions.Deny  | ForEach-Object { $_.displayName })
+                        Write-Host ("    Identity='{0}' originId={1} descriptor={2} Allow=[{3}] Deny=[{4}]" -f `
+                            $ace.Identity.Value.principalName, $ace.Identity.Value.originId, `
+                            $ace.Identity.Value.ACLIdentity.descriptor, ($allow -join ','), ($deny -join ','))
+                    }
+                }
+            }
+            Write-Host "===== end diagnostic: $Label ====="
+        }
+
         $PROJECTNAME = "TEST_SECAUD_CHAIN"
         $AUDITORS    = "ChainSecurityAuditors"
         $SECONDARY   = "ChainSecondaryGroup"
@@ -167,6 +205,13 @@ Describe "Security Auditors multi-namespace chain (reproduction)" -Tag "Integrat
             $buildPermParams.Method = 'Test'
             (Invoke-DscResource @buildPermParams).InDesiredState | Should -BeTrue
         }
+
+        It "DIAGNOSTIC: dump the actual vs desired ACE lists (always runs, never fails the suite)" {
+            $buildPermParams.Method = 'Get'
+            $get = Invoke-DscResource @buildPermParams
+            Write-AceDiagnostic -Label 'Step 2 - AzDoSecurityNamespacePermission (Build)' -LookupResult $get.LookupResult
+            $true | Should -BeTrue
+        }
     }
 
     Context "Step 3: AzDoProcessPermission grants the SAME identity a third ACE (own inherited process)" {
@@ -197,6 +242,13 @@ Describe "Security Auditors multi-namespace chain (reproduction)" -Tag "Integrat
             Start-Sleep -Seconds 5
             $processPermParams.Method = 'Test'
             (Invoke-DscResource @processPermParams).InDesiredState | Should -BeTrue
+        }
+
+        It "DIAGNOSTIC: dump the actual vs desired ACE lists (always runs, never fails the suite)" {
+            $processPermParams.Method = 'Get'
+            $get = Invoke-DscResource @processPermParams
+            Write-AceDiagnostic -Label 'Step 3 - AzDoProcessPermission' -LookupResult $get.LookupResult
+            $true | Should -BeTrue
         }
     }
 

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/New-DevOpsArtifactFeed.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Api/ArtifactFeed/New-DevOpsArtifactFeed.tests.ps1
@@ -33,4 +33,21 @@ Describe 'New-DevOpsArtifactFeed' -Tag "Unit", "ArtifactFeed", "API" {
         { New-DevOpsArtifactFeed -ApiUri 'https://feeds.dev.azure.com/myorg' -FeedName 'TestFeed' } | Should -Throw
     }
 
+    It 'Targets the ORGANIZATION-scoped endpoint when no ProjectName is supplied' {
+        New-DevOpsArtifactFeed -ApiUri 'https://feeds.dev.azure.com/myorg' -FeedName 'OrgFeed'
+        Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and
+            $ApiUri -like 'https://feeds.dev.azure.com/myorg/_apis/packaging/feeds*' -and
+            $ApiUri -notlike '*MyProject*'
+        }
+    }
+
+    It 'Targets the PROJECT-scoped endpoint when ProjectName is supplied' {
+        New-DevOpsArtifactFeed -ApiUri 'https://feeds.dev.azure.com/myorg' -ProjectName 'MyProject' -FeedName 'ProjFeed'
+        Assert-MockCalled -CommandName Invoke-AzDevOpsApiRestMethod -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and
+            $ApiUri -like 'https://feeds.dev.azure.com/myorg/MyProject/_apis/packaging/feeds*'
+        }
+    }
+
 }

--- a/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/New-AzDoArtifactFeed.tests.ps1
+++ b/tests/Unit/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoArtifactFeed/New-AzDoArtifactFeed.tests.ps1
@@ -101,4 +101,26 @@ Describe "New-AzDoArtifactFeed" -Tag "Unit", "ArtifactFeed" {
             }
         }
     }
+
+    Context "when creating an organization-scoped feed (no ProjectName)" {
+
+        It "creates the feed without requiring ProjectName" {
+            { New-AzDoArtifactFeed -FeedName 'OrgFeed' } | Should -Not -Throw
+            Assert-MockCalled -CommandName New-DevOpsArtifactFeed -Exactly -Times 1
+        }
+
+        It "does not pass a ProjectName through to New-DevOpsArtifactFeed" {
+            New-AzDoArtifactFeed -FeedName 'OrgFeed'
+            Assert-MockCalled -CommandName New-DevOpsArtifactFeed -Exactly -Times 1 -ParameterFilter {
+                [string]::IsNullOrEmpty($ProjectName) -and $FeedName -eq 'OrgFeed'
+            }
+        }
+
+        It "caches the org feed under a project-less key" {
+            New-AzDoArtifactFeed -FeedName 'OrgFeed'
+            Assert-MockCalled -CommandName Add-CacheItem -Exactly -Times 1 -ParameterFilter {
+                $Key -eq '\OrgFeed' -and $Type -eq 'LiveArtifactFeeds'
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a chain of bugs that caused several Azure DevOps permission resources
(`AzDoProcessPermission`, `AzDoIterationPermission`, `AzDoProjectPermission`,
`AzDoSecurityNamespacePermission`) and related resources (artifact feeds, pipeline
settings, team settings, branch policies) to never converge against a live org.

### Highlights

- **Org-scoped artifact feeds**: made `ProjectName` optional across the `AzDoArtifactFeed*`
  resource functions so `ProjectName: ''` (org scope) works; fixed `UpstreamSources` type
  coercion (`String[]` → `HashTable[]`).
- **`AzDoArtifactFeedPermission`**: fixed comparison to recognize a default/inherited
  permission (`Project Collection Valid Users: Reader`) as already satisfying the desired
  state, instead of retrying a PATCH the platform silently no-ops.
- **`AzDoPipelineSettings`**: `disableClassicPipelineCreation` is a documented but
  effectively read-only aggregate field on Azure DevOps' side (confirmed against
  [microsoft/azure-devops-go-api#133](https://github.com/microsoft/azure-devops-go-api/issues/133));
  now drives the two fields that actually work
  (`disableClassicBuildPipelineCreation` / `disableClassicReleasePipelineCreation`).
- **`Test-ACLListforChanges`**: fixed a status returned as `NotFound` where the code's own
  comment said it should be `Changed` — `NotFound` gets read as `Ensure = Absent`, so `Set`
  never actually applied the permission.
- **`Find-Identity`**: groups loaded by the module's init-time cache warm-up were never
  enriched with `.ACLIdentity`, silently producing ACEs with a `$null` descriptor for any
  pre-existing group. Also replaced a full org-wide group list scan with a targeted
  get-by-descriptor lookup for groups resolved after cache init.
- **`ConvertTo-ACETokenList`**: strips the `ReadProcessPermissions` bit before sending
  Process-namespace ACEs — Azure DevOps rejects it with a `500 VS403284: ... reserved by
  the system`, and because the Set path's error handling is non-terminating, that failure
  was silently poisoning the *entire* batched ACE write (every identity in the same call).
- **`AzDoSecurityNamespacePermission`**: three compounding bugs that together explain why
  this resource (and namespaces like `Build` in particular) never converged:
  1. `Set-*` merged the entire org-wide namespace ACL cache into every single-ACE request
     (confirmed via live wire capture: ~11,000 lines of JSON for one ACE update, accepted
     but never persisted).
  2. `Get-*` had the same unscoped-fetch problem on the read side, plus queried using the
     human-readable project name instead of the API's actual wire-format token (bare
     project GUID for `Build`).
  3. The real reason nothing ever converged, independent of the above: a client-side
     filter compared against a field (`.Token.TokenValue`) that `Parse-ACLToken` only
     populates for its `Generic`/unrecognised-namespace fallback — for every
     explicitly-handled type it's always `$null`, so the filter matched nothing,
     unconditionally, since it was first written.
- **`New-ACLToken`**: added a live-API fallback (`Resolve-AzDoProjectIdForToken`) for the
  `Build`/`Library`/`ServiceEndpoints`/`DistributedTask`/`Git` branches, which previously
  built a token with a silently-`$null` `ProjectId` on a cache miss.
- **`Set-AzDoPermission`**: fixed a crash on the first-ever `Set` for several permission
  resources. `Clear-AzDoACE`'s own `-DifferenceACLs` parameter is `Mandatory` with no null
  allowance; `Set-AzDoPermission` called it unconditionally whenever `-ClearACEs` was
  passed, even when `-DifferenceACLs` was `$null` (true for any resource whose `Get`
  returns a genuine `$null`, rather than an empty array, when no live ACL exists yet).
  Found via the full integration suite: `AzDoAgentPoolPermission`,
  `AzDoEnvironmentPermission`, `AzDoServiceConnectionPermission` and
  `AzDoVariableGroupPermission` all failed their "Setting permissions" contexts with
  `Cannot bind argument to parameter 'DifferenceACLs' because it is null.` (16 failures
  total). Fixed once at the shared call site so it protects every resource using the same
  pattern.
- Misc: `AzDoTeamSettings` iteration-path comparison/ordering, `Format-AzDoAreaPath`
  double-prefix bug, `AzDoBranchPolicy` display-name lookup, live-API fallback on cache
  miss for `AgentPool`/`AgentQueue`/`Extension`/`PipelineEnvironment`, agent pool
  deployment-type filtering.

### New tests

- `AzDoSecurityAuditorsMultiNamespace.tests.ps1` (new): chains one identity through
  `AzDoProjectPermission → AzDoSecurityNamespacePermission(Build) → AzDoProcessPermission
  → AzDoIterationPermission` in a single session, matching production's dependency order.
  This is what actually reproduced the bugs above — every existing test only ever
  exercised one resource type/identity in isolation, so none of them caught this class of
  issue. Also includes a regression check re-testing earlier steps after later ones touch
  the same identity.
- Extended `AzDoProcessPermission.tests.ps1` with multi-identity and
  per-process-scope (vs. `AllProcesses` root) coverage.
- Extended `AzDoArtifactFeed.tests.ps1` with organization-scoped coverage.

## Test plan

- [x] Full multi-namespace chain (`AzDoSecurityAuditorsMultiNamespace.tests.ps1`) run
      against `akkodistestorg`: `SecurityNamespacePermission` and `ProcessPermission` both
      now show `Status: Unchanged` (exact Reference/Difference ACL match), down from
      300-450+ second failures to single-digit-second convergence.
- [x] **Full integration suite** (`Invoke-Tests.ps1`, all `tests/Integration/Resources/*`,
      ~73 min) run end-to-end against `akkodistestorg`: **372 passed, 17 failed, 14 skipped**
      (skips are pre-existing licensing-tier gates on `AuditStream`/`UserEntitlement`,
      unrelated to this PR). All 17 failures triaged to exactly two causes:
      - 16 failures (`AgentPoolPermission`, `EnvironmentPermission`,
        `ServiceConnectionPermission`, `VariableGroupPermission` × 4 each) → the
        `Set-AzDoPermission` `DifferenceACLs` crash above. Fixed and **re-confirmed via a
        targeted re-run of all four files: 32/32 passing.**
      - 1 failure → the known `AzDoProjectPermission` regression-check edge case below,
        not otherwise part of this PR.
- [ ] One known follow-up not covered by this PR: a regression re-check on
      `AzDoProjectPermission` after later resources touch the same identity intermittently
      fails once in the chain test. Filing a separate issue to track (also: audit the ~10
      other permission resources using the same `DescriptorACLList = Get-CacheItem ...
      'LiveACLList'` pattern that caused the `SecurityNamespacePermission` bug, since only
      `SecurityNamespacePermission` and `ProcessPermission` were individually confirmed
      against a large accumulated ACL cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
