### PR TITLE
Let a prerelease tag ship despite individual integration test failures

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,8 +15,19 @@ name: Integration Tests
 
 on:
   workflow_dispatch:
-  # Called by publish.yml as a release gate. A release does not proceed unless every
-  # integration test in this workflow passes.
+    inputs:
+      allowFailures:
+        description: >-
+          Exit 0 even if individual integration tests fail (setup/infrastructure
+          failures still fail the run). Useful for running the suite on a preview
+          branch without gating on flaky tests.
+        required: false
+        default: false
+        type: boolean
+  # Called by publish.yml as a release gate. A full release does not proceed unless every
+  # integration test passes; a prerelease (vX.Y.Z-<suffix>) passes allowFailures=true so
+  # the release still proceeds despite individual test failures, while any environmental
+  # break (Pester missing, module not resolving, etc.) still fails the gate.
   workflow_call:
     inputs:
       moduleVersion:
@@ -26,6 +37,13 @@ on:
           Left empty, the build falls back to the manifest version.
         required: false
         type: string
+      allowFailures:
+        description: >-
+          Exit 0 even if individual integration tests fail. Set by publish.yml on a
+          prerelease tag. Setup/infrastructure failures still fail the run.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -170,8 +188,17 @@ jobs:
       - name: Run integration tests
         shell: pwsh
         working-directory: tests/Integration
+        env:
+          # Booleans from workflow inputs arrive as PowerShell literals. Normalise to a
+          # bare 'true'/'false' string so the pwsh block below can treat it uniformly.
+          ALLOW_FAILURES: ${{ inputs.allowFailures && 'true' || 'false' }}
         run: |
-          .\Invoke-Tests.ps1 -TestFrameworkConfigurationPath .\TestFrameworkConfiguration.json
+          $params = @{ TestFrameworkConfigurationPath = '.\TestFrameworkConfiguration.json' }
+          if ($env:ALLOW_FAILURES -eq 'true') {
+              Write-Host 'AllowFailures is enabled - test failures will be reported but will not fail this run.'
+              $params['AllowFailures'] = $true
+          }
+          .\Invoke-Tests.ps1 @params
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,10 +77,17 @@ jobs:
           }
           Write-Host "Tag commit is contained in main."
 
-  # Release gate: every integration test must pass before anything is published.
+  # Release gate: the integration suite must run before anything is published.
   # This reuses integration-tests.yml rather than duplicating it, so the release runs
   # exactly the suite that is maintained there, on its self-hosted AZDO-AGENT runner.
   # If the runner is offline the release queues here rather than failing.
+  #
+  # For a full release (vX.Y.Z) every test must pass. For a prerelease
+  # (vX.Y.Z-<suffix>) allowFailures is set, so individual test failures are logged as
+  # warnings and the release still proceeds - preview builds can ship despite flaky or
+  # in-progress tests. Setup/infrastructure failures (Pester missing, module not
+  # resolving, no test result object) still fail the gate in both modes, so a broken
+  # environment cannot silently pass.
   integration-tests:
     name: Integration Tests (release gate)
     needs: validate
@@ -88,6 +95,7 @@ jobs:
     secrets: inherit
     with:
       moduleVersion: ${{ needs.validate.outputs.version }}
+      allowFailures: ${{ needs.validate.outputs.isPrerelease == 'true' }}
 
   publish:
     name: Build, Test, and Publish Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- AzureDevOpsDscNative
+  - The integration-test release gate now differentiates between a full release
+    and a prerelease. A full release tag (`vX.Y.Z`) still requires every
+    integration test to pass; a prerelease tag (`vX.Y.Z-<suffix>`) passes
+    `allowFailures=true` to the integration workflow, so individual test failures
+    are logged as warnings but the release still proceeds - preview builds can
+    ship despite flaky or in-progress tests. Setup and infrastructure failures
+    (Pester missing, module not resolving, no test result at all) still fail the
+    gate in both modes, so a broken environment cannot silently pass. Implemented
+    by an `-AllowFailures` switch on `Invoke-Tests.ps1` and an `allowFailures`
+    input on `integration-tests.yml` that `publish.yml` sets from the tag.
+
 ### Added
 
 - AzureDevOpsDsc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -970,8 +970,14 @@ each gating the next.
 
 3. Calls `integration-tests.yml` as a reusable workflow, building the exact
    version being released and running the full suite against the live Azure
-   DevOps organization. **If any integration test fails, the release fails and
-   nothing is published.**
+   DevOps organization. **For a full release (`vX.Y.Z`), any integration test
+   failure fails the release and nothing is published.** For a **prerelease**
+   (`vX.Y.Z-<suffix>`), the workflow passes `allowFailures=true`: individual
+   test failures are logged as warnings but the release still proceeds, so a
+   preview build can ship despite flaky or in-progress tests. Setup and
+   infrastructure failures — Pester missing, module not resolving, or no test
+   result at all — still fail the gate in both modes, so a broken environment
+   can never silently pass.
 
    This job runs on the self-hosted `AZDO-AGENT` runner with no approval gate, so
    it starts as soon as the runner is free. The suite is slow — the

