### PR TITLE
Tooling: Add /run-azuredevopsdscnative skill for headless test runs

### DIFF
--- a/.claude/skills/run-azuredevopsdscnative/SKILL.md
+++ b/.claude/skills/run-azuredevopsdscnative/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: run-azuredevopsdscnative
+description: Run, build, and test the AzureDevOpsDscNative PowerShell DSC module. Use whenever the user wants to run tests, run Pester, run the unit tests, run the Common suite, build the module, verify changes to source/, smoke-test a resource, or otherwise drive the module locally. Also for questions like "does this test still pass?" or "does the module still load?".
+---
+
+# run-azuredevopsdscnative
+
+This repo produces one PowerShell module: **AzureDevOpsDscNative** (name from
+`source/AzureDevOpsDscNative.psd1`). It has no runnable app — it's a library
+loaded by DSC. The interesting things to "run" here are the **unit test
+suites** and the **build**.
+
+**Paths in this document are relative to the repo root** (`/home/user/AzureDevOpsDsc`).
+The driver itself lives at `.claude/skills/run-azuredevopsdscnative/driver.sh`.
+
+---
+
+## What this container can and cannot do
+
+| Task | Runs here? | Why |
+|---|---|---|
+| **Common unit suite** (`azuredevopsdsc.common.tests.ps1`) | Yes — via driver | Dot-sources source files. No build needed. ~60s on this container. |
+| **Load-only smoke** (`-LoadModulesOnly`) | Yes — via driver | Confirms every helper/cache/public file parses. |
+| **Classes unit suite** (`azuredevopsdsc.tests.ps1`) | **No** | Test files parse-time resolve types via `using module AzureDevOpsDscNative` against the built module. No build = no run. |
+| **Build** (`./build.ps1 -Tasks build`) | **No** | Needs Sampler/ModuleBuilder/InvokeBuild from PowerShell Gallery; PSGallery is proxy-blocked here (`www.powershellgallery.com` -> 403). CI runs the build on `windows-latest`. |
+| **Integration tests** | **No** | Hit a live Azure DevOps org. Only run on the self-hosted `AZDO-AGENT` runner from `.github/workflows/integration-tests.yml`. See CLAUDE.md. |
+
+The driver picks the largest suite that actually works headless on Linux. If
+you need the Classes suite or a full build verify, push and let CI run it.
+
+---
+
+## Prerequisites
+
+Handled automatically by the driver on first run:
+
+- **PowerShell 7** (installs `powershell` from
+  `https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb`
+  — the 22.04 package works on 24.04).
+- **Pester 5.7.1** side-loaded to `/root/psmods/Pester/5.7.1/` from
+  `https://api.nuget.org/v3-flatcontainer/pester/5.7.1/pester.5.7.1.nupkg`.
+  The nupkg is a Chocolatey package: the module ships under `tools/`,
+  the driver copies it to `<root>/Pester/5.7.1/`.
+
+You never need to run `Install-Module` — it would fail against PSGallery.
+
+---
+
+## Run
+
+### Full Common suite (default — the one to use)
+
+```bash
+.claude/skills/run-azuredevopsdscnative/driver.sh
+```
+
+Expected on this container: `Passed: 1672  Failed: 31  Skipped: 10  Duration: ~00:01:00`.
+
+The 31 failures are Linux-only and cluster on:
+- **Cache export/import** (`Export-CacheObject`, `Import-CacheObject`,
+  `Initialize-CacheObject`, `BypassFileCheck switch`) — path-separator and
+  clixml round-trip differences vs Windows.
+- **`New-AzDoAuthenticationProvider` parameter sets** and **`Token export
+  functionality`** — DPAPI SecureString APIs are Windows-only.
+- **`Get-AzDoProjectPermission` / `AzDoPipelinePermission`** — a test-fixture
+  security-namespace lookup that only resolves against Windows-shipped data.
+
+On the `windows-latest` CI runner these all pass. Don't treat the local
+number as a regression signal; treat a delta against 1672/31/10 as one.
+
+### One file or one subtree
+
+```bash
+# Single file
+.claude/skills/run-azuredevopsdscnative/driver.sh \
+  ./tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Cache/Get-CacheItem.tests.ps1
+
+# Whole subtree (e.g. all Cache tests, all AzDoProject tests)
+.claude/skills/run-azuredevopsdscnative/driver.sh \
+  ./tests/Unit/Modules/AzureDevOpsDsc.Common/Api/Functions/Private/Cache
+```
+
+### Load-only smoke (fast: dot-sources source, no tests)
+
+```bash
+.claude/skills/run-azuredevopsdscnative/driver.sh --load-only
+```
+
+Use this when editing a private helper or a public resource function and you
+just want to know it parses.
+
+---
+
+## Build
+
+**Do not attempt** — PSGallery is proxy-blocked in this container.
+
+The way it's done on CI (`.github/workflows/unit-tests.yml`, on
+`windows-latest`):
+
+```pwsh
+./build.ps1 -ResolveDependency -Tasks build
+```
+
+Output lands in `output/builtModule/AzureDevOpsDscNative/<version>/`. That
+directory is what the Classes suite adds to `PSModulePath` before running
+Pester.
+
+If the build task is what you actually need to test, push to a branch and
+let `Unit Tests` workflow run it.
+
+---
+
+## Integration tests
+
+Never runnable here. Live Azure DevOps org + self-hosted runner. Doc lives
+in `CLAUDE.md` and `tests/Integration/Invoke-Tests.ps1`. To run them, push
+a tag (only the user is authorised to tag) and the release pipeline
+executes `integration-tests.yml`.
+
+---
+
+## Gotchas
+
+- **Backslashes in test paths are the norm.** The bootstrap scripts use
+  `$Global:RepositoryRoot\source\...` — that string is fed to `Import-Module`
+  / `Get-ChildItem` on Linux and PowerShell resolves it correctly because
+  those cmdlets are separator-tolerant. Don't "fix" the backslashes.
+- **`$Global:RepositoryRoot` is required.** Both bootstrap files (and every
+  test that uses `Get-FunctionItem` / `Find-MockedFunctions`) key off this
+  global. The driver always runs the bootstrap first (`-LoadModulesOnly`),
+  which sets it. Running a stray `Invoke-Pester ./tests/...` from a bare
+  pwsh will fail with "term 'Get-FunctionItem' is not recognized" — that's
+  the tell.
+- **PSGallery is blocked; nuget.org is not.** For every module you'd
+  normally `Install-Module` from PSGallery, check first whether it exists
+  on `api.nuget.org` — Pester does, most of the Sampler stack does not.
+- **`Get-Variable Azdo*` in `Refresh-AzDoCache`.** When you run tests that
+  hit `Refresh-AzDoCache`, all globals matching `Azdo*` in the current
+  session get wiped. It's expected — don't chase "my variable disappeared".
+- **Docs task and the `.METHOD` help keyword.** If unit tests suddenly
+  break with "Cannot index into a null array" during `GetHelpContent`, a
+  class file has grown an invalid `.METHOD` in its help block. Fold the
+  methods into `.NOTES` (see the fix in PR #41, files 042 and 043).
+- **DPAPI-encrypted SecureStrings in `ModuleSettings.clixml`.** Any test
+  that decrypts a fixture SecureString by round-tripping through clixml
+  will fail on Linux — DPAPI is Windows-only. That's why the token-export
+  suite is in the 31 expected failures.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `pwsh: command not found` | Re-run the driver — it installs `powershell` on first run. If that also fails, apt is offline; wait for the outbound proxy to recover. |
+| `Unable to find repository 'PSGallery'` | You tried to `Install-Module`. Use the driver's nupkg-from-nuget.org side-load path instead. |
+| `The term 'Get-FunctionItem' is not recognized` | You bypassed the bootstrap. Always run `azuredevopsdsc.common.tests.ps1 -LoadModulesOnly` (the driver does this for you) before calling `Invoke-Pester` on the Common suite. |
+| `Unable to find type [AzDevOpsApiDscResourceBase]` on the Classes suite | You tried to run the Classes suite without a built module. Not fixable here — needs `./build.ps1 -Tasks build` on a machine with PSGallery access. Push and let CI run it. |
+| Driver hangs installing pwsh | The proxy has a `403` on the Microsoft package repo. Retry once; the transient case is common right after container start. |
+| Test count deltas from `1672 / 31 / 10` | The Common suite has changed. Compare the failing test-file list (rerun with `--load-only` then a targeted subtree) against the "cluster" list above to see if it's a new Linux-only flake or a real regression. |

--- a/.claude/skills/run-azuredevopsdscnative/driver.sh
+++ b/.claude/skills/run-azuredevopsdscnative/driver.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# run-azuredevopsdscnative driver
+#
+# What this does:
+#   * Verifies pwsh (installs 7.6.x from Microsoft's repo if missing).
+#   * Verifies Pester 5.7.1 is on PSModulePath (side-loads from nuget.org if
+#     PowerShell Gallery is blocked - it is, in Claude Code's sandbox).
+#   * Runs one of the two unit-test suites, or the full Common suite by
+#     default. Reports Passed/Failed/Skipped and exits non-zero on failure.
+#
+# What this does NOT do:
+#   * The `build` task. `./build.ps1 -ResolveDependency -Tasks build` needs
+#     PSGallery (Sampler/ModuleBuilder/InvokeBuild), which is proxy-blocked
+#     here. See SKILL.md "Build" for what CI does.
+#   * The Classes suite (`azuredevopsdsc.tests.ps1`). Its tests parse-time
+#     resolve classes via `using module AzureDevOpsDscNative` against the
+#     BUILT module - no build, no run. This driver skips it.
+#   * Integration tests. They target a live Azure DevOps org and only run
+#     on the self-hosted `AZDO-AGENT` runner. See CLAUDE.md.
+#
+# Usage:
+#   ./driver.sh              # runs the full Common suite (~60s, ~1670 tests)
+#   ./driver.sh <path>       # runs one test file or subdirectory
+#   ./driver.sh --load-only  # dot-sources modules & exits (smoke test)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PSMODS_DIR="${PSMODS_DIR:-/root/psmods}"
+PESTER_VERSION="5.7.1"
+
+log() { printf '[driver] %s\n' "$*" >&2; }
+
+# --- pwsh ------------------------------------------------------------------
+if ! command -v pwsh >/dev/null 2>&1; then
+    log "pwsh not found; installing PowerShell 7 from Microsoft's Ubuntu 22.04 repo"
+    sudo apt-get update -qq
+    sudo apt-get install -y wget apt-transport-https software-properties-common
+    wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O /tmp/pmp.deb
+    sudo dpkg -i /tmp/pmp.deb
+    sudo apt-get update -qq
+    sudo apt-get install -y powershell
+fi
+log "pwsh: $(pwsh --version)"
+
+# --- Pester (side-load from nuget.org because PSGallery is blocked) --------
+if [ ! -f "$PSMODS_DIR/Pester/$PESTER_VERSION/Pester.psd1" ]; then
+    log "Pester $PESTER_VERSION not present; downloading from api.nuget.org"
+    mkdir -p "$PSMODS_DIR/Pester"
+    tmp=$(mktemp -d)
+    curl -sSf --max-time 60 \
+        "https://api.nuget.org/v3-flatcontainer/pester/$PESTER_VERSION/pester.$PESTER_VERSION.nupkg" \
+        -o "$tmp/Pester.nupkg"
+    unzip -q "$tmp/Pester.nupkg" -d "$tmp/unpacked"
+    # nuget/Chocolatey layout puts the module under tools/; PSModulePath needs it
+    # directly under <path>/Pester/<version>/Pester.psd1
+    mkdir -p "$PSMODS_DIR/Pester/$PESTER_VERSION"
+    cp -r "$tmp/unpacked/tools/." "$PSMODS_DIR/Pester/$PESTER_VERSION/"
+    rm -rf "$tmp"
+fi
+log "Pester side-load path: $PSMODS_DIR/Pester/$PESTER_VERSION"
+
+# --- Args ------------------------------------------------------------------
+LOAD_ONLY=0
+TEST_PATH="./tests/Unit/Modules/AzureDevOpsDsc.Common"
+if [ "${1:-}" = "--load-only" ]; then
+    LOAD_ONLY=1
+elif [ -n "${1:-}" ]; then
+    TEST_PATH="$1"
+fi
+
+# --- Invoke pwsh -----------------------------------------------------------
+cd "$REPO_ROOT"
+export PSMODULEPATH="$PSMODS_DIR:${PSModulePath:-}"
+
+if [ "$LOAD_ONLY" = 1 ]; then
+    log "Load-only smoke: dot-sourcing modules"
+    pwsh -NoProfile -Command "
+        \$env:PSModulePath = '$PSMODS_DIR:' + \$env:PSModulePath
+        ./azuredevopsdsc.common.tests.ps1 -LoadModulesOnly
+        Write-Host '[driver] LoadModulesOnly OK'
+    "
+    exit 0
+fi
+
+log "Running Pester against: $TEST_PATH"
+pwsh -NoProfile -Command "
+    \$env:PSModulePath = '$PSMODS_DIR:' + \$env:PSModulePath
+    ./azuredevopsdsc.common.tests.ps1 -LoadModulesOnly
+    Import-Module Pester -RequiredVersion $PESTER_VERSION -Force
+
+    \$cfg = New-PesterConfiguration
+    \$cfg.Run.Path      = '$TEST_PATH'
+    \$cfg.Run.PassThru  = \$true
+    \$cfg.Output.Verbosity = 'Minimal'
+    \$cfg.CodeCoverage.Enabled = \$false
+
+    \$sw = [Diagnostics.Stopwatch]::StartNew()
+    \$r  = Invoke-Pester -Configuration \$cfg
+    \$sw.Stop()
+
+    Write-Host ''
+    Write-Host ('[driver] Passed: {0}  Failed: {1}  Skipped: {2}  Duration: {3}' -f \$r.PassedCount, \$r.FailedCount, \$r.SkippedCount, \$sw.Elapsed)
+    if (\$r.FailedCount -gt 0) { exit 1 }
+"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
 # Needed for publishing of examples, build worker defaults to core.autocrlf=input.
 * text eol=crlf
 
+# Skill driver scripts must stay LF — Bash refuses CRLF shebang lines.
+.claude/skills/**/*.sh text eol=lf
+.claude/skills/**/SKILL.md text eol=lf
+
 # Ensure any exe files are treated as binary
 *.exe binary
 *.jpg binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- AzureDevOpsDscNative
+  - Added a `/run-azuredevopsdscnative` skill (`.claude/skills/run-azuredevopsdscnative/`)
+    with a self-contained driver script for running the Common unit suite
+    headless on Linux from a clean container. Installs PowerShell 7 if missing,
+    side-loads Pester 5.7.1 from `api.nuget.org` when PowerShell Gallery is
+    unreachable, runs the bootstrap, and exits non-zero on test failure. Does
+    not run the Classes suite (needs a built module) or the build (needs
+    PSGallery-hosted Sampler/ModuleBuilder) or integration tests (need the
+    self-hosted runner and a live org).
 - AzureDevOpsDsc
   - Added DSC v3 support: all 49 class-based DSC resources now declare `Set()`
     and `Test()` directly (delegating to `AzDevOpsDscResourceBase`) instead of


### PR DESCRIPTION
#### Pull Request (PR) description

Adds a `/run-azuredevopsdscnative` skill so a future Claude Code session (or a human) can drive the module's tests from a clean Linux container without hunting through docs.

The skill lives at `.claude/skills/run-azuredevopsdscnative/` and has two files:

- **`driver.sh`** — self-contained runner. Installs PowerShell 7 from Microsoft's Ubuntu repo if `pwsh` is missing, side-loads Pester 5.7.1 from `api.nuget.org` when PSGallery is unreachable (it is, in the sandbox), runs the `azuredevopsdsc.common.tests.ps1 -LoadModulesOnly` bootstrap, executes Pester with a real exit code. Accepts a path argument for one file / subtree, or `--load-only` for a parse-time smoke.
- **`SKILL.md`** — man page. Documents what runs and what doesn't (Classes suite needs the built module, the build needs PSGallery, integration tests need the self-hosted `AZDO-AGENT` runner and a live org), and captures Linux-only failure clusters (DPAPI SecureString / clixml round-trip) that don't appear on the `windows-latest` CI runner.

Also adds a `.gitattributes` override so `.sh` files under `.claude/skills/` stay LF — the repo-wide `* text eol=crlf` would otherwise write a CRLF shebang line and bash would refuse to execute the driver.

Verified end-to-end this session on a Linux 24.04 container with no `pwsh` and no Pester pre-installed: cold-installed both, then ran the full Common suite (`1672 Passed / 31 Failed / 10 Skipped` in ~60s; the 31 failures are the documented Linux-only clusters), a single test file, and the `--load-only` smoke.

No changes to `source/` or the module itself — this is repo tooling only.

#### This Pull Request (PR) fixes the following issues

None.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
- [ ] Resource documentation updated in the resource's README.md.
- [ ] Resource parameter descriptions updated in schema.mof.
- [ ] Comment-based help updated, including parameter descriptions.
- [ ] Localization strings updated.
- [ ] Examples updated.
- [ ] Unit tests updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Code changes adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

---
_Generated by [Claude Code](https://claude.ai/code/session_019iuTRf59PpW7us9Yty15Zg)_