### PR TITLE
Fix DSC Community style guide violations introduced in #28

### DIFF
--- a/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Format-AzDoIterationPath.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Helper/Format-AzDoIterationPath.ps1
@@ -20,9 +20,12 @@ Function Format-AzDoIterationPath {
             # without the \Iteration\ segment. Strip that prefix first so it isn't duplicated -
             # blindly prepending "$ProjectName\Iteration\" here previously produced malformed
             # paths like "Project\Iteration\Project\Sprint 1".
-            if ($Path -eq $ProjectName) {
+            if ($Path -eq $ProjectName)
+            {
                 $Path = ''
-            } elseif ($Path.StartsWith("$ProjectName\")) {
+            }
+            elseif ($Path.StartsWith("$ProjectName\"))
+            {
                 $Path = $Path.Substring("$ProjectName\".Length)
             }
             $Path = if ($Path) { "$ProjectName\Iteration\$Path" } else { "$ProjectName\Iteration" }

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProjectPermission/Get-AzDoProjectPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProjectPermission/Get-AzDoProjectPermission.ps1
@@ -123,8 +123,10 @@ Function Get-AzDoProjectPermission
     # Managers requests START_BUILD: Allow) are unaffected since Allow/Deny are compared separately.
     # Strip it from the live side only, so we stop fighting a bit we don't manage - same rationale as
     # ConvertTo-ACETokenList's reserved-bit stripping for Process/ReadProcessPermissions.
-    foreach ($ace in $DifferenceACLs[0].aces) {
-        if ($ace.Permissions.Deny) {
+    foreach ($ace in $DifferenceACLs[0].aces)
+    {
+        if ($ace.Permissions.Deny)
+        {
             $ace.Permissions.Deny = @($ace.Permissions.Deny | Where-Object { $_.bit -ne 32 })
         }
     }

--- a/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProjectPermission/Set-AzDoProjectPermission.ps1
+++ b/source/Modules/AzureDevOpsDsc.Common/Resources/Functions/Public/AzDoProjectPermission/Set-AzDoProjectPermission.ps1
@@ -48,7 +48,14 @@ Function Set-AzDoProjectPermission
     $targetDescriptors = @($LookupResult.propertiesChanged.aces | ForEach-Object { $_.Identity.value.ACLIdentity.descriptor } | Where-Object { $_ })
     if ($targetDescriptors)
     {
-        $clearInput = @(@{ token = @{ _token = $projectToken }; aces = $LookupResult.propertiesChanged.aces })
+        $clearInput = @(
+            @{
+                token = @{
+                    _token = $projectToken
+                }
+                aces  = $LookupResult.propertiesChanged.aces
+            }
+        )
         Clear-AzDoACE -OrganizationName $OrganizationName -SecurityNamespaceID $SecurityNamespace.namespaceId -DifferenceACLs $clearInput
     }
 


### PR DESCRIPTION
## Summary

Ran the project's own PSScriptAnalyzer configuration (`Indented.ScriptAnalyzerRules` +
`DscResource.AnalyzerRules` + `PSSA_rules_config.json` - the same rules the `hqrmtest` build
task uses) against every file changed in #28, and cross-referenced each finding against the
actual diff to separate genuinely-new code from pre-existing repo conventions (e.g. capitalized
`Function`/`param(` placement, used identically throughout the whole codebase - not touched
here, out of scope for this PR).

Three real violations in code added by #28:

- `Format-AzDoIterationPath.ps1`: an `if`/`elseif` with the opening brace on the same line as
  the statement - the style guide requires Allman-style (brace on its own line).
- `Get-AzDoProjectPermission.ps1`: same issue in the new START_BUILD-bit-stripping
  `foreach`/`if` block.
- `Set-AzDoProjectPermission.ps1`: the `$clearInput` hashtable (including its nested `token`
  hashtable) was written inline with semicolons instead of one key-value pair per line, which
  the project's `Measure-Hashtable` rule requires even for small hashtables.

No logic changes - purely brace placement and hashtable layout.

## Test plan

- [x] PSScriptAnalyzer re-run: all three findings gone, no new ones introduced.
- [x] Unit tests: 1606 Common + 164 Classes passed, matching the established `main` baseline
      exactly (0 new failures).
- [x] Full elevated integration suite against `akkodistestorg`: 389 Passed, 0 Failed, 14 Skipped -
      identical to #28's original clean run, confirming these are pure formatting changes with
      no behavioral difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
