### PR TITLE
Fix DSC resource discovery breaking due to explicit FunctionsToExport/CmdletsToExport

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,39 +1,39 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/powershell
 {
-	"name": "PowerShell",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/powershell:lts-debian-11",
-	"features": {
-		"ghcr.io/devcontainers/features/common-utils:2": {
-			"installZsh": "true",
-			"username": "vscode",
-			"upgradePackages": "false",
-			"nonFreePackages": "true"
-		}
-	},
+    "name": "PowerShell",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/powershell:lts-debian-11",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": "true",
+            "username": "vscode",
+            "upgradePackages": "false",
+            "nonFreePackages": "true"
+        }
+    },
 
-	"postCreateCommand": "sudo chsh vscode -s \"$(which pwsh)\"",
+    "postCreateCommand": "sudo chsh vscode -s \"$(which pwsh)\"",
 
-	// Configure tool-specific properties.
-	"customizations": {
-		// Configure properties specific to VS Code.
-		"vscode": {
-			// Set *default* container specific settings.json values on container create.
-			"settings": { 
-				"terminal.integrated.defaultProfile.linux": "pwsh"
-			},
-			
-			// Add the IDs of extensions you want installed when the container is created.
-			"extensions": [
-				"ms-vscode.powershell"
-			]
-		}
-	}
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "pwsh"
+            },
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "ms-vscode.powershell"
+            ]
+        }
+    }
 
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # AzureDevOpsDsc
 
+> Note - This repo is mostly unmaintained and as such you may be better looking at [this new DSCv3 version by @mimachniak](https://github.com/mimachniak/AzureDevOpsDscv3)
+> As such @kilasuit who is looking for a replacement maintainer in https://github.com/dsccommunity/AzureDevOpsDsc/issues/44 is recommending this repo be archived unless another maintainer steps up.
+
+
 The **AzureDevOpsDsc** module contains DSC Resources for deployment and
 configuration of Azure DevOps and Azure DevOps Server.
 

--- a/source/AzureDevOpsDsc.psd1
+++ b/source/AzureDevOpsDsc.psd1
@@ -1,44 +1,44 @@
 @{
-    RootModule = 'AzureDevOpsDsc.psm1'
+    RootModule           = 'AzureDevOpsDsc.psm1'
 
     # Version number of this module.
     moduleVersion      = '0.0.2'
 
     # ID used to uniquely identify this module
-    GUID               = '3f8bbada-0fa9-4d80-b3d8-f019c3c60230'
+    GUID                 = '3f8bbada-0fa9-4d80-b3d8-f019c3c60230'
 
     # Author of this module
-    Author             = 'DSC Community'
+    Author               = 'DSC Community'
 
     # Company or vendor of this module
-    CompanyName        = 'DSC Community'
+    CompanyName          = 'DSC Community'
 
     # Copyright statement for this module
-    Copyright          = 'Copyright the DSC Community contributors. All rights reserved.'
+    Copyright            = 'Copyright the DSC Community contributors. All rights reserved.'
 
     # Description of the functionality provided by this module
-    Description        = 'Module with DSC Resources for deployment and configuration of Azure DevOps Server/Services.'
+    Description          = 'Module with DSC Resources for deployment and configuration of Azure DevOps Server/Services.'
 
     # Minimum version of the Windows PowerShell engine required by this module
     PowerShellVersion  = '7.0'
 
     # Minimum version of the common language runtime (CLR) required by this module
-    CLRVersion         = '4.0'
+    CLRVersion           = '4.0'
 
     # Functions to export from this module
-    #FunctionsToExport  = @()
+    #FunctionsToExport    = @()
 
     # Cmdlets to export from this module
-    #CmdletsToExport    = @()
+    #CmdletsToExport      = @()
 
     # Variables to export from this module
     VariablesToExport  = @()
 
     # Aliases to export from this module
-    AliasesToExport    = @()
+    AliasesToExport      = @()
 
     # Import all the 'DSCClassResource', modules as part of this module
-    NestedModules = @()
+    NestedModules        = @()
 
     DscResourcesToExport = @(
       'AzDevOpsProject',
@@ -93,10 +93,10 @@
       'AzDoPipelineSettings'
     )
 
-    RequiredAssemblies = @()
+    RequiredAssemblies   = @()
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
-    PrivateData        = @{
+    PrivateData          = @{
 
         PSData = @{
             # Set to a prerelease string value if the release should be a prerelease.


### PR DESCRIPTION
## Summary

Rebases PR #20's actual intent onto current `main` and fixes a real bug the original PR would
have introduced along the way.

The original PR description:

1. **DevContainer Configuration**: Converted indentation from tabs to spaces (4-space
   indentation) for consistency with JSON formatting standards in `.devcontainer/devcontainer.json`.
2. **Module Manifest Formatting**: Aligned property assignments in `source/AzureDevOpsDsc.psd1`
   for improved readability. Also uncommented `FunctionsToExport` and `CmdletsToExport`
   properties that were previously commented out.
3. **Repository Documentation**: Added a maintenance notice to `README.md` indicating that the
   repository is mostly unmaintained and directing users to the newer DSCv3 version, along with
   information about seeking a replacement maintainer.

Items 1 and 3 are carried over unchanged. Item 2's alignment is also carried over, but **the
`FunctionsToExport`/`CmdletsToExport` uncomment is reverted** - confirmed live that this
specific, intentional change breaks `Get-DscResource` entirely for this module:

- With `FunctionsToExport`/`CmdletsToExport` commented out (original/current `main` state):
  `Get-DscResource -Module AzureDevOpsDsc` finds all 40+ class-based resources normally.
- With them uncommented to explicit `@()` (as this PR originally proposed): `Get-DscResource`
  returns **zero** resources, and the full integration suite fails at the first resource lookup
  (`The term 'AzDoProject' is not recognized as the name of a Resource.`).

This module exposes its DSC resources through the separate `DscResourcesToExport` manifest
field, not `FunctionsToExport`/`CmdletsToExport` - those two apply to regular exported
functions/cmdlets, which is a different mechanism from class-based DSC resource discovery.
Setting them to an explicit empty array is reasonable-looking manifest hygiene in general, but
for this project it silently breaks `Get-DscResource`'s reflection-based resource discovery.
Reproduced this cleanly and repeatedly across multiple rebuild/redeploy cycles, and ruled out
environment/deployment artifacts by confirming a known-good branch kept working immediately
before and after toggling just this one manifest field.

## Test plan

- [x] Unit tests: 1606 Common + 164 Classes passed, matching the established `main` baseline
      exactly (0 new failures).
- [x] Full elevated integration suite against `akkodistestorg`: 389 Passed, 0 Failed, 14 Skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
