### PR TITLE
Fix DescriptorACLList oversized-payload bug in 8 more permission resources

### DIFF
--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoAgentPoolPermission/Set-AzDoAgentPoolPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoAgentPoolPermission/Set-AzDoAgentPoolPermission.ps1
@@ -23,9 +23,14 @@ Function Set-AzDoAgentPoolPermission
     }
     if (-not $SecurityNamespace) { Write-Error "[Set-AzDoAgentPoolPermission] Namespace not found."; return }
     $matchToken = if ($Pool) { $LocalizedDataAzSerializationPatten.AgentPoolPermission -f $Pool.id } else { '.*' }
+    # DescriptorACLList intentionally empty: 'merge=false' on the Set-AzDoPermission POST replaces the
+    # ACL per-token (only tokens present in the request body are touched), so there is no need to
+    # re-submit every other token's ACL. Merging in the whole namespace-wide 'LiveACLList' cache (as
+    # this used to) meant the request body grew with every OTHER pool's cached ACL across the org -
+    # same bug/fix as Set-AzDoSecurityNamespacePermission.ps1.
     $serializeACLParams = @{
         ReferenceACLs        = $LookupResult.propertiesChanged
-        DescriptorACLList    = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'
+        DescriptorACLList    = @()
         DescriptorMatchToken = $matchToken
     }
     $params = @{

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoAreaPermission/Set-AzDoAreaPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoAreaPermission/Set-AzDoAreaPermission.ps1
@@ -59,10 +59,14 @@ Function Set-AzDoAreaPermission
 
     $token = $(($LookupResult.identifiers | ForEach-Object { "vstfs:///Classification/Node/{0}" -f $_ }) -join ':')
 
-    # More work is needed here.
+    # DescriptorACLList intentionally empty: 'merge=false' on the Set-AzDoPermission POST replaces the
+    # ACL per-token (only tokens present in the request body are touched), so there is no need to
+    # re-submit every other token's ACL. Merging in the whole namespace-wide 'LiveACLList' cache (as
+    # this used to) meant the request body grew with every OTHER area node's cached ACL across every
+    # project - same bug/fix as Set-AzDoSecurityNamespacePermission.ps1 / Set-AzDoIterationPermission.ps1.
     $serializeACLParams = @{
         ReferenceACLs = $LookupResult.propertiesChanged
-        DescriptorACLList = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'
+        DescriptorACLList = @()
         DescriptorMatchToken = $token
     }
 

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoEnvironmentPermission/Set-AzDoEnvironmentPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoEnvironmentPermission/Set-AzDoEnvironmentPermission.ps1
@@ -15,9 +15,12 @@ Function Set-AzDoEnvironmentPermission
     $SecurityNamespace = Get-CacheItem -Key 'DistributedTask' -Type 'SecurityNamespaces'
     $Project           = Get-CacheItem -Key $ProjectName -Type 'LiveProjects'
     if ((-not $SecurityNamespace) -or (-not $Project)) { Write-Error "[Set-AzDoEnvironmentPermission] Cache miss."; return }
+    # DescriptorACLList intentionally empty: 'merge=false' on the Set-AzDoPermission POST replaces the
+    # ACL per-token, so there is no need to re-submit every other token's ACL - same bug/fix as
+    # Set-AzDoSecurityNamespacePermission.ps1.
     $serializeACLParams = @{
         ReferenceACLs        = $LookupResult.propertiesChanged
-        DescriptorACLList    = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'
+        DescriptorACLList    = @()
         DescriptorMatchToken = ($LocalizedDataAzSerializationPatten.EnvironmentPermission -f $Project.id)
     }
     $params = @{

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Set-AzDoGitPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGitPermission/Set-AzDoGitPermission.ps1
@@ -48,10 +48,12 @@ Function Set-AzDoGitPermission
     #
     # Serialize the ACLs
 
-    # More work is needed here.
+    # DescriptorACLList intentionally empty: 'merge=false' on the Set-AzDoPermission POST replaces the
+    # ACL per-token, so there is no need to re-submit every other token's (repo's) ACL - same bug/fix
+    # as Set-AzDoSecurityNamespacePermission.ps1.
     $serializeACLParams = @{
         ReferenceACLs = $LookupResult.propertiesChanged
-        DescriptorACLList = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'
+        DescriptorACLList = @()
         DescriptorMatchToken = ($LocalizedDataAzSerializationPatten.GitRepository -f $Project.id)
     }
 

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGroupPermission/Set-AzDoGroupPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoGroupPermission/Set-AzDoGroupPermission.ps1
@@ -84,11 +84,12 @@ Function Set-AzDoGroupPermission
     #
     # Serialize the ACLs
 
-    # The cache key for a token-scoped ACL fetch is "{namespaceId}|{token}"; the old whole-namespace
-    # key no longer exists. Fall back to an empty list so ConvertTo-ACLHashtable still works — the
-    # accesscontrollists POST endpoint merges, so omitting other groups' ACLs is harmless.
-    $cachedACLList = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'
-    if ($null -eq $cachedACLList) { $cachedACLList = @() }
+    # DescriptorACLList intentionally empty: 'merge=false' on the Set-AzDoPermission POST replaces the
+    # ACL per-token, so there is no need to re-submit every other token's (group's) ACL - same bug/fix
+    # as Set-AzDoSecurityNamespacePermission.ps1. (The old whole-namespace 'LiveACLList' cache key this
+    # used to look up no longer exists since ACL fetches became token-scoped, so this was already a
+    # de facto no-op - made explicit here for clarity.)
+    $cachedACLList = @()
 
     $group = Get-CacheItem -Key $GroupName -Type 'LiveGroups'
     $descriptorMatchToken = if ($null -ne $group) {

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelinePermission/Set-AzDoPipelinePermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoPipelinePermission/Set-AzDoPipelinePermission.ps1
@@ -23,9 +23,12 @@ Function Set-AzDoPipelinePermission
         return
     }
 
+    # DescriptorACLList intentionally empty: 'merge=false' on the Set-AzDoPermission POST replaces the
+    # ACL per-token, so there is no need to re-submit every other token's (pipeline's) ACL - same
+    # bug/fix as Set-AzDoSecurityNamespacePermission.ps1.
     $serializeACLParams = @{
         ReferenceACLs        = $LookupResult.propertiesChanged
-        DescriptorACLList    = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'
+        DescriptorACLList    = @()
         DescriptorMatchToken = ($LocalizedDataAzSerializationPatten.BuildPermission -f $Project.id)
     }
 

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceConnectionPermission/Set-AzDoServiceConnectionPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoServiceConnectionPermission/Set-AzDoServiceConnectionPermission.ps1
@@ -22,9 +22,12 @@ Function Set-AzDoServiceConnectionPermission
         if ($Project) { Add-CacheItem -Key $ProjectName -Value $Project -Type 'LiveProjects' }
     }
     if ((-not $SecurityNamespace) -or (-not $Project)) { Write-Error "[Set-AzDoServiceConnectionPermission] Cache miss."; return }
+    # DescriptorACLList intentionally empty: 'merge=false' on the Set-AzDoPermission POST replaces the
+    # ACL per-token, so there is no need to re-submit every other token's (service connection's) ACL -
+    # same bug/fix as Set-AzDoSecurityNamespacePermission.ps1.
     $serializeACLParams = @{
         ReferenceACLs        = $LookupResult.propertiesChanged
-        DescriptorACLList    = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'
+        DescriptorACLList    = @()
         DescriptorMatchToken = ($LocalizedDataAzSerializationPatten.ServiceEndpointPermission -f $Project.id)
     }
     $params = @{

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoVariableGroupPermission/Set-AzDoVariableGroupPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoVariableGroupPermission/Set-AzDoVariableGroupPermission.ps1
@@ -27,9 +27,12 @@ Function Set-AzDoVariableGroupPermission
 
     if ((-not $SecurityNamespace) -or (-not $Project)) { Write-Error "[Set-AzDoVariableGroupPermission] Cache miss."; return }
 
+    # DescriptorACLList intentionally empty: 'merge=false' on the Set-AzDoPermission POST replaces the
+    # ACL per-token, so there is no need to re-submit every other token's (variable group's) ACL - same
+    # bug/fix as Set-AzDoSecurityNamespacePermission.ps1.
     $serializeACLParams = @{
         ReferenceACLs        = $LookupResult.propertiesChanged
-        DescriptorACLList    = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type 'LiveACLList'
+        DescriptorACLList    = @()
         DescriptorMatchToken = ($LocalizedDataAzSerializationPatten.LibraryPermission -f $Project.id)
     }
 


### PR DESCRIPTION
## Summary

Closes the second half of #26 (the first half - a regression re-check for `AzDoProjectPermission`
after other resources touch the same identity - was independently resolved by the ACL
convergence fixes in #28/#29, and re-verified as part of this PR's own live validation, which
runs the full multi-namespace chain in one pass).

Audits and fixes the `DescriptorACLList` oversized-payload anti-pattern already fixed for
`SecurityNamespacePermission` (#27, commit b68e868), `IterationPermission`, and
`ProjectPermission` (#28/#29) in the ~10 other permission resources #26 flagged as never
individually validated:

- `Set-AzDoAgentPoolPermission`
- `Set-AzDoAreaPermission`
- `Set-AzDoEnvironmentPermission`
- `Set-AzDoGitPermission`
- `Set-AzDoPipelinePermission`
- `Set-AzDoServiceConnectionPermission`
- `Set-AzDoVariableGroupPermission`

Each declared `DescriptorACLList = Get-CacheItem -Key $SecurityNamespace.namespaceId -Type
'LiveACLList'`, merging the *entire* namespace-wide ACL cache into every single-token Set
request - the exact same bug that caused the oversized-payload issue in
`SecurityNamespacePermission`. Changed each to `DescriptorACLList = @()`: the accesscontrollists
API's `merge=false` already replaces per-token, so there's no need to resend every other token's
ACL.

Also cleaned up `Set-AzDoGroupPermission`: it looked up the ACL cache by the old whole-namespace
key format, which no longer exists since ACL fetches became token-scoped elsewhere in the
codebase, so it was already silently falling back to an empty list every time. Made that explicit
instead of leaving a dead lookup that reads as if it's doing something it isn't.

**Not in scope for this PR**: the `New-*`/`Remove-*` variants of these same resources carry the
same pattern but only run once at resource creation/deletion, not on every convergence check, so
the blast radius (and the case for prioritizing them) is much smaller. Left as a follow-up.

## Test plan

- [x] Unit tests for all 8 changed functions: 25/25 passing.
- [x] Live LCM Set run against `contoso-engineering-3`: zero SET-phase failures across
      Aurora/Helios/Nimbus, with the same `FAIL=14/15/15` baseline as immediately before this
      change (no regressions introduced across agent pools, area paths, environments, git repos,
      pipelines, service connections, and variable groups).

Closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
