### PR TITLE
Fix docs task failure blocking release, and remove phantom exported DSC resource

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,11 +115,17 @@ jobs:
       # `docs` must run here, not just `dscv3`: Generate_Conceptual_Help writes the
       # about_*.help.txt files into the *built* module, so skipping it ships a Gallery
       # package with no conceptual help. It also produces output/WikiContent, which the
-      # wiki publish step below consumes.
-      - name: Generate docs and DSC v3 manifests, and package module
+      # wiki publish step below consumes. Kept as its own step so a doc-generation
+      # failure is attributable at a glance rather than hidden inside packaging.
+      - name: Generate documentation
         shell: pwsh
         run: |
-          ./build.ps1 -Tasks docs,dscv3,package_module_nupkg
+          ./build.ps1 -Tasks docs
+
+      - name: Generate DSC v3 manifests and package module
+        shell: pwsh
+        run: |
+          ./build.ps1 -Tasks dscv3,package_module_nupkg
 
       # Both sub-tasks self-guard on their own token being set, so this is safe to run
       # even if GALLERY_API_TOKEN isn't configured yet - it just skips the Gallery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - AzureDevOpsDscNative
+  - Fixed the `docs` build task, which failed with `Cannot index into a null
+    array` and broke the Build workflow. The comment-based help in
+    `042.AzDoAreaPermission.ps1` and `043.AzDoIterationPermission.ps1` used a
+    `.METHOD` keyword, which PowerShell's help parser does not recognise - it
+    rejects the entire help block and `GetHelpContent()` returns `$null`, which
+    `DscResource.DocGenerator`'s `New-DscResourcePowerShellHelp` then indexes
+    into. The method documentation is folded into `.NOTES` instead, and the
+    placeholder `<link to the GitHub repository>` in both `.LINK` sections is
+    replaced with the actual repository URL. All 49 resource classes now produce
+    conceptual help.
+  - Removed `AzDevOpsProject` from `DscResourcesToExport`. No class, MOF schema,
+    or any other implementation of that resource exists - it is a leftover from
+    the upstream module - so the manifest advertised 50 resources while shipping
+    49, and the Gallery listing would have claimed a resource that could never
+    be found by `Get-DscResource`. Also added a missing comma after
+    `AzDoProcessPermission` in the same list.
   - Removed the `build-publish.yml` workflow. It triggered on the same version
     tags as `publish.yml`, so every release ran two competing publishes. Its
     publish job could never succeed - it looked for the built module at

