### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Run Unit Tests


### PR DESCRIPTION
Potential fix for [https://github.com/ZanattaMichael/AzureDevOpsDsc/security/code-scanning/1](https://github.com/ZanattaMichael/AzureDevOpsDsc/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/unit-tests.yml` to restrict `GITHUB_TOKEN` privileges.

Best fix without changing functionality:
- Add `permissions:` at the workflow root (after triggers and before `jobs`), with:
  - `contents: read`
- This is sufficient for checkout and typical read operations; it also satisfies CodeQL’s minimal recommendation.
- No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