--- a/tests/Integration/Invoke-Tests.ps1
+++ b/tests/Integration/Invoke-Tests.ps1
@@ -1,7 +1,15 @@
 #Requires -Modules @{ ModuleName="Pester"; ModuleVersion="5.0.0" }
 param(
     [Parameter(Mandatory = $true)]
-    [String]$TestFrameworkConfigurationPath
+    [String]$TestFrameworkConfigurationPath,
+
+    # When set, individual test failures are logged as a warning and the script exits 0
+    # provided the suite genuinely ran (Pester returned a result object with at least one
+    # test executed). Setup/infrastructure failures - Pester never started, module resolution
+    # failed, etc. - still exit non-zero, so a broken environment cannot silently pass.
+    # The publish workflow passes this on a prerelease tag to let a preview release proceed
+    # despite flaky or in-progress tests, without weakening the gate for a full release.
+    [switch]$AllowFailures
 )
 
 #
@@ -106,6 +114,16 @@ Write-Host ("[Invoke-Tests] Passed: {0}, Failed: {1}, Skipped: {2}, NotRun: {3}"
 
 if ($testResults.FailedCount -gt 0)
 {
+    if ($AllowFailures.IsPresent -and $testResults.PassedCount -gt 0)
+    {
+        # In allow-failures mode (prerelease), let the release proceed but leave a loud,
+        # machine-parseable record so the run summary still shows what failed. The
+        # PassedCount > 0 guard ensures we only tolerate real test failures, not a run
+        # where every test blew up in setup - that stays a hard failure.
+        Write-Warning ("[Invoke-Tests] {0} integration test(s) failed. AllowFailures is set (prerelease), exiting 0." -f $testResults.FailedCount)
+        exit 0
+    }
+
     Write-Error ("[Invoke-Tests] {0} integration test(s) failed." -f $testResults.FailedCount)
     exit 1
 }


### PR DESCRIPTION
#### Pull Request (PR) description

The `v1.0.0-preview01` release was blocked because **one** test flaked — `AzDoWIPTags` "add and remove multiple tags" (380 passed / 1 failed), the same `/wit/tags` eventual-consistency issue tracked as #44. My best-effort retry in `New-WITTags` helped (a prior full run got 381/0) but didn't fully cure the flake.

For a preview that's exactly the kind of failure the release should tolerate. For a full release it must remain a hard gate. This PR makes that split explicit.

##### How it works

**`Invoke-Tests.ps1`** — new `-AllowFailures` switch. When set:
- Individual test failures are still recorded (`Passed/Failed` line, per-test log, NUnit artifact upload).
- The script exits **0** *provided the suite really ran* (Pester returned a result object with at least one test executed).
- Setup / infrastructure failures still exit non-zero: Pester never started, module not resolving, no test result object at all, run with 0 passes. A broken environment cannot silently pass under this mode.

**`integration-tests.yml`** — new `allowFailures` boolean input (`workflow_dispatch` + `workflow_call`), threaded through to `Invoke-Tests.ps1`.

**`publish.yml`** — sets:
```yaml
allowFailures: ${{ needs.validate.outputs.isPrerelease == 'true' }}
```

So:

| Tag | Behaviour |
|---|---|
| `vX.Y.Z` | Every integration test must pass (existing behaviour) |
| `vX.Y.Z-<suffix>` | Test failures tolerated, structural failures still block |

##### Why this shape (and not simpler alternatives)

- Not `continue-on-error: true` on the whole gate — that hides real infrastructure breakage (Pester missing, module cast crash, etc.), which we spent this whole cycle *stopping* from being silent.
- Not an `if:` in `publish.yml` — the integration gate should still be visibly attempted and its results still gathered as an artifact for a preview release.
- Not a per-test tolerance list — this codebase doesn't have one, and inventing one for one flake is out of scope for the release-gate work.

##### For the v1.0.0-preview01 tag specifically

GitHub re-runs execute the workflow **at the run's SHA**, not the current one, so re-running the failed publish will keep failing. Once this is merged, either:
- push a fresh prerelease tag (`v1.0.0-preview02`) — it picks up the change immediately, **or**
- delete and re-create `v1.0.0-preview01` at main's new HEAD (destroys the failed run's tag→commit link but works).

##### Verification

- YAML parses for both workflows; `Invoke-Tests.ps1` parses under PowerShell 7.4.6.
- The `-AllowFailures` path is unit-testable inline but I didn't add a Pester test for `Invoke-Tests.ps1` itself — this file is a runner, not a module, and the branch is small enough to inspect. Happy to add one if you'd prefer.

##### Not included (separate PR)

Performance work — I have per-test timings from the last green integration run showing 13 tests > 100s, with `AzDoServiceConnectionPermission` and `AzDoProject.Description` dominating (~19 minutes each per file). That's coming as a separate PR since it's investigation-heavy and would muddy the release-gate change.

#### This Pull Request (PR) fixes the following issues

None directly. Related: #44 (the AzDoWIPTags flake this PR lets a preview tolerate).

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iuTRf59PpW7us9Yty15Zg

---
_Generated by [Claude Code](https://claude.ai/code/session_019iuTRf59PpW7us9Yty15Zg)_