--- a/source/AzureDevOpsDscNative.psd1
+++ b/source/AzureDevOpsDscNative.psd1
@@ -46,7 +46,6 @@
     NestedModules        = @()
 
     DscResourcesToExport = @(
-      'AzDevOpsProject',
       'AzDoGroupPermission',
       'AzDoOrganizationGroup',
       'AzDoProject',
@@ -92,7 +91,7 @@
       'AzDoArtifactFeedSettings',
       'AzDoArtifactFeedView',
       'AzDoProcess',
-      'AzDoProcessPermission'
+      'AzDoProcessPermission',
       'AzDoUserEntitlement',
       'AzDoServiceHook',
       'AzDoPipelineSettings'

--- a/source/Classes/042.AzDoAreaPermission.ps1
+++ b/source/Classes/042.AzDoAreaPermission.ps1
@@ -13,8 +13,17 @@ It inherits from the `AzDevOpsDscResourceBase` class and provides methods for re
 - This class is part of the AzureDevOpsDsc module.
 - The `Test()` and `Set()` methods are inherited from the base class `AzDevOpsDscResourceBase`.
 
+Methods:
+
+- `Get()` retrieves the current state of the area permissions as an instance of
+  the `AzDoAreaPermission` class.
+- `GetDscResourcePropertyNamesWithNoSetSupport()` returns an array of property
+  names that do not support the `Set` operation. This method is hidden.
+- `GetDscCurrentStateProperties()` retrieves the current state properties of the
+  resource as a hashtable. This method is hidden.
+
 .LINK
-    GitHub Repository: <link to the GitHub repository>
+    GitHub Repository: https://github.com/ZanattaMichael/AzureDevOpsDsc
 
 .PARAMETER ProjectName
 Specifies the name of the Azure DevOps project. This is a mandatory key property.
@@ -27,15 +36,6 @@ Indicates whether the permissions are inherited. Defaults to `$true`.
 
 .PARAMETER Permissions
 Specifies a hashtable array of permissions to be applied to the area.
-
-.METHOD Get
-Retrieves the current state of the iteration permissions as an instance of the `AzDoIterationPermission` class.
-
-.METHOD GetDscResourcePropertyNamesWithNoSetSupport
-Returns an array of property names that do not support the `Set` operation. This method is hidden.
-
-.METHOD GetDscCurrentStateProperties
-Retrieves the current state properties of the resource as a hashtable. This method is hidden.
 
 .EXAMPLE
 # Example usage of the AzDoAreaPermission DSC resource

--- a/source/Classes/043.AzDoIterationPermission.ps1
+++ b/source/Classes/043.AzDoIterationPermission.ps1
@@ -13,8 +13,17 @@ It inherits from the `AzDevOpsDscResourceBase` class and provides properties and
 - The `Get()` and `Set()` methods are inherited from the base class `AzDevOpsDscResourceBase`.
 - The `GetDscCurrentStateProperties` method includes verbose logging for debugging purposes.
 
+Methods:
+
+- `Get()` retrieves the current state of the iteration permissions as an instance
+  of the `AzDoIterationPermission` class.
+- `GetDscResourcePropertyNamesWithNoSetSupport()` returns an array of property
+  names that do not support the `Set` operation. This method is hidden.
+- `GetDscCurrentStateProperties()` retrieves the current state properties of the
+  resource as a hashtable. This method is hidden.
+
 .LINK
-    GitHub Repository: <link to the GitHub repository>
+    GitHub Repository: https://github.com/ZanattaMichael/AzureDevOpsDsc
 
 .PARAMETER ProjectName
 Specifies the name of the Azure DevOps project. This is a mandatory key property.
@@ -27,15 +36,6 @@ Indicates whether the permissions are inherited. Defaults to `$true`.
 
 .PARAMETER Permissions
 Specifies a hashtable array of permissions to be applied to the iteration.
-
-.METHOD Get
-Retrieves the current state of the iteration permissions as an instance of the `AzDoIterationPermission` class.
-
-.METHOD GetDscResourcePropertyNamesWithNoSetSupport
-Returns an array of property names that do not support the `Set` operation. This method is hidden.
-
-.METHOD GetDscCurrentStateProperties
-Retrieves the current state properties of the resource as a hashtable. This method is hidden.
 
 .EXAMPLE
 # Example usage of the AzDoIterationPermission DSC resource


### PR DESCRIPTION
#### Pull Request (PR) description

**Build is currently red on `main`** ([run 31929426227](https://github.com/ZanattaMichael/AzureDevOpsDsc/actions/runs/31929426227)), and the same failure would abort a release — `publish.yml` runs `docs` while packaging. This unblocks both.

##### The `docs` failure

`Generate_Conceptual_Help` dies with `Cannot index into a null array` inside `DscResource.DocGenerator`'s `New-DscResourcePowerShellHelp`.

Root cause: the comment-based help in `042.AzDoAreaPermission.ps1` and `043.AzDoIterationPermission.ps1` uses a **`.METHOD`** keyword. PowerShell's help parser doesn't recognise it and rejects the *entire* help block, so `GetHelpContent()` returns `$null`; DocGenerator then does `$help.Parameters[$prop.Name.ToUpper()]` on that null ([line 377](https://github.com/dsccommunity/DscResource.DocGenerator/blob/v0.13.0/source/Public/New-DscResourcePowerShellHelp.ps1)).

I reproduced this locally by replaying DocGenerator's own extraction logic against all 49 resource classes — exactly those two returned `$null`, and both pass once `.METHOD` is removed:

```
BEFORE                                          AFTER
  AzDoAreaPermission      GetHelpContent() NULL    No class reproduces the failure
  AzDoIterationPermission GetHelpContent() NULL    Total classes scanned: 49
```

The method documentation is folded into `.NOTES`, which carries the same content in a form the parser accepts. The placeholder `<link to the GitHub repository>` in both `.LINK` sections is replaced with the real URL, since that text ships in the generated help.

`.METHODS` also appears in `002.PersonalAccessToken.ps1` and `007.APIRateLimit.ps1`, but those aren't `[DscResource()]` classes so DocGenerator never parses them — left alone.

##### Phantom exported resource

`DscResourcesToExport` listed **`AzDevOpsProject`**, for which no class, MOF schema, or any other implementation exists anywhere in `source/` — a leftover from the upstream module. The manifest advertised 50 resources while shipping 49, so the Gallery listing would have claimed a resource `Get-DscResource` could never return. The exported list now matches the 49 class files exactly (verified with `Compare-Object`). A missing comma after `AzDoProcessPermission` in the same list is fixed too.

##### Workflow

`publish.yml` splits `docs` into its own step so a doc-generation failure is attributable at a glance rather than hidden inside the packaging step.

##### Verification

Run against real PowerShell 7.4.6:
- DocGenerator's help-extraction path replayed over all 49 resource classes — no nulls, and no throw from the per-property `Parameters[...]` lookup that follows.
- All 60 class files parse with no syntax errors.
- `Import-PowerShellDataFile` on the manifest succeeds; `DscResourcesToExport` (49) compares equal to the discovered class list (49).

The full Sampler build still hasn't been run here (Linux container, Windows-targeted module) — CI on this PR is the real check, and the Build workflow now exercises `docs` on every push.

#### This Pull Request (PR) fixes the following issues

None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [x] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iuTRf59PpW7us9Yty15Zg

---
_Generated by [Claude Code](https://claude.ai/code/session_019iuTRf59PpW7us9Yty15Zg)_