### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Module and Generate DSC v3 Manifests


### PR DESCRIPTION
Potential fix for [https://github.com/ZanattaMichael/AzureDevOpsDsc/security/code-scanning/2](https://github.com/ZanattaMichael/AzureDevOpsDsc/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/build.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal and appropriate permission is:

- `contents: read`

This preserves existing functionality (checkout/build/cache/artifact upload) while ensuring the token cannot silently inherit broader write access.

Change region: insert the block after the `on:` triggers and before `jobs:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